### PR TITLE
Save the model on user's arks directory 

### DIFF
--- a/server/proto/sqlflow.proto
+++ b/server/proto/sqlflow.proto
@@ -23,6 +23,7 @@ message Session {
     string token = 1;
     string db_conn_str = 2;
     bool exit_on_submit = 3;
+    string user_id = 4;
 }
 
 // SQL statements to run

--- a/sql/codegen_alps.go
+++ b/sql/codegen_alps.go
@@ -210,6 +210,12 @@ func newALPSTrainFiller(pr *extendedSelect, db *DB, session *pb.Session) (*alpsF
 	}
 	var modelDir string
 	var scratchDir string
+	exitOnSubmit := true
+	userID := ""
+	if session != nil {
+		exitOnSubmit = session.ExitOnSubmit
+		userID = session.UserId
+	}
 	if resolved.EngineParams.etype == "local" {
 		//TODO(uuleon): the scratchDir will be deleted after model uploading
 		scratchDir, err = ioutil.TempDir("/tmp", "alps_scratch_dir_")
@@ -220,12 +226,9 @@ func newALPSTrainFiller(pr *extendedSelect, db *DB, session *pb.Session) (*alpsF
 	} else {
 		scratchDir = ""
 		// TODO(joyyoj) hard code currently.
-		modelDir = fmt.Sprintf("arks://sqlflow/%s.tar.gz", pr.trainClause.save)
+		modelDir = fmt.Sprintf("arks://%s/%s.tar.gz", filepath.Join("sqlflow", userID), pr.trainClause.save)
 	}
-	exitOnSubmit := true
-	if session != nil {
-		exitOnSubmit = session.ExitOnSubmit
-	}
+	log.Printf("Will save the models on: %s\n", modelDir)
 	return &alpsFiller{
 		IsTraining:          true,
 		TrainInputTable:     tableName,


### PR DESCRIPTION
Will save the model on arks if using alps submitter, for a crude example SQL:
``` sql
SELECT * FROM ....
TRAIN ...
engine.type = YARN
INTO example_model
``` 
And `export SQLFLOW_USER_ID=sqlflow_user` in notebook, the Alps job would save the model on the arks directory: `arks://sqlflow/sqlflow_user/example_model.tar.gz`
