### PR TITLE
Make tidb.Parser calls TiDB parser twice as Calcite paser does

### DIFF
--- a/parser/tidb/tidb_parser_test.go
+++ b/parser/tidb/tidb_parser_test.go
@@ -21,18 +21,56 @@ import (
 
 func TestTiDBParser(t *testing.T) {
 	a := assert.New(t)
+	var (
+		i int
+		e error
+	)
 
-	i, e := Parse("select * frm tbl") // frm->from
+	Init()
+
+	i, e = Parse("select * frm t1") // frm->from
 	a.NoError(e)
 	a.Equal(9, i)
 
-	i, e = Parse("select * from tbl where id = 1")
+	i, e = Parse("select a frm t1") // frm->from
+	a.NoError(e)
+	a.Equal(13, i) // This seems a bug of TiDB parser.  Should be 9.
+
+	i, e = Parse("select a, b from t1")
 	a.NoError(e)
 	a.Equal(-1, i)
 
-	i, e = Parse("select * from tbl where id = 1 TRAIN DNNClassifier WITH learning_rate=0.1")
+	i, e = Parse("select a b from t1")
 	a.NoError(e)
-	a.Equal(31, i)
+	a.Equal(-1, i)
+
+	i, e = Parse("select a b c from t1") // Same as Calcite parser -- no more than 2 fields without ','.
+	a.NoError(e)
+	a.Equal(11, i)
+
+	i, e = Parse("select * from t1")
+	a.NoError(e)
+	a.Equal(-1, i)
+
+	i, e = Parse("select * from t1, t2")
+	a.NoError(e)
+	a.Equal(-1, i)
+
+	i, e = Parse("select * from t1 t2")
+	a.NoError(e)
+	a.Equal(-1, i)
+
+	i, e = Parse("select * from t1 t2 t3") // Same as Calcite parser -- no more than 2 tables without ",".
+	a.NoError(e)
+	a.Equal(20, i)
+
+	i, e = Parse("select * from t1 where id in (select * from t2)")
+	a.NoError(e)
+	a.Equal(-1, i)
+
+	i, e = Parse("select * from t1 where id in (select * from t2) TRAIN DNNClassifier WITH learning_rate=0.1")
+	a.NoError(e)
+	a.Equal(48, i)
 
 	i, e = Parse("select * from tbl where id = 1 predict tbl.predicted using my_model")
 	a.NoError(e)


### PR DESCRIPTION
This PR implements a building block of the [`external_parser`](https://github.com/sql-machine-learning/sqlflow/blob/ab1307d93ef3973ba9853924e0f094c9035f59fb/parser/README.md#the-external-parser-abstraction) in the design of integrated parser.