### PR TITLE
Edit the comments similar to Jekyll variables

### DIFF
--- a/doc/submitter.md
+++ b/doc/submitter.md
@@ -28,9 +28,9 @@ type ColumnType struct {
 type TrainDescription struct {
     StandardSelect string       // e.g. SELECT * FROM iris.train
     Estimator      string       // e.g. DNNClassifier
-    Attrs          map[string]string // e.g. {{"n_classes", "3"}, {"hidden_units", "[10, 20]"}}
-    X              []ColumnType // e.g. {{"sepal_length", "FLOAT"}, ...}
-    Y              ColumnType   // e.g. {"class", "INT"}
+    Attrs          map[string]string // e.g. "n_classes": "3", "hidden_units": "[10, 20]"
+    X              []ColumnType // e.g. "sepal_length": "FLOAT", ...
+    Y              ColumnType   // e.g. "class": "INT"
     ModelName      string       // e.g. my_dnn_model
 }
 


### PR DESCRIPTION
After merging https://github.com/sql-machine-learning/sql-machine-learning.github.io/pull/17, I received the error message from Github.com. This PR is to fix this error.

```
The page build failed for the `master` branch with the following error:

The variable `{{"n_classes", "3"}` on line 31 in `sqlflow/doc/submitter.md` was not properly closed with `}}`. For more information, see https://help.github.com/en/articles/page-build-failed-tag-not-properly-terminated.

For information on troubleshooting Jekyll see:

  https://help.github.com/articles/troubleshooting-jekyll-builds
```