### PR TITLE
rename infer to pred

### DIFF
--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -26,7 +26,7 @@ func TestCreatePredictionTable(t *testing.T) {
 	a := assert.New(t)
 	trainParsed, e := newParser().Parse(testTrainSelectIris)
 	a.NoError(e)
-	inferParsed, e := newParser().Parse(testPredictSelectIris)
+	predParsed, e := newParser().Parse(testPredictSelectIris)
 	a.NoError(e)
-	a.NoError(createPredictionTable(trainParsed, inferParsed, testDB))
+	a.NoError(createPredictionTable(trainParsed, predParsed, testDB))
 }

--- a/sql/verifier.go
+++ b/sql/verifier.go
@@ -118,27 +118,27 @@ func indexSelectFields(slct *extendedSelect) (ft fieldTypes) {
 	return ft
 }
 
-// Check train and infer clause uses has the same feature columns
-// 1. every column field in the training clause is selected in the infer clause, and they are of the same type
-func verifyColumnNameAndType(trainParsed, inferParsed *extendedSelect, db *sql.DB) error {
+// Check train and pred clause uses has the same feature columns
+// 1. every column field in the training clause is selected in the pred clause, and they are of the same type
+func verifyColumnNameAndType(trainParsed, predParsed *extendedSelect, db *sql.DB) error {
 	trainFields, e := verify(trainParsed, db)
 	if e != nil {
 		return e
 	}
 
-	inferFields, e := verify(inferParsed, db)
+	predFields, e := verify(predParsed, db)
 	if e != nil {
 		return e
 	}
 
 	for _, c := range trainParsed.columns {
-		it, ok := inferFields.get(c.val)
+		it, ok := predFields.get(c.val)
 		if !ok {
-			return fmt.Errorf("inferFields doesn't contain column %s", c.val)
+			return fmt.Errorf("predFields doesn't contain column %s", c.val)
 		}
 		tt, _ := trainFields.get(c.val)
 		if it != tt {
-			return fmt.Errorf("field %s type dismatch %s(infer) vs %s(train)", c.val, it, tt)
+			return fmt.Errorf("field %s type dismatch %s(pred) vs %s(train)", c.val, it, tt)
 		}
 	}
 	return nil

--- a/sql/verifier_test.go
+++ b/sql/verifier_test.go
@@ -87,18 +87,18 @@ LABEL class
 INTO my_dnn_model;`)
 	a.NoError(e)
 
-	inferParse, e := newParser().Parse(`SELECT gender, tenure, TotalCharges
+	predParse, e := newParser().Parse(`SELECT gender, tenure, TotalCharges
 FROM churn.churn LIMIT 10
 PREDICT iris.predict.class
 USING my_dnn_model;`)
 	a.NoError(e)
-	a.NoError(verifyColumnNameAndType(trainParse, inferParse, testDB))
+	a.NoError(verifyColumnNameAndType(trainParse, predParse, testDB))
 
-	inferParse, e = newParser().Parse(`SELECT gender, tenure
+	predParse, e = newParser().Parse(`SELECT gender, tenure
 FROM churn.churn LIMIT 10
 PREDICT iris.predict.class
 USING my_dnn_model;`)
 	a.NoError(e)
-	a.EqualError(verifyColumnNameAndType(trainParse, inferParse, testDB),
-		"inferFields doesn't contain column TotalCharges")
+	a.EqualError(verifyColumnNameAndType(trainParse, predParse, testDB),
+		"predFields doesn't contain column TotalCharges")
 }


### PR DESCRIPTION
The current code uses both `infer` and `pred`. Unify them to `pred`.