### PR TITLE
avoid using log in test functions

### DIFF
--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 	"testing"
@@ -59,11 +58,8 @@ func TestCodeGenTrain(t *testing.T) {
 
 	cmd := tensorflowCmd(cwd)
 	cmd.Stdin = pr
-	o, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Println(err)
-	}
-
+	o, e := cmd.CombinedOutput()
+	a.NoError(e)
 	a.True(strings.Contains(string(o), "Done training"))
 }
 
@@ -92,9 +88,7 @@ func TestCodeGenPredict(t *testing.T) {
 
 	cmd := tensorflowCmd(cwd)
 	cmd.Stdin = pr
-	o, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Println(err)
-	}
+	o, e := cmd.CombinedOutput()
+	a.NoError(e)
 	a.True(strings.Contains(string(o), "Done predicting"))
 }

--- a/sql/db_test.go
+++ b/sql/db_test.go
@@ -2,7 +2,7 @@ package sql
 
 import (
 	"database/sql"
-	"log"
+	"fmt"
 	"os"
 	"testing"
 
@@ -22,8 +22,9 @@ func TestMain(m *testing.M) {
 	}
 	db, e := sql.Open("mysql", testCfg.FormatDSN())
 	if e != nil {
-		log.Panicf("TestMain cannot connect to MySQL: %q.\n"+
+		fmt.Println("TestMain cannot connect to MySQL: %q.\n"+
 			"Please run MySQL server as in example/churn/README.md.", e)
+		os.Exit(-1)
 	}
 	testDB = db
 


### PR DESCRIPTION
Since we are planning to use log in the sqlflow package #158, the `log` shouldn't be shared in the test buddy.