### PR TITLE
Support maxcompute

### DIFF
--- a/sql/cmd.go
+++ b/sql/cmd.go
@@ -24,8 +24,9 @@ func hasDatabaseConnector(driverName string) bool {
 		return tryRun("python", "-c", "from mysql.connector import connect")
 	} else if driverName == "sqlite3" {
 		return tryRun("python", "-c", "from sqlite3 import connect")
+	} else if driverName == "maxcompute" {
+		return true
 	}
-	// TODO(weiguo): need an `else` to support maxCompute ?
 	return false
 }
 

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"sqlflow.org/gohive"
+	"sqlflow.org/gomaxcompute"
 )
 
 type columnType struct {
@@ -123,6 +124,13 @@ func fillDatabaseInfo(r *filler, db *DB) (*filler, error) {
 		r.User, r.Password = cfg.User, cfg.Passwd
 		// remove the last ';' which leads to a ParseException
 		r.StandardSelect = removeLastSemicolon(r.StandardSelect)
+	case "maxcompute":
+		cfg, err := gomaxcompute.ParseDSN(db.dataSourceName)
+		if err != nil {
+			return nil, err
+		}
+		r.Host, r.Database = cfg.Endpoint, cfg.Project
+		r.User, r.Password = cfg.AccessID, cfg.AccessKey
 	default:
 		return nil, fmt.Errorf("sqlfow currently doesn't support DB %v", db.driverName)
 	}

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -50,8 +50,9 @@ func translateColumnToFeature(fts *fieldTypes, driverName, ident string) (*colum
 	if e != nil {
 		return nil, e
 	}
+	ctype = strings.ToUpper(ctype)
 
-	if ctype == "FLOAT" || ctype == "INT" || ctype == "DOUBLE" {
+	if ctype == "FLOAT" || ctype == "INT" || ctype == "DOUBLE" || ctype == "BIGINT" {
 		return &columnType{ident, "numeric_column"}, nil
 	} else if ctype == "TEXT" || ctype == "VARCHAR" {
 		// FIXME(typhoonzero): only support preprocessed string of int vector

--- a/sql/column_type.go
+++ b/sql/column_type.go
@@ -161,7 +161,7 @@ func parseVal(val interface{}) (interface{}, error) {
 }
 
 func universalizeColumnType(driverName, dialectType string) (string, error) {
-	if driverName == "mysql" || driverName == "sqlite3" {
+	if driverName == "mysql" || driverName == "sqlite3" || driverName == "maxcompute" {
 		return dialectType, nil
 	} else if driverName == "hive" {
 		if strings.HasSuffix(dialectType, hiveCTypeSuffix) {

--- a/sql/database.go
+++ b/sql/database.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/mattn/go-sqlite3"
 	_ "sqlflow.org/gohive"
+	_ "sqlflow.org/gomaxcompute"
 )
 
 const driverSeparator = "://"
@@ -39,7 +40,7 @@ func Open(datasource string) (*DB, error) {
 
 	var err error
 	switch db.driverName {
-	case "sqlite3", "mysql", "hive":
+	case "sqlite3", "mysql", "hive", "maxcompute":
 		db.DB, err = sql.Open(db.driverName, db.dataSourceName)
 	default:
 		return nil, fmt.Errorf("sqlfow currently doesn't support DB %v", db.driverName)

--- a/sql/verifier.go
+++ b/sql/verifier.go
@@ -72,7 +72,8 @@ func describeTables(slct *extendedSelect, db *DB) (ft fieldTypes, e error) {
 	ft = indexSelectFields(slct)
 	hasStar := len(ft) == 0
 	for _, tn := range slct.tables {
-		q := "SELECT * FROM " + tn + " LIMIT 1"
+		// MaxCompute's statement ends with a semicolon
+		q := "SELECT * FROM " + tn + " LIMIT 1;"
 		rows, err := db.Query(q)
 		if err != nil {
 			return nil, err

--- a/sqlfs/table.go
+++ b/sqlfs/table.go
@@ -14,7 +14,7 @@ func createTable(db *sql.DB, driver, table string) error {
 	var stmt string
 	if driver == "mysql" || driver == "sqlite3" {
 		stmt = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT, block TEXT, PRIMARY KEY (id))", table)
-	} else if driver == "hive" {
+	} else if driver == "hive" || driver == "maxcompute" {
 		stmt = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT, block STRING)", table)
 	} else {
 		return fmt.Errorf("createTable not supported for %s", driver)


### PR DESCRIPTION
Fix #421 
- Support standard SQL
- [Parse credentials](https://github.com/weiguoz/sqlflow/blob/984035221a9ac7035dd59bea27fad58dd2c0d5e1/sql/codegen.go#L128-L134)

Next, we are going to import [pyodps](https://github.com/aliyun/aliyun-odps-python-sdk) to support reading datasets for the train/pred.