### PR TITLE
Add hive db-api in codegen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt-get update
 RUN apt-get install -y python3-pip
+
 RUN pip3 install --upgrade pip
-RUN pip3 install tensorflow mysql-connector-python jupyter sqlflow
+RUN pip3 install tensorflow mysql-connector-python pyhive jupyter sqlflow
 # Fix jupyter server "connecting to kernel" problem
 # https://github.com/jupyter/notebook/issues/2664#issuecomment-468954423
 RUN pip3 install tornado==4.5.3

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,10 +5,12 @@ RUN apt-get install -y git
 RUN apt-get install -y wget curl
 RUN apt-get install -y python3-pip
 
+ENV PIP_INDEX_URL="http://pypi.douban.com/simple/" PIP_TRUSTED_HOST="pypi.douban.com"
 RUN pip3 install --upgrade pip
 RUN pip3 install grpcio-tools
 RUN pip3 install tensorflow
 RUN pip3 install mysql-connector-python
+RUN pip3 install pyhive
 
 RUN wget --quiet https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,6 @@ RUN apt-get install -y git
 RUN apt-get install -y wget curl
 RUN apt-get install -y python3-pip
 
-ENV PIP_INDEX_URL="http://pypi.douban.com/simple/" PIP_TRUSTED_HOST="pypi.douban.com"
 RUN pip3 install --upgrade pip
 RUN pip3 install grpcio-tools
 RUN pip3 install tensorflow

--- a/doc/build.md
+++ b/doc/build.md
@@ -1,6 +1,6 @@
 # Canonical Development Environment
 
-Referring to [this example](https://github.com/sql-machine-learning/canonicalize-go-python-grpc-dev-env),
+Referring to [this example](https://github.com/wangkuiyi/canonicalize-go-python-grpc-dev-env),
 we create a canonical development environment for Go and Python programmers using Docker.
 
 ## Editing on Host

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -20,7 +20,7 @@ After data is popularized in MySQL, let's test the installation from running a q
 
    ```
    docker run --rm -it -p 8888:8888 sqlflow/sqlflow:latest \
-   bash -c "sqlflowserver --datasource="mysql://root:root@tcp(host.docker.internal:3306)/?maxAllowedPacket=0" &
+   bash -c "sqlflowserver --datasource='mysql://root:root@tcp(host.docker.internal:3306)/?maxAllowedPacket=0' &
    SQLFLOW_SERVER=localhost:50051 jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root"
    ```
 

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -195,8 +195,7 @@ def eval_input_fn(features, labels, batch_size):
 
 eval_result = classifier.evaluate(
     input_fn=lambda:eval_input_fn(X, Y, BATCHSIZE), steps=STEP)
-print("\nTraining set accuracy: {accuracy:0.5f}\n".format(**eval_result))
-
+print("Training set accuracy: {accuracy:0.5f}".format(**eval_result))
 print("Done training")
 {{- else}}
 def eval_input_fn(features, batch_size):
@@ -227,7 +226,7 @@ def insert(table_name, X, db):
 
 insert("{{.TableName}}", X, db)
 
-print("Done predicting. Predict Table : {{.TableName}}")
+print("Done predicting. Predict table : {{.TableName}}")
 {{- end}}
 `
 

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -118,7 +118,14 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 import sys, json
 import tensorflow as tf
+
+{{if eq .Driver "mysql"}}
 import mysql.connector
+{{else if eq .Driver "sqlite3"}}
+import sqlite3
+{{else if eq .Driver "hive"}}
+from pyhive import hive
+{{end}}
 
 # Disable Tensorflow INFO and WARNING logs
 tf.logging.set_verbosity(tf.logging.ERROR)
@@ -133,12 +140,14 @@ db = mysql.connector.connect(user="{{.User}}",
                              passwd="{{.Password}}",
                              host="{{.Host}}",
                              port={{.Port}}{{if eq .Database ""}}{{- else}}, database="{{.DATABASE}}"{{end}})
-{{else}}
-{{if eq .Driver "sqlite3"}}
+{{else if eq .Driver "sqlite3"}}
 db = sqlite3.connect({{.Database}})
+{{else if eq .Driver "hive"}}
+hive.connect(host="{{.Host}}", 
+			port={{.Port}},
+			auth='NOSASL')
 {{else}}
 raise ValueError("unrecognized database driver: {{.Driver}}")
-{{end}}
 {{end}}
 
 cursor = db.cursor()

--- a/sql/verifier.go
+++ b/sql/verifier.go
@@ -61,7 +61,8 @@ func (ft fieldTypes) get(ident string) (string, bool) {
 // identifier: t.f=>(t,f), db.t.f=>(db.t,f), f=>("",f).
 func decomp(ident string) (tbl string, fld string) {
 	s := strings.Split(ident, ".")
-	return strings.Join(s[:len(s)-1], "."), s[len(s)-1]
+	n := len(s)
+	return strings.Join(s[:n-1], "."), s[n-1]
 }
 
 // Retrieve the type of fields mentioned in SELECT.
@@ -112,7 +113,6 @@ func describeTables(slct *extendedSelect, db *DB) (ft fieldTypes, e error) {
 				}
 			}
 		}
-
 	}
 	return ft, nil
 }


### PR DESCRIPTION
Here still has an issue,
Consider a query: `SELECT * FROM churn.train`
Hive returns a schema: `[('train.customerid', 'VARCHAR_TYPE', None, None, None, None, True), ...]`, notice:
1. the column name train.customerid has a prefix: *train*
Our parser `sql.y` and MySQL return `customerId`
2. the column name consists of lowercases always
3. the field type name with a suffix: *_TYPE

Especially the first 2 points are incompatible with our parser `sql.y`. These will cause a mismatch [in  `codegen`](https://github.com/sql-machine-learning/sqlflow/blob/develop/sql/codegen.go#L62).