### PR TITLE
support configure async cluster job submit from user's session

### DIFF
--- a/cmd/demo/demo.go
+++ b/cmd/demo/demo.go
@@ -105,7 +105,7 @@ func main() {
 		isTable, tableRendered := false, false
 		table := tablewriter.NewWriter(os.Stdout)
 
-		stream := sql.Run(slct, db, *modelDir)
+		stream := sql.Run(slct, db, *modelDir, nil)
 		for rsp := range stream.ReadAll() {
 			isTable = render(rsp, table)
 

--- a/server/proto/sqlflow.proto
+++ b/server/proto/sqlflow.proto
@@ -22,6 +22,7 @@ service SQLFlow {
 message Session {
     string token = 1;
     string db_conn_str = 2;
+    bool exit_on_submit = 3;
 }
 
 // SQL statements to run

--- a/server/sqlflowserver_test.go
+++ b/server/sqlflowserver_test.go
@@ -43,7 +43,7 @@ const (
 
 var testServerAddress string
 
-func mockRun(sql string, db *sf.DB, modelDir string) *sf.PipeReader {
+func mockRun(sql string, db *sf.DB, modelDir string, session *pb.Session) *sf.PipeReader {
 	rd, wr := sf.Pipe()
 	go func() {
 		defer wr.Close()

--- a/sql/codegen_alps.go
+++ b/sql/codegen_alps.go
@@ -535,7 +535,10 @@ if __name__ == "__main__":
     if isinstance(experiment.engine, LocalEngine):
         run_experiment(experiment)
     else:
-        submit_experiment(experiment, exit_on_submit={{.ExitOnSubmit}})
+        if "{{.ExitOnSubmit}}" == "false":
+            run_experiment(experiment)
+        else:
+            submit_experiment(experiment, exit_on_submit=True)
 `
 
 var alpsTemplate = template.Must(template.New("alps").Parse(alpsTemplateText))

--- a/sql/codegen_alps.go
+++ b/sql/codegen_alps.go
@@ -21,10 +21,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sqlflow.org/gomaxcompute"
 	"strconv"
 	"strings"
 	"text/template"
+
+	pb "github.com/sql-machine-learning/sqlflow/server/proto"
+	"sqlflow.org/gomaxcompute"
 )
 
 type alpsFiller struct {
@@ -49,6 +51,7 @@ type alpsFiller struct {
 	ModelCreatorCode  string
 	FeatureColumnCode string
 	TrainClause       *resolvedTrainClause
+	ExitOnSubmit      bool
 
 	// Feature map
 	FeatureMapTable     string
@@ -120,7 +123,7 @@ func modelCreatorCode(resolved *resolvedTrainClause, args []string) (string, str
 		fmt.Sprintf("%s(%s)", modelName, strings.Join(cl, ",")), nil
 }
 
-func newALPSTrainFiller(pr *extendedSelect, db *DB) (*alpsFiller, error) {
+func newALPSTrainFiller(pr *extendedSelect, db *DB, session *pb.Session) (*alpsFiller, error) {
 	resolved, err := resolveTrainClause(&pr.trainClause)
 	if err != nil {
 		return nil, err
@@ -219,6 +222,10 @@ func newALPSTrainFiller(pr *extendedSelect, db *DB) (*alpsFiller, error) {
 		// TODO(joyyoj) hard code currently.
 		modelDir = fmt.Sprintf("arks://sqlflow/%s.tar.gz", pr.trainClause.save)
 	}
+	exitOnSubmit := true
+	if session != nil {
+		exitOnSubmit = session.ExitOnSubmit
+	}
 	return &alpsFiller{
 		IsTraining:          true,
 		TrainInputTable:     tableName,
@@ -235,24 +242,25 @@ func newALPSTrainFiller(pr *extendedSelect, db *DB) (*alpsFiller, error) {
 		TrainClause:         resolved,
 		FeatureMapTable:     fmap.Table,
 		FeatureMapPartition: fmap.Partition,
-		EngineCode:          engineCode}, nil
+		EngineCode:          engineCode,
+		ExitOnSubmit:        exitOnSubmit}, nil
 }
 
 func newALPSPredictFiller(pr *extendedSelect) (*alpsFiller, error) {
 	return nil, fmt.Errorf("alps predict not supported")
 }
 
-func genALPSFiller(w io.Writer, pr *extendedSelect, db *DB) (*alpsFiller, error) {
+func genALPSFiller(w io.Writer, pr *extendedSelect, db *DB, session *pb.Session) (*alpsFiller, error) {
 	if pr.train {
-		return newALPSTrainFiller(pr, db)
+		return newALPSTrainFiller(pr, db, session)
 	}
 	return newALPSPredictFiller(pr)
 }
 
-func submitALPS(w *PipeWriter, pr *extendedSelect, db *DB, cwd string) error {
+func submitALPS(w *PipeWriter, pr *extendedSelect, db *DB, cwd string, session *pb.Session) error {
 	var program bytes.Buffer
 
-	filler, err := genALPSFiller(&program, pr, db)
+	filler, err := genALPSFiller(&program, pr, db, session)
 	if err != nil {
 		return err
 	}
@@ -527,7 +535,7 @@ if __name__ == "__main__":
     if isinstance(experiment.engine, LocalEngine):
         run_experiment(experiment)
     else:
-        submit_experiment(experiment, exit_on_submit=True)
+        submit_experiment(experiment, exit_on_submit={{.ExitOnSubmit}})
 `
 
 var alpsTemplate = template.Must(template.New("alps").Parse(alpsTemplateText))

--- a/sql/codegen_alps_test.go
+++ b/sql/codegen_alps_test.go
@@ -42,7 +42,7 @@ func TestTrainALPSFiller(t *testing.T) {
 	r, e := parser.Parse(wndStatement)
 	a.NoError(e)
 
-	filler, e := newALPSTrainFiller(r, nil)
+	filler, e := newALPSTrainFiller(r, nil, nil)
 	a.NoError(e)
 
 	a.True(filler.IsTraining)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -22,12 +22,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	pb "github.com/sql-machine-learning/sqlflow/server/proto"
 )
 
 // Run executes a SQL query and returns a stream of rows or messages
-func Run(slct string, db *DB, modelDir string) *PipeReader {
+func Run(slct string, db *DB, modelDir string, session *pb.Session) *PipeReader {
 	if len(splitExtendedSQL(slct)) == 2 {
-		return runExtendedSQL(slct, db, modelDir)
+		return runExtendedSQL(slct, db, modelDir, session)
 	}
 	return runStandardSQL(slct, db)
 }
@@ -232,7 +234,7 @@ func runExec(slct string, db *DB) *PipeReader {
 	return rd
 }
 
-func runExtendedSQL(slct string, db *DB, modelDir string) *PipeReader {
+func runExtendedSQL(slct string, db *DB, modelDir string, session *pb.Session) *PipeReader {
 	rd, wr := Pipe()
 	go func() {
 		defer wr.Close()
@@ -262,7 +264,7 @@ func runExtendedSQL(slct string, db *DB, modelDir string) *PipeReader {
 
 			// FIXME(tony): temporary branch to alps
 			if os.Getenv("SQLFLOW_submitter") == "alps" {
-				return submitALPS(wr, pr, db, cwd)
+				return submitALPS(wr, pr, db, cwd, session)
 			}
 
 			if pr.train {

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -71,10 +71,10 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 	a := assert.New(t)
 	modelDir := ""
 	a.NotPanics(func() {
-		stream := runExtendedSQL(testTrainSelectIris, testDB, modelDir)
+		stream := runExtendedSQL(testTrainSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 
-		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir)
+		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -85,10 +85,10 @@ func TestExecutorTrainAndPredictDNNLocalFS(t *testing.T) {
 	a.Nil(e)
 	defer os.RemoveAll(modelDir)
 	a.NotPanics(func() {
-		stream := runExtendedSQL(testTrainSelectIris, testDB, modelDir)
+		stream := runExtendedSQL(testTrainSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 
-		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir)
+		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -109,12 +109,12 @@ BATCHSIZE = 10
 COLUMN NUMERIC(dense, 4)
 LABEL class
 INTO sqlflow_models.my_dense_dnn_model
-;`, testDB, "")
+;`, testDB, "", nil)
 		a.True(goodStream(stream.ReadAll()))
 		stream = Run(`SELECT * FROM iris.test_dense
 PREDICT iris.predict_dense.class
 USING sqlflow_models.my_dense_dnn_model
-;`, testDB, "")
+;`, testDB, "", nil)
 		a.True(goodStream(stream.ReadAll()))
 	})
 }


### PR DESCRIPTION
Can generate `ALPS` code that choose from below mode according to user "session":
- exit immediately after the training job is submitted to the cluster.
- wait until the job is done.

Related PR for `pysqlflow` will be updated here.