### PR TITLE
fix keras predict hang on tf 2.0.0b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 # Miniconda - Python 3.6, 64-bit, x86, latest
 ARG CONDA_ADD_PACKAGES=""
 ARG PIP_ADD_PACKAGES=""
-ARG TENSORFLOW_VERSION="2.0.0a0"
+ARG TENSORFLOW_VERSION="2.0.0b1"
 
 ENV GOPATH /go
 ENV PATH /miniconda/envs/sqlflow-dev/bin:/miniconda/bin:/usr/local/go/bin:/go/bin:$PATH

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -410,6 +410,8 @@ def eval_input_fn(batch_size):
     dataset = dataset.map(ds_mapper).batch(batch_size)
     return dataset
 
+# NOTE: always use batch_size=1 when predicting to get the pairs of features and predict results
+#       to insert into result table.
 pred_dataset = eval_input_fn(1)
 one_batch = pred_dataset.__iter__().next()
 # NOTE: must run predict one batch to initialize parameters
@@ -441,6 +443,7 @@ while True:
 if len(buff_rows) > 0:
     insert_values(driver, conn, "{{.TableName}}", column_names, buff_rows)
     buff_rows.clear()
+del pred_dataset
 {{else}}
 
 def fast_input_fn(generator):


### PR DESCRIPTION
found that the stack trace was:

```
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x00007fb5ba099bdb in nsync::nsync_mu_semaphore_p(nsync::nsync_semaphore_s_*) () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#2  0x00007fb5ba0979e0 in nsync::nsync_mu_lock_slow_(nsync::nsync_mu_s_*, nsync::waiter*, unsigned int, nsync::lock_type_s*) ()
   from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#3  0x00007fb5ba097add in nsync::nsync_mu_lock(nsync::nsync_mu_s_*) () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#4  0x00007fb5b0f051e9 in tensorflow::ResourceMgr::DoDelete(std::string const&, unsigned long long, std::string const&, std::string const&) ()
   from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#5  0x00007fb5b0f058cc in tensorflow::ResourceMgr::Delete(tensorflow::ResourceHandle const&) () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#6  0x00007fb5b64dc715 in tensorflow::data::IteratorResource::Deleter::Helper::~Helper() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#7  0x00007fb5b64dc3b1 in tensorflow::data::IteratorResource::Deleter::~Deleter() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#8  0x00007fb5b64dc4b4 in tensorflow::Variant::Value<tensorflow::data::IteratorResource::Deleter>::~Value() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#9  0x00007fb5b0f3ed3e in tensorflow::Variant::~Variant() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#10 0x00007fb5b0f3d260 in tensorflow::TypedAllocator::RunVariantDtor(tensorflow::Variant*, unsigned long) () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#11 0x00007fb5b0f1b573 in tensorflow::(anonymous namespace)::Buffer<tensorflow::Variant>::~Buffer() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#12 0x00007fb5b0f1b601 in tensorflow::(anonymous namespace)::Buffer<tensorflow::Variant>::~Buffer() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#13 0x00007fb5b0f1c036 in tensorflow::Tensor::~Tensor() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/../libtensorflow_framework.so.2
#14 0x00007fb5b606832f in tensorflow::TensorHandle::~TensorHandle() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#15 0x00007fb5b6068451 in tensorflow::TensorHandle::~TensorHandle() () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#16 0x00007fb5b425477e in TFE_DeleteTensorHandle () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#17 0x00007fb5b41c9a0f in EagerTensor_dealloc () from /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/tensorflow/python/_pywrap_tensorflow_internal.so
#18 0x00005587e9b61858 in dict_dealloc () at /tmp/build/80754af9/python_1546130271559/work/Objects/dictobject.c:2017
#19 0x00005587e9c093b1 in subtype_dealloc () at /tmp/build/80754af9/python_1546130271559/work/Objects/typeobject.c:1207
#20 0x00005587e9b618a8 in dict_dealloc () at /tmp/build/80754af9/python_1546130271559/work/Objects/dictobject.c:2017
#21 0x00005587e9c093b1 in subtype_dealloc () at /tmp/build/80754af9/python_1546130271559/work/Objects/typeobject.c:1207
#22 0x00005587e9b6066b in free_keys_object (keys=<optimized out>) at /tmp/build/80754af9/python_1546130271559/work/Objects/dictobject.c:562
#23 PyDict_Clear () at /tmp/build/80754af9/python_1546130271559/work/Objects/dictobject.c:1753
#24 0x00005587e9b6073a in dict_tp_clear (op=<optimized out>) at /tmp/build/80754af9/python_1546130271559/work/Objects/dictobject.c:3069
#25 0x00005587e9bd8ea2 in delete_garbage (old=<optimized out>, collectable=<optimized out>) at /tmp/build/80754af9/python_1546130271559/work/Modules/gcmodule.c:864
#26 collect () at /tmp/build/80754af9/python_1546130271559/work/Modules/gcmodule.c:1016
#27 0x00005587e9c60cfa in _PyGC_CollectNoFail () at /tmp/build/80754af9/python_1546130271559/work/Modules/gcmodule.c:1626
#28 0x00005587e9c13a0e in PyImport_Cleanup () at /tmp/build/80754af9/python_1546130271559/work/Python/import.c:484
#29 0x00005587e9c7f5f1 in Py_FinalizeEx () at /tmp/build/80754af9/python_1546130271559/work/Python/pylifecycle.c:608
#30 0x00005587e9c8a1fe in Py_Main () at /tmp/build/80754af9/python_1546130271559/work/Modules/main.c:831
#31 0x00005587e9b5302e in main () at /tmp/build/80754af9/python_1546130271559/work/Programs/python.c:69
#32 0x00007fb5c3e2e830 in __libc_start_main (main=0x5587e9b52f40 <main>, argc=2, argv=0x7ffc27547288, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffc27547278) at ../csu/libc-start.c:291
#33 0x00005587e9c33e0e in _start () at ../sysdeps/x86_64/elf/start.S:103
```

so delete python side tensor handlers explicitly.