### PR TITLE
Only build on develop branch and gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 branches:
   only:
   - gh-pages
-  - "/.*/"
+  - develop
 service:
   - docker
 


### PR DESCRIPTION
This would skip builds for all other branches to reduce the load on Travis. PR builds are sufficient already. It's not necessary to trigger builds on individual branches.