### PR TITLE
remove sqlfs todo

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -169,7 +169,6 @@ func createPredictionTable(trainParsed, inferParsed *extendedSelect, cfg *mysql.
 	}
 	defer db.Close()
 
-	// TODO(tonyyang-svail): reuse createTable and dropTable at sqlfs
 	dropStmt := fmt.Sprintf("drop table if exists %s;", tableName)
 	if _, e := db.Query(dropStmt); e != nil {
 		return fmt.Errorf("failed executing %s: %q", dropStmt, e)


### PR DESCRIPTION
sqlfs doesn't provide a general API on tables, so we'd better not reuse them. For example, `CreateTable` in `sqlfs` assumes the table contains one column `(block BLOB)`.
https://github.com/wangkuiyi/sqlflow/blob/2af342cafb2863c189b11725b73771bd245e33a6/sqlfs/table.go#L24-L27