### PR TITLE
Fix drivername parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /logs
 sql/my_dnn_model
 .DS_Store
+coverage.out

--- a/sql/database.go
+++ b/sql/database.go
@@ -11,6 +11,8 @@ import (
 	_ "sqlflow.org/gohive"
 )
 
+const driverSeparator = "://"
+
 // DB extends sql.DB
 type DB struct {
 	driverName     string
@@ -26,11 +28,14 @@ type DB struct {
 // In addition to sql.Open, it also does the book keeping on driverName and
 // dataSourceName
 func Open(datasource string) (*DB, error) {
-	dses := strings.Split(datasource, "://")
-	if len(dses) != 2 {
-		return nil, fmt.Errorf("bad datasource")
+	sep := strings.Index(datasource, driverSeparator)
+	if sep == -1 {
+		return nil, fmt.Errorf("bad datasource, driver name is missing")
 	}
-	db := &DB{driverName: dses[0], dataSourceName: dses[1]}
+	db := &DB{
+		driverName:     datasource[:sep],
+		dataSourceName: datasource[sep+len(driverSeparator):],
+	}
 
 	var err error
 	switch db.driverName {


### PR DESCRIPTION
`maxcompute` use `url.Parse(dsn)` to parse a data source, so the `dsn` must begin with a scheme, which means sqlflow should accept the input like: "maxcompute://http://u:p@host/api?curr_project=xx"