### PR TITLE
Add evaluation to alps_submitter

### DIFF
--- a/sql/alps_submitter.go
+++ b/sql/alps_submitter.go
@@ -511,9 +511,8 @@ func newALPSPredictFiller(pr *extendedSelect) (*alpsFiller, error) {
 func genALPSFiller(w io.Writer, pr *extendedSelect) (*alpsFiller, error) {
 	if pr.train {
 		return newALPSTrainFiller(pr)
-	} else {
-		return newALPSPredictFiller(pr)
 	}
+	return newALPSPredictFiller(pr)
 }
 
 func submitALPS(w *PipeWriter, pr *extendedSelect, db *DB, cwd string) error {

--- a/sql/alps_submitter.go
+++ b/sql/alps_submitter.go
@@ -409,6 +409,7 @@ func generateEstimatorCreator(estimator string, attrs []*attribute, args []strin
 }
 
 func newALPSTrainFiller(pr *extendedSelect) (*alpsFiller, error) {
+	//TODO(uuleon): the scratchDir will be deleted after model uploading
 	scratchDir, err := ioutil.TempDir("/tmp", "alps_scratch_dir_")
 	if err != nil {
 		return nil, err

--- a/sql/alps_submitter.go
+++ b/sql/alps_submitter.go
@@ -557,6 +557,7 @@ import os
 
 import tensorflow as tf
 
+from alps.conf.closure import Closure
 from alps.framework.train.training import build_run_config
 from alps.framework.exporter import ExportStrategy, FileLocation
 from alps.framework.exporter.arks_exporter import ArksExporter
@@ -606,7 +607,7 @@ if __name__ == "__main__":
 
 	evalDs = AlpsDataset(
 		num_epochs=1,
-		batch_size=512,
+		batch_size=64,
 		reader=OdpsReader(
 			odps=OdpsConf(
 				accessid={{.OdpsConf.Get "accessid" "None"}},
@@ -626,12 +627,20 @@ if __name__ == "__main__":
 	experiment = Experiment(
 		user="sqlflow",
 		engine=LocalEngine(),
-		train=TrainConf(input=trainDs, max_steps={{.TrainSpec.Get "max_steps" "1000"}}),
+		train=TrainConf(input=trainDs, 
+						max_steps={{.TrainSpec.Get "max_steps" "1000"}},
+						save_summary_steps={{.TrainSpec.Get "save_summary_steps" "100"}},
+						save_timeline_steps={{.TrainSpec.Get "save_timeline_steps" "100"}},
+						save_checkpoints_steps={{.TrainSpec.Get "save_checkpoints_steps" "100"}},
+						log_step_count_steps={{.TrainSpec.Get "log_step_count_steps" "100"}}
+		),
 		eval=EvalConf(input=evalDs, 
 					  steps={{.TrainSpec.Get "steps" "100"}}, 
 					  start_delay_secs={{.TrainSpec.Get "start_delay_secs" "120"}},
-					  throttle_secs={{.TrainSpec.Get "throttle_secs" "600"}}),
-		exporter=ArksExporter(export_path=export_path, export_strategy=ExportStrategy.BEST, compare_fn=best_auc_fn),
+					  throttle_secs={{.TrainSpec.Get "throttle_secs" "600"}},
+ 					  throttle_steps={{.TrainSpec.Get "throttle_steps" "None"}}
+		),
+		exporter=ArksExporter(export_path=export_path, export_strategy=ExportStrategy.BEST, compare_fn=Closure(best_auc_fn)),
 		model_dir="{{.ScratchDir}}",
 		model_builder=SQLFlowEstimatorBuilder())
 

--- a/sql/alps_submitter_test.go
+++ b/sql/alps_submitter_test.go
@@ -108,7 +108,7 @@ func TestAlpsEstimatorCodeGenerate(t *testing.T) {
 	attrs, err := resolveTrainAttribute(&r.attrs)
 	a.NoError(err)
 
-	code, err := generateEstimatorCreator(r.estimator, filter(attrs, estimator))
+	code, err := generateEstimatorCreator(r.estimator, filter(attrs, estimator), nil)
 
 	a.Equal(estimatorCode, code)
 }


### PR DESCRIPTION
The major work of this PR contains the following:
1. refactoring `alpsFiller` to make it adaptive to train and predict
2. add `Get` method which supports default value to make code generation easier
3. support `eval_spec` setting and train_with_evaluation