### PR TITLE
Fix a dead link in the document pipe.md, and update to support latest precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 - repo: git://github.com/dnephin/pre-commit-golang
-  sha: HEAD
+  rev: v0.3.3
   hooks:
     - id: go-fmt
     - id: go-vet

--- a/doc/pipe.md
+++ b/doc/pipe.md
@@ -3,7 +3,7 @@
 
 ## Streaming Responses
 
-As described in the [overall design](doc/design.md), a SQLFlow job could be a standard or an extended SQL statemnt, where an extended SQL statement will be translated into a Python program.  Therefore, each job might generate up to the following data streams:
+As described in the [overall design](doc/syntax.md), a SQLFlow job could be a standard or an extended SQL statemnt, where an extended SQL statement will be translated into a Python program.  Therefore, each job might generate up to the following data streams:
 
 1. standard output, where each element is a line of text,
 1. standard error, where each element is a line of text,


### PR DESCRIPTION
- Fix a deadlink in the document: https://github.com/sql-machine-learning/sqlflow/blob/develop/doc/pipe.md
- update `.pre-commit-config.yaml` to be compatible to latest pre-commit versions (> 1.7.0), use `rev` instead of sha