### PR TITLE
Remove invalid func Scan in rows.

### DIFF
--- a/gohive/Gopkg.toml
+++ b/gohive/Gopkg.toml
@@ -2,6 +2,10 @@
   name = "git.apache.org/thrift.git"
   version = "0.9.3"
 
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "v1.3.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/gohive/connection.go
+++ b/gohive/connection.go
@@ -60,7 +60,7 @@ func (c *Connection) QueryContext(ctx context.Context, query string, args []driv
 		return nil, fmt.Errorf("Error from server: %s", resp.Status.String())
 	}
 
-	return newRowSet(c.thrift, resp.OperationHandle, c.options), nil
+	return newRows(c.thrift, resp.OperationHandle, c.options), nil
 }
 
 func isSuccessStatus(p *tcliservice.TStatus) bool {


### PR DESCRIPTION
some code refactoring for rows.go:
1. remove invalid func Scan(...) as the Scan method  is already implemented in database/sql/sql.go.
2. modify the naming spec for some functions.