### PR TITLE
alps can run iris demo

### DIFF
--- a/sql/codegen_alps.go
+++ b/sql/codegen_alps.go
@@ -245,10 +245,11 @@ if __name__ == "__main__":
         reader=OdpsReader(
             odps=odpsConf,
             project="{{.OdpsConf.Project}}",
-            table="{{.TrainInputTable}}",
-            field_names={{.Fields}},
+			table="{{.TrainInputTable}}",
+			# FIXME(typhoonzero): add field_names back if needed.
+            # field_names={{.Fields}},
             features={{.X}},
-			labels={{.Y}},
+            labels={{.Y}},
 {{if ne .FeatureMapTable ""}}
             feature_map=FeatureMap(table="{{.FeatureMapTable}}",
 {{if ne .FeatureMapPartition ""}}
@@ -266,8 +267,9 @@ if __name__ == "__main__":
         reader=OdpsReader(
         odps=odpsConf,
             project="{{.OdpsConf.Project}}",
-            table="{{.EvalInputTable}}",
-            field_names={{.Fields}},
+			table="{{.EvalInputTable}}",
+			# FIXME(typhoonzero): add field_names back if needed.
+            # field_names={{.Fields}},
             features={{.X}},
             labels={{.Y}}
         )
@@ -283,14 +285,17 @@ if __name__ == "__main__":
                         max_steps={{.TrainClause.MaxSteps}},
 {{end}}
         ),
-        eval=EvalConf(input=evalDs, 
+		eval=EvalConf(input=evalDs,
+                      # FIXME(typhoonzero): Support configure metrics
+                      metrics_set=['accuracy'],
 {{if (ne .TrainClause.EvalSteps -1)}}
                       steps={{.TrainClause.EvalSteps}}, 
 {{end}}
                       start_delay_secs={{.TrainClause.EvalStartDelay}},
                       throttle_secs={{.TrainClause.EvalThrottle}},
-        ),
-        exporter=ArksExporter(deploy_path=export_path, strategy=ExportStrategy.BEST, compare_fn=Closure(best_auc_fn)),
+		),
+		# FIXME(typhoonzero): Use ExportStrategy.BEST when possible.
+        exporter=ArksExporter(deploy_path=export_path, strategy=ExportStrategy.LATEST, compare_fn=Closure(best_auc_fn)),
         model_dir="{{.ScratchDir}}",
         model_builder=SQLFlowEstimatorBuilder())
 

--- a/sql/expression_resolver.go
+++ b/sql/expression_resolver.go
@@ -810,6 +810,10 @@ func resolveDelimiter(delimiter string) (string, error) {
 
 func (a *attribute) GenerateCode() (string, error) {
 	if val, ok := a.Value.(string); ok {
+		// auto convert to int first.
+		if _, err := strconv.Atoi(val); err == nil {
+			return fmt.Sprintf("%s=%s", a.Name, val), nil
+		}
 		return fmt.Sprintf("%s=\"%s\"", a.Name, val), nil
 	}
 	if val, ok := a.Value.([]interface{}); ok {


### PR DESCRIPTION
Fix issues so that below SQL can finish the training. Must start with `SQLFLOW_submitter=alps ./sqlflowserver -datasource="maxcompute://user:pass@endpoint/api?curr_project=database&scheme=http" --model_dir="./"`

```sql
SELECT *
FROM iris_train
TRAIN DNNClassifier
WITH model.n_classes = 3, model.hidden_units = [10, 20], train.batch_size = 10
COLUMN DENSE(sepal_length, 1, comma), DENSE(sepal_width, 1, comma), DENSE(petal_length, 1, comma), DENSE(petal_width, 1, comma), 
       NUMERIC(sepal_length,1), NUMERIC(sepal_width,1), NUMERIC(petal_length,1), NUMERIC(petal_width,1)
LABEL class
INTO sqlflow_models.my_dnn_model;
```


TODO: add unitest to verify generated models.