### PR TITLE
fix notebook version

### DIFF
--- a/scripts/image_build.sh
+++ b/scripts/image_build.sh
@@ -25,8 +25,6 @@ echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
 echo "source activate sqlflow-dev" >> ~/.bashrc
 
 # keras.datasets.imdb only works with numpy==1.16.1
-# Fix jupyter server "connecting to kernel" problem by installing tornado==4.5.3
-# https://github.com/jupyter/notebook/issues/2664#issuecomment-468954423
 source /miniconda/bin/activate sqlflow-dev && python -m pip install \
 numpy==1.16.1 \
 tensorflow==${TENSORFLOW_VERSION} \
@@ -34,9 +32,9 @@ mysqlclient \
 impyla \
 pyodps \
 jupyter \
+notebook==6.0.0 \
 sqlflow==0.2.0 \
 pre-commit \
-tornado==4.5.3 \
 odps \
 ${PIP_ADD_PACKAGES}
 


### PR DESCRIPTION
Since notebook released a new tag: `6.0.0`, and the older tornado version would cause connection failed.
