### PR TITLE
Split table into two views for training&validation

### DIFF
--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -98,7 +98,7 @@ func parseModelURI(modelString string) (bool, string) {
 	return false, fmt.Sprintf("tf.estimator.%s", modelString)
 }
 
-func newFiller(pr *extendedSelect, ds trainingDataset, fts fieldTypes, db *DB) (*filler, error) {
+func newFiller(pr *extendedSelect, ds *trainingDataset, fts fieldTypes, db *DB) (*filler, error) {
 	// TODO(weiguo): modify filler struct to carry trainingDatase in the next PR
 	isKerasModel, modelClassString := parseModelURI(pr.estimator)
 	r := &filler{
@@ -225,7 +225,7 @@ func removeLastSemicolon(s string) string {
 	return s
 }
 
-func genTF(w io.Writer, pr *extendedSelect, ds trainingDataset, fts fieldTypes, db *DB) error {
+func genTF(w io.Writer, pr *extendedSelect, ds *trainingDataset, fts fieldTypes, db *DB) error {
 	r, e := newFiller(pr, ds, fts, db)
 	if e != nil {
 		return e

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -99,6 +99,7 @@ func parseModelURI(modelString string) (bool, string) {
 }
 
 func newFiller(pr *extendedSelect, ds trainingDataset, fts fieldTypes, db *DB) (*filler, error) {
+	// TODO(weiguo): modify filler struct to carry trainingDatase in the next PR
 	isKerasModel, modelClassString := parseModelURI(pr.estimator)
 	r := &filler{
 		IsTrain:        pr.train,
@@ -229,6 +230,7 @@ func genTF(w io.Writer, pr *extendedSelect, ds trainingDataset, fts fieldTypes, 
 	if e != nil {
 		return e
 	}
+	// TODO(weiguo): fix codegen to carry trainingDatase in the next PR
 	if e = codegenTemplate.Execute(w, r); e != nil {
 		return fmt.Errorf("genTF: failed executing template: %v", e)
 	}

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -98,8 +98,7 @@ func parseModelURI(modelString string) (bool, string) {
 	return false, fmt.Sprintf("tf.estimator.%s", modelString)
 }
 
-// TODO(weiguo): fts -> pointer
-func newFiller(pr *extendedSelect, fts fieldTypes, db *DB) (*filler, error) {
+func newFiller(pr *extendedSelect, ds trainingDataset, fts fieldTypes, db *DB) (*filler, error) {
 	isKerasModel, modelClassString := parseModelURI(pr.estimator)
 	r := &filler{
 		IsTrain:        pr.train,
@@ -225,8 +224,8 @@ func removeLastSemicolon(s string) string {
 	return s
 }
 
-func genTF(w io.Writer, pr *extendedSelect, fts fieldTypes, db *DB) error {
-	r, e := newFiller(pr, fts, db)
+func genTF(w io.Writer, pr *extendedSelect, ds trainingDataset, fts fieldTypes, db *DB) error {
+	r, e := newFiller(pr, ds, fts, db)
 	if e != nil {
 		return e
 	}

--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -98,7 +98,7 @@ func parseModelURI(modelString string) (bool, string) {
 	return false, fmt.Sprintf("tf.estimator.%s", modelString)
 }
 
-func newFiller(pr *extendedSelect, ds *trainingDataset, fts fieldTypes, db *DB) (*filler, error) {
+func newFiller(pr *extendedSelect, ds *trainAndValDataset, fts fieldTypes, db *DB) (*filler, error) {
 	// TODO(weiguo): modify filler struct to carry trainingDatase in the next PR
 	isKerasModel, modelClassString := parseModelURI(pr.estimator)
 	r := &filler{
@@ -225,7 +225,7 @@ func removeLastSemicolon(s string) string {
 	return s
 }
 
-func genTF(w io.Writer, pr *extendedSelect, ds *trainingDataset, fts fieldTypes, db *DB) error {
+func genTF(w io.Writer, pr *extendedSelect, ds *trainAndValDataset, fts fieldTypes, db *DB) error {
 	r, e := newFiller(pr, ds, fts, db)
 	if e != nil {
 		return e

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -26,7 +26,7 @@ const (
 SELECT *
 FROM iris.train
 `
-	testGenerateRandomColumnTable = `
+	testTrainingDataset = `
 SELECT a.sepal_length,b.sepal_width,a.petal_length,b.petal_width,a.class 
 FROM iris_train a,iris_test b
 WHERE a.class=b.class

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -59,7 +59,7 @@ func TestCodeGenTrain(t *testing.T) {
 	fts, e := verify(r, testDB)
 	a.NoError(e)
 
-	a.NoError(genTF(ioutil.Discard, r, trainingDataset{}, fts, testDB))
+	a.NoError(genTF(ioutil.Discard, r, nil, fts, testDB))
 }
 
 func TestCodeGenPredict(t *testing.T) {
@@ -75,5 +75,5 @@ func TestCodeGenPredict(t *testing.T) {
 	fts, e := verify(r, testDB)
 	a.NoError(e)
 
-	a.NoError(genTF(ioutil.Discard, r, trainingDataset{}, fts, testDB))
+	a.NoError(genTF(ioutil.Discard, r, nil, fts, testDB))
 }

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -26,7 +26,7 @@ const (
 SELECT *
 FROM iris.train
 `
-	testTrainingDataset = `
+	testTrainAndValDataset = `
 SELECT a.sepal_length,b.sepal_width,a.petal_length,b.petal_width,a.class 
 FROM iris_train a,iris_test b
 WHERE a.class=b.class

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -59,7 +59,7 @@ func TestCodeGenTrain(t *testing.T) {
 	fts, e := verify(r, testDB)
 	a.NoError(e)
 
-	a.NoError(genTF(ioutil.Discard, r, fts, testDB))
+	a.NoError(genTF(ioutil.Discard, r, trainingDataset{}, fts, testDB))
 }
 
 func TestCodeGenPredict(t *testing.T) {
@@ -75,5 +75,5 @@ func TestCodeGenPredict(t *testing.T) {
 	fts, e := verify(r, testDB)
 	a.NoError(e)
 
-	a.NoError(genTF(ioutil.Discard, r, fts, testDB))
+	a.NoError(genTF(ioutil.Discard, r, trainingDataset{}, fts, testDB))
 }

--- a/sql/create_train_val_test.go
+++ b/sql/create_train_val_test.go
@@ -30,7 +30,5 @@ func TestCreateTrainAndValDataset(t *testing.T) {
 	a.NoError(e)
 	if testDB.driverName == "maxcompute" {
 		a.True(ds.supported)
-	} else {
-		a.False(ds.supported)
 	}
 }

--- a/sql/create_train_val_test.go
+++ b/sql/create_train_val_test.go
@@ -19,14 +19,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateTrainingDataset(t *testing.T) {
+func TestCreateTrainAndValDataset(t *testing.T) {
 	a := assert.New(t)
-	_, e := createTrainingDataset(testDB, testTrainingDataset, 1)
+	_, e := newTrainAndValDataset(testDB, testTrainAndValDataset, 1)
 	a.Error(e)
-	_, e = createTrainingDataset(testDB, testTrainingDataset, 0)
+	_, e = newTrainAndValDataset(testDB, testTrainAndValDataset, 0)
 	a.Error(e)
 
-	ds, e := createTrainingDataset(testDB, testTrainingDataset, 0.8)
+	ds, e := newTrainAndValDataset(testDB, testTrainAndValDataset, 0.8)
 	a.NoError(e)
 	if testDB.driverName == "maxcompute" {
 		a.True(ds.supported)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -269,7 +269,7 @@ func runExtendedSQL(slct string, db *DB, modelDir string, session *pb.Session) *
 
 			if pr.train {
 				// TODO(weiguo): fix the hard code 0.8
-				ds, e := createTrainingDataset(db, pr.standardSelect.String(), 0.8)
+				ds, e := newTrainAndValDataset(db, pr.standardSelect.String(), 0.8)
 				if e != nil {
 					return e
 				}
@@ -333,7 +333,7 @@ func (cw *logChanWriter) Close() {
 	}
 }
 
-func train(tr *extendedSelect, ds *trainingDataset, slct string, db *DB, cwd string, wr *PipeWriter, modelDir string) error {
+func train(tr *extendedSelect, ds *trainAndValDataset, slct string, db *DB, cwd string, wr *PipeWriter, modelDir string) error {
 	fts, e := verify(tr, db)
 	if e != nil {
 		return e

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -268,12 +268,12 @@ func runExtendedSQL(slct string, db *DB, modelDir string, session *pb.Session) *
 			}
 
 			if pr.train {
-				_, e := tableWithRandomColumn(db, pr.standardSelect.String())
-				// TODO(weiguo): remove this `errNotSupportYet` branch
-				if e != nil && e != errNotSupportYet {
+				// TODO(weiguo): fix the hard code 0.8
+				ds, e := createTrainingDataset(db, pr.standardSelect.String(), 0.8)
+				if e != nil {
 					return e
 				}
-				return train(pr, slct, db, cwd, wr, modelDir)
+				return train(pr, ds, slct, db, cwd, wr, modelDir)
 			}
 			return pred(pr, db, cwd, wr, modelDir)
 		}()
@@ -333,14 +333,14 @@ func (cw *logChanWriter) Close() {
 	}
 }
 
-func train(tr *extendedSelect, slct string, db *DB, cwd string, wr *PipeWriter, modelDir string) error {
+func train(tr *extendedSelect, ds trainingDataset, slct string, db *DB, cwd string, wr *PipeWriter, modelDir string) error {
 	fts, e := verify(tr, db)
 	if e != nil {
 		return e
 	}
 
 	var program bytes.Buffer
-	if e := genTF(&program, tr, fts, db); e != nil {
+	if e := genTF(&program, tr, ds, fts, db); e != nil {
 		return fmt.Errorf("genTF %v", e)
 	}
 
@@ -394,7 +394,7 @@ func pred(pr *extendedSelect, db *DB, cwd string, wr *PipeWriter, modelDir strin
 	}
 
 	var buf bytes.Buffer
-	if e := genTF(&buf, pr, fts, db); e != nil {
+	if e := genTF(&buf, pr, trainingDataset{}, fts, db); e != nil {
 		return fmt.Errorf("genTF: %v", e)
 	}
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -333,7 +333,7 @@ func (cw *logChanWriter) Close() {
 	}
 }
 
-func train(tr *extendedSelect, ds trainingDataset, slct string, db *DB, cwd string, wr *PipeWriter, modelDir string) error {
+func train(tr *extendedSelect, ds *trainingDataset, slct string, db *DB, cwd string, wr *PipeWriter, modelDir string) error {
 	fts, e := verify(tr, db)
 	if e != nil {
 		return e
@@ -394,7 +394,7 @@ func pred(pr *extendedSelect, db *DB, cwd string, wr *PipeWriter, modelDir strin
 	}
 
 	var buf bytes.Buffer
-	if e := genTF(&buf, pr, trainingDataset{}, fts, db); e != nil {
+	if e := genTF(&buf, pr, nil, fts, db); e != nil {
 		return fmt.Errorf("genTF: %v", e)
 	}
 

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -46,16 +46,6 @@ func goodStream(stream chan interface{}) (bool, string) {
 	return true, ""
 }
 
-func TestTableWithRandomColumn(t *testing.T) {
-	a := assert.New(t)
-	a.NotPanics(func() {
-		_, e := tableWithRandomColumn(testDB, testGenerateRandomColumnTable)
-		if e != errNotSupportYet {
-			a.NoError(e)
-		}
-	})
-}
-
 func TestSplitExtendedSQL(t *testing.T) {
 	a := assert.New(t)
 	s := splitExtendedSQL(`select a train b with c;`)

--- a/sql/validation.go
+++ b/sql/validation.go
@@ -20,38 +20,82 @@ import (
 	"github.com/pkg/errors"
 )
 
+type trainingDataset struct {
+	// `supported` here identifies if SQLFlow is able to split dataset into
+	// training dataset and validation dataset.
+	// So, TODO(weiguo): Let's remove `supproted` if SQLFlow supports other
+	// drivers, like: MySQL, hive(specified in database.go:open()).
+	supported      bool
+	table          string
+	trainingView   string // view of table (<k)
+	validationView string // view of table (>=k)
+}
+
 const (
 	temporaryTableLifecycle = 14 // day(s)
 	randomColumn            = "sqlflow_rdm"
-	randomTablePrefix       = "sqlflow_tv_" // 'tv' = training & validation
+	tablePrefix             = "sqlflow_tv_" // 'tv' = training & validation
+	trainingViewPrefix      = "sqlflow_view_training_"
+	validationViewPrefix    = "sqlflow_view_validation_"
 )
 
-var errNotSupportYet = errors.New("not support yet")
+var (
+	errBadBoundary = errors.New("boundary should between (0.0, 1.0) exclude")
+)
 
 // SQLFlow generates a temporary table, + sqlflow_randowm column
-func tableWithRandomColumn(db *DB, standardSelect string) (string, error) {
+func createTrainingDataset(db *DB, slct string, trainingUpperbound float32) (trainingDataset, error) {
+	if trainingUpperbound <= 0 || trainingUpperbound >= 1 {
+		return trainingDataset{}, errBadBoundary
+	}
+
 	switch db.driverName {
 	case "maxcompute":
-		return createMaxcomputeRandomTable(db, standardSelect)
-	// TODO(weiguo): support other databases
-	case "hive", "mysql", "sqlite3":
-		return "", errNotSupportYet
+		return createMaxcomputeDataset(db, slct, trainingUpperbound)
+		// TODO(weiguo): support other databases, like: "hive", "mysql"...
 	default:
-		return "", fmt.Errorf("sqlflow currently doesn't support validation for %s", db.driverName)
+		return trainingDataset{}, nil
 	}
 }
 
-func createMaxcomputeRandomTable(db *DB, standardSelect string) (string, error) {
-	tbl := randomTableName()
-	createStmt := fmt.Sprintf("CREATE TABLE %s LIFECYCLE %d AS SELECT *, RAND() AS %s FROM (%s) AS %s_ori", tbl, temporaryTableLifecycle, randomColumn, standardSelect, tbl)
-	if _, e := db.Exec(createStmt); e != nil {
-		log.Errorf("create temporary table failed, statememnt:[%s], err:%v", createStmt, e)
-		return "", e
-	}
-	return tbl, nil
+func releaseTrainingDataset(ds trainingDataset) {
+	// TODO(weiguo): release resources for databases, like: "hive", "mysql"...
 }
 
-func randomTableName() string {
-	n := time.Now().UnixNano() / 1e3
-	return fmt.Sprintf("%s%d", randomTablePrefix, n)
+func createMaxcomputeDataset(db *DB, slct string, trainingUpperbound float32) (trainingDataset, error) {
+	ds := namingTrainingDataset()
+	// create a table, then split it into 2 views
+	stmt := fmt.Sprintf("CREATE TABLE %s LIFECYCLE %d AS SELECT *, RAND() AS %s FROM (%s) AS %s_ori", ds.table, temporaryTableLifecycle, randomColumn, slct, ds.table)
+	if _, e := db.Exec(stmt); e != nil {
+		log.Errorf("create temporary table failed, stmt:[%s], err:%v", stmt, e)
+		return trainingDataset{}, e
+	}
+	trainingCond := fmt.Sprintf("%s < %f", randomColumn, trainingUpperbound)
+	if e := createView(db, ds.table, ds.trainingView, trainingCond); e != nil {
+		return trainingDataset{}, e
+	}
+	validationCond := fmt.Sprintf("%s >= %f", randomColumn, trainingUpperbound)
+	if e := createView(db, ds.table, ds.validationView, validationCond); e != nil {
+		return trainingDataset{}, e
+	}
+	return ds, nil
+}
+
+func createView(db *DB, table, view, where string) error {
+	stmt := fmt.Sprintf("CREATE VIEW %s AS SELECT * FROM %s WHERE %s", view, table, where)
+	if _, e := db.Exec(stmt); e != nil {
+		log.Errorf("create view failed, stmt:[%s], err:%v", stmt, e)
+		return e
+	}
+	return nil
+}
+
+func namingTrainingDataset() trainingDataset {
+	uniq := time.Now().UnixNano() / 1e3
+	return trainingDataset{
+		supported:      true,
+		table:          fmt.Sprintf("%s%d", tablePrefix, uniq),
+		trainingView:   fmt.Sprintf("%s%d", trainingViewPrefix, uniq),
+		validationView: fmt.Sprintf("%s%d", validationViewPrefix, uniq),
+	}
 }

--- a/sql/validation_test.go
+++ b/sql/validation_test.go
@@ -21,6 +21,16 @@ import (
 
 func TestCreateTrainingDataset(t *testing.T) {
 	a := assert.New(t)
-	_, e := createTrainingDataset(testDB, testGenerateRandomColumnTable, 0.8)
+	_, e := createTrainingDataset(testDB, testTrainingDataset, 1)
+	a.Error(e)
+	_, e = createTrainingDataset(testDB, testTrainingDataset, 0)
+	a.Error(e)
+
+	ds, e := createTrainingDataset(testDB, testTrainingDataset, 0.8)
 	a.NoError(e)
+	if testDB.driverName == "maxcompute" {
+		a.True(ds.supported)
+	} else {
+		a.False(ds.supported)
+	}
 }

--- a/sql/validation_test.go
+++ b/sql/validation_test.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTrainingDataset(t *testing.T) {
+	a := assert.New(t)
+	_, e := createTrainingDataset(testDB, testGenerateRandomColumnTable, 0.8)
+	a.NoError(e)
+}


### PR DESCRIPTION
Fix #569 

**Notice** 
It's different from the [design doc](https://github.com/sql-machine-learning/sqlflow/blob/develop/doc/training_and_validation.md).
`ALPS` doesn't support using a query to specify the dataset for training(or validation), it reads all records from a  table instead. Hence, SQLFlow creates 2 views to fulfill this.
Of cause, I will fix the design doc to follow the code.