### PR TITLE
Add incomplete demonstrative python/db.py

### DIFF
--- a/sql/python/db.py
+++ b/sql/python/db.py
@@ -1,0 +1,16 @@
+def connect(driver, database, user, passwd, host, port):
+    if driver == "mysql":
+        return mysql.connector.connect(user=user,
+                                       passwd=passwd,
+                                       database=database,
+                                       host=host,
+                                       port=port)
+    elif driver == "sqllite3":
+        return sqlite3.connect(database)
+    elif driver == "hive":
+        return impala.dbapi.connect(user=user,
+                                    password=passwd,
+                                    database=database,
+                                    host=host,
+                                    port=port)
+    raise ValueError("unrecognized database driver: {{.Driver}}")


### PR DESCRIPTION
I am writing this PR as an incomplete example demonstrating my idea presented in https://github.com/sql-machine-learning/sqlflow/pull/417#discussion_r286237342.  In particular, this example shows how we could separate template code from `codegen.go` and `codegen_alps.go` into `sql/python/*.py` files.

In this PR, the `def connect(...)` function is a rewrite of the following template snippet:

https://github.com/sql-machine-learning/sqlflow/blob/50933a048fa1872b1679933c83d852a7fda1419b/sql/codegen.go#L160-L196

Could @uuleon and @tonyyang-svail please follow up with this PR and complete it by moving most part of the aforementioned template into `sql/python/db.py` and reduce the template to contain only a function call in the `main` function with parameter values assigned to template variables?