### PR TITLE
Use db instead of cfg

### DIFF
--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -37,7 +37,7 @@ func TestCodeGenTrain(t *testing.T) {
 	r, e := newParser().Parse(testTrainSelectIris)
 	a.NoError(e)
 
-	fts, e := verify(r, testCfg)
+	fts, e := verify(r, testDB)
 	a.NoError(e)
 
 	pr, pw := io.Pipe()
@@ -78,7 +78,7 @@ func TestCodeGenPredict(t *testing.T) {
 	a.NoError(e)
 	r.trainClause = tc
 
-	fts, e := verify(r, testCfg)
+	fts, e := verify(r, testDB)
 	a.NoError(e)
 
 	pr, pw := io.Pipe()

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -28,5 +28,5 @@ func TestCreatePredictionTable(t *testing.T) {
 	a.NoError(e)
 	inferParsed, e := newParser().Parse(testPredictSelectIris)
 	a.NoError(e)
-	a.NoError(createPredictionTable(trainParsed, inferParsed, testCfg))
+	a.NoError(createPredictionTable(trainParsed, inferParsed, testDB))
 }

--- a/sql/verifier.go
+++ b/sql/verifier.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-
-	"github.com/go-sql-driver/mysql"
 )
 
 // fieldTypes[field][table]type.  For more information, please check
@@ -21,13 +19,7 @@ type fieldTypes map[string]map[string]string
 //    star '*'.
 //
 // It returns a fieldTypes describing types of fields in SELECT.
-func verify(slct *extendedSelect, cfg *mysql.Config) (ft fieldTypes, e error) {
-	db, e := sql.Open("mysql", cfg.FormatDSN())
-	if e != nil {
-		return nil, fmt.Errorf("verify cannot connect to MySQL: %q", e)
-	}
-	defer func() { e = db.Close() }()
-
+func verify(slct *extendedSelect, db *sql.DB) (ft fieldTypes, e error) {
 	if e := dryRunSelect(slct, db); e != nil {
 		return nil, e
 	}
@@ -128,9 +120,9 @@ func indexSelectFields(slct *extendedSelect) (ft fieldTypes) {
 
 // Check train and infer clause uses has the same feature columns
 // 1. every column field in the training clause is selected in the infer clause, and they are of the same type
-func verifyColumnNameAndType(trainParsed, inferParsed *extendedSelect, cfg *mysql.Config) (e error) {
-	trainFields, e := verify(trainParsed, cfg)
-	inferFields, e := verify(inferParsed, cfg)
+func verifyColumnNameAndType(trainParsed, inferParsed *extendedSelect, db *sql.DB) (e error) {
+	trainFields, e := verify(trainParsed, db)
+	inferFields, e := verify(inferParsed, db)
 	for _, c := range trainParsed.columns {
 		it, ok := inferFields.get(c.val)
 		if !ok {

--- a/sql/verifier_test.go
+++ b/sql/verifier_test.go
@@ -56,7 +56,7 @@ func TestVerify(t *testing.T) {
 	a := assert.New(t)
 	r, e := newParser().Parse(`SELECT Churn, churn.churn.Partner FROM churn.churn LIMIT 10;`)
 	a.NoError(e)
-	fts, e := verify(r, testCfg)
+	fts, e := verify(r, testDB)
 	a.NoError(e)
 	a.Equal(2, len(fts))
 	typ, ok := fts.get("Churn")
@@ -92,13 +92,13 @@ FROM churn.churn LIMIT 10
 PREDICT iris.predict.class
 USING my_dnn_model;`)
 	a.NoError(e)
-	a.NoError(verifyColumnNameAndType(trainParse, inferParse, testCfg))
+	a.NoError(verifyColumnNameAndType(trainParse, inferParse, testDB))
 
 	inferParse, e = newParser().Parse(`SELECT gender, tenure
 FROM churn.churn LIMIT 10
 PREDICT iris.predict.class
 USING my_dnn_model;`)
 	a.NoError(e)
-	a.EqualError(verifyColumnNameAndType(trainParse, inferParse, testCfg),
+	a.EqualError(verifyColumnNameAndType(trainParse, inferParse, testDB),
 		"inferFields doesn't contain column TotalCharges")
 }


### PR DESCRIPTION
Fix https://github.com/wangkuiyi/sqlflow/issues/140

Make our function definitions use *sql.DB instead of *mysql.Config as the parameter, so to reduce redundant MySQL connections.