### PR TITLE
can customize tensorflow version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 # Miniconda - Python 3.6, 64-bit, x86, latest
 ARG CONDA_ADD_PACKAGES=""
 ARG PIP_ADD_PACKAGES=""
+ARG TENSORFLOW_VERSION="2.0.0-b1"
 
 ENV GOPATH /go
 ENV PATH /miniconda/envs/sqlflow-dev/bin:/miniconda/bin:/usr/local/go/bin:/go/bin:$PATH

--- a/scripts/image_build.sh
+++ b/scripts/image_build.sh
@@ -29,7 +29,7 @@ echo "source activate sqlflow-dev" >> ~/.bashrc
 # https://github.com/jupyter/notebook/issues/2664#issuecomment-468954423
 source /miniconda/bin/activate sqlflow-dev && python -m pip install \
 numpy==1.16.1 \
-tensorflow==2.0.0-alpha0 \
+tensorflow==${TENSORFLOW_VERSION} \
 mysql-connector-python \
 impyla \
 pyodps \


### PR DESCRIPTION
run `docker build --build-arg TENSORFLOW_VERSION="1.8.0" -t sqlflow/sqlflow:tf1.8.0 .` to build images depend on desired tensorflow version. (`codegen_alps.go` depends on tf1.8.0`)

NOTE: beware that not all versions are supported.