### PR TITLE
Use np.fromstring and remove hard coded training steps

### DIFF
--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -21,27 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	testTrainBoostedTreeOnIris = `
-SELECT *
-FROM iris.train
-WHERE class = 0 OR class = 1
-TRAIN BoostedTreesClassifier
-WITH
-  n_batches_per_layer = 20
-COLUMN sepal_length, sepal_width, petal_length, petal_width
-LABEL class
-INTO sqlflow_models.my_boosted_tree_model;
-`
-	testPredBoostedTreeOnIris = `
-SELECT *
-FROM iris.test
-WHERE class = 0 OR class = 1
-predict iris.predict.class
-USING sqlflow_models.my_boosted_tree_model;
-`
-)
-
 func goodStream(stream chan interface{}) (bool, string) {
 	lastResp := list.New()
 	keepSize := 10
@@ -76,14 +55,6 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 		a.NoError(e)
 		stream = runExtendedSQL(testPredictSelectIris, testDB, pr)
 		a.True(goodStream(stream.ReadAll()))
-	})
-}
-
-func TestExecutorTrainAndPredictBoostedTree(t *testing.T) {
-	a := assert.New(t)
-	a.NotPanics(func() {
-		a.True(goodStream(Run(testTrainBoostedTreeOnIris, testDB).ReadAll()))
-		a.True(goodStream(Run(testPredBoostedTreeOnIris, testDB).ReadAll()))
 	})
 }
 

--- a/sql/python/sqlflow_submitter/db.py
+++ b/sql/python/sqlflow_submitter/db.py
@@ -77,7 +77,7 @@ def db_generator(driver, conn, statement,
                 features = dict()
                 for name in feature_column_names:
                     if column_name_to_type[name] == "categorical_column_with_identity":
-                        cell = np.array([int(v) for v in row[field_names.index(name)].split(",")])
+                        cell = np.fromstring(row[field_names.index(name)], dtype=int, sep=",")
                     else:
                         cell = row[field_names.index(name)]
                     features[name] = cell
@@ -105,7 +105,7 @@ def db_generator_predict(driver, conn, statement,
                 features = dict()
                 for name in feature_column_names:
                     if column_name_to_type[name] == "categorical_column_with_identity":
-                        cell = np.array([int(v) for v in row[field_names.index(name)].split(",")])
+                        cell = np.fromstring(row[field_names.index(name)], dtype=int, sep=",")
                     else:
                         cell = row[field_names.index(name)]
                     features[name] = cell


### PR DESCRIPTION
- Use np.fromstring for common `categorical_column_with_identity`
- remove hard coded training steps
- remove estimator `BoostedTreesClassifier` test because it will cause error when not using steps, and we may not use this model for BoostedTrees cases.