### PR TITLE
Add .gitignore to include Gopkg.lock and vendor

### DIFF
--- a/gohive/.gitignore
+++ b/gohive/.gitignore
@@ -1,0 +1,3 @@
+Gopkg.lock
+vendor
+nohup.out


### PR DESCRIPTION
Currently, running `dep ensure` generates `Gopkg.lock` and `vendor/`. Running the development Docker image generates `nohup.out`.