### PR TITLE
[ElasticDL] Auto generate `dataset_fn` code for training and prediction

### DIFF
--- a/sql/codegen_elasticdl.go
+++ b/sql/codegen_elasticdl.go
@@ -49,6 +49,9 @@ type elasticDLFiller struct {
 	PredictInputModel  string
 	PredictOutputShape int
 
+	FeaturesDescription string
+	LabelColName        string
+
 	TrainClause *resolvedTrainClause
 }
 
@@ -119,6 +122,11 @@ func newElasticDLTrainFiller(pr *extendedSelect, db *DB, session *pb.Session, ds
 	if err != nil {
 		return nil, err
 	}
+	featureNames, err := getFeaturesNames(pr)
+	if err != nil {
+		log.Fatalf("Failed to get feature names from SELECT statement %v", err)
+		return nil, err
+	}
 	var trainInput, evalInput string
 	if ds != nil && ds.supported {
 		trainInput, evalInput = ds.training, ds.validation
@@ -126,21 +134,29 @@ func newElasticDLTrainFiller(pr *extendedSelect, db *DB, session *pb.Session, ds
 		trainInput, evalInput = pr.tables[0], pr.tables[0]
 	}
 	return &elasticDLFiller{
-		IsTraining:      true,
-		TrainInputTable: trainInput,
-		EvalInputTable:  evalInput,
-		TrainClause:     resolved,
+		IsTraining:          true,
+		TrainInputTable:     trainInput,
+		EvalInputTable:      evalInput,
+		FeaturesDescription: genFeaturesDescription(featureNames),
+		LabelColName:        pr.label,
+		TrainClause:         resolved,
 	}, err
 }
 
-func newElasticDLPredictFiller(pr *extendedSelect, outputShape int) *elasticDLFiller {
-	return &elasticDLFiller{
-		IsTraining:         false,
-		PredictInputTable:  pr.tables[0],
-		PredictOutputTable: pr.predictClause.into,
-		PredictInputModel:  pr.predictClause.model,
-		PredictOutputShape: outputShape,
+func newElasticDLPredictFiller(pr *extendedSelect, outputShape int) (*elasticDLFiller, error) {
+	featureNames, err := getFeaturesNames(pr)
+	if err != nil {
+		log.Fatalf("Failed to get feature names from SELECT statement %v", err)
+		return nil, err
 	}
+	return &elasticDLFiller{
+		IsTraining:          false,
+		PredictInputTable:   pr.tables[0],
+		PredictOutputTable:  pr.predictClause.into,
+		PredictInputModel:   pr.predictClause.model,
+		PredictOutputShape:  outputShape,
+		FeaturesDescription: genFeaturesDescription(featureNames),
+	}, err
 }
 
 func elasticDLTrain(w *PipeWriter, pr *extendedSelect, db *DB, cwd string, session *pb.Session, ds *trainAndValDataset) error {

--- a/sql/codegen_elasticdl.go
+++ b/sql/codegen_elasticdl.go
@@ -66,6 +66,20 @@ func getFeaturesNames(pr *extendedSelect) ([]string, error) {
 	return features, nil
 }
 
+func genFeaturesDescription(featureNames []string) string {
+	var sb strings.Builder
+	for i, featureName := range featureNames {
+		sb.WriteString(`"`)
+		sb.WriteString(featureName)
+		sb.WriteString(`"`)
+		sb.WriteString(`: tf.io.FixedLenFeature([1], tf.float32),`)
+		if i != len(featureNames)-1 {
+			sb.WriteString(` `)
+		}
+	}
+	return sb.String()
+}
+
 func makePythonListCode(items []string) string {
 	var sb strings.Builder
 	sb.WriteString("[")

--- a/sql/codegen_elasticdl_test.go
+++ b/sql/codegen_elasticdl_test.go
@@ -141,3 +141,9 @@ func TestMakePythonListCode(t *testing.T) {
 	listCode := makePythonListCode([]string{"a", "b", "c"})
 	a.Equal(`["a", "b", "c"]`, listCode)
 }
+
+func TestGenFeaturesDescription(t *testing.T) {
+	a := assert.New(t)
+	listCode := genFeaturesDescription([]string{"a", "b", "c"})
+	a.Equal(`"a": tf.io.FixedLenFeature([1], tf.float32), "b": tf.io.FixedLenFeature([1], tf.float32), "c": tf.io.FixedLenFeature([1], tf.float32),`, listCode)
+}

--- a/sql/codegen_elasticdl_test.go
+++ b/sql/codegen_elasticdl_test.go
@@ -87,6 +87,7 @@ func TestTrainElasticDLFiller(t *testing.T) {
 	a.True(strings.Contains(code, `dataset = dataset.shuffle(buffer_size=120)`), code)
 	a.True(strings.Contains(code, `"c5": tf.io.FixedLenFeature([1], tf.int64),`), code)
 	a.True(strings.Contains(code, `"c1": tf.io.FixedLenFeature([1], tf.float32), "c2": tf.io.FixedLenFeature([1], tf.float32), "c3": tf.io.FixedLenFeature([1], tf.float32), "c4": tf.io.FixedLenFeature([1], tf.float32),`), code)
+	a.True(strings.Contains(code, `return parsed_example, tf.cast(parsed_example["c5"], tf.int32)`), code)
 }
 
 func TestPredElasticDLFiller(t *testing.T) {

--- a/sql/codegen_elasticdl_test.go
+++ b/sql/codegen_elasticdl_test.go
@@ -34,6 +34,7 @@ func TestTrainElasticDLFiller(t *testing.T) {
 			model.eval_metrics_fn = "eval_metrics_fn",
 			model.num_classes = 10,
 			model.dataset_fn = "dataset_fn",
+			train.shuffle = 120,
 			train.epoch = 2,
 			train.grads_to_wait = 2,
 			train.tensorboard_log_dir = "",
@@ -75,6 +76,16 @@ func TestTrainElasticDLFiller(t *testing.T) {
 	a.NoError(e)
 	a.True(filler.IsTraining)
 	a.Equal("training_data", filler.TrainInputTable)
+	a.Equal(true, filler.TrainClause.EnableShuffle)
+	a.Equal(120, filler.TrainClause.ShuffleBufferSize)
+
+	var program bytes.Buffer
+	e = elasticdlTrainTemplate.Execute(&program, filler)
+	a.NoError(e)
+	code := program.String()
+	a.True(strings.Contains(code, `if mode != Mode.PREDICTION and "true" == "true":`), code)
+	a.True(strings.Contains(code, `dataset = dataset.shuffle(buffer_size=120)`), code)
+	a.True(strings.Contains(code, `"c5": tf.io.FixedLenFeature([1], tf.int64),`), code)
 }
 
 func TestPredElasticDLFiller(t *testing.T) {
@@ -85,7 +96,8 @@ func TestPredElasticDLFiller(t *testing.T) {
 		USING trained_elasticdl_keras_classifier;`
 
 	r, e := parser.Parse(predStatement)
-	filler := newElasticDLPredictFiller(r, 10)
+	filler, err := newElasticDLPredictFiller(r, 10)
+	a.NoError(err)
 
 	a.False(filler.IsTraining)
 	a.Equal(filler.PredictInputTable, "prediction_data")
@@ -101,6 +113,7 @@ func TestPredElasticDLFiller(t *testing.T) {
 	a.True(strings.Contains(code, `columns=["pred_" + str(i) for i in range(10)]`), code)
 	a.True(strings.Contains(code, `column_types=["double" for _ in range(10)]`), code)
 	a.True(strings.Contains(code, `table = "prediction_results_table"`), code)
+	// a.True(strings.Contains(code, `"c1": tf.io.FixedLenFeature([1], tf.float32), "c2": tf.io.FixedLenFeature([1], tf.float32), "c3": tf.io.FixedLenFeature([1], tf.float32), "c4": tf.io.FixedLenFeature([1], tf.float32),`), code)
 }
 
 func TestElasticDLDataConversionFiller(t *testing.T) {

--- a/sql/codegen_elasticdl_test.go
+++ b/sql/codegen_elasticdl_test.go
@@ -86,6 +86,7 @@ func TestTrainElasticDLFiller(t *testing.T) {
 	a.True(strings.Contains(code, `if mode != Mode.PREDICTION and "true" == "true":`), code)
 	a.True(strings.Contains(code, `dataset = dataset.shuffle(buffer_size=120)`), code)
 	a.True(strings.Contains(code, `"c5": tf.io.FixedLenFeature([1], tf.int64),`), code)
+	a.True(strings.Contains(code, `"c1": tf.io.FixedLenFeature([1], tf.float32), "c2": tf.io.FixedLenFeature([1], tf.float32), "c3": tf.io.FixedLenFeature([1], tf.float32), "c4": tf.io.FixedLenFeature([1], tf.float32),`), code)
 }
 
 func TestPredElasticDLFiller(t *testing.T) {
@@ -113,7 +114,7 @@ func TestPredElasticDLFiller(t *testing.T) {
 	a.True(strings.Contains(code, `columns=["pred_" + str(i) for i in range(10)]`), code)
 	a.True(strings.Contains(code, `column_types=["double" for _ in range(10)]`), code)
 	a.True(strings.Contains(code, `table = "prediction_results_table"`), code)
-	// a.True(strings.Contains(code, `"c1": tf.io.FixedLenFeature([1], tf.float32), "c2": tf.io.FixedLenFeature([1], tf.float32), "c3": tf.io.FixedLenFeature([1], tf.float32), "c4": tf.io.FixedLenFeature([1], tf.float32),`), code)
+	a.True(strings.Contains(code, `"c1": tf.io.FixedLenFeature([1], tf.float32), "c2": tf.io.FixedLenFeature([1], tf.float32), "c3": tf.io.FixedLenFeature([1], tf.float32), "c4": tf.io.FixedLenFeature([1], tf.float32),`), code)
 }
 
 func TestElasticDLDataConversionFiller(t *testing.T) {

--- a/sql/template_elasticdl.go
+++ b/sql/template_elasticdl.go
@@ -175,11 +175,11 @@ def dataset_fn(dataset, mode):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {
-                {{.FEATURES_DESCRIPTION}}
+                {{.FeaturesDescription}}
             }
         else:
             feature_description = {
-                {{.FEATURES_DESCRIPTION}}
+                {{.FeaturesDescription}}
                 "{{.LabelColName}}": tf.io.FixedLenFeature([1], tf.int64),
             }
         parsed_example = tf.io.parse_single_example(record, feature_description)
@@ -192,8 +192,8 @@ def dataset_fn(dataset, mode):
 
     dataset = dataset.map(_parse_data)
 
-    if mode != Mode.PREDICTION:
-        dataset = dataset.shuffle(buffer_size=1024)
+    if mode != Mode.PREDICTION and "{{.TrainClause.EnableShuffle}}" == "true":
+        dataset = dataset.shuffle(buffer_size={{.TrainClause.ShuffleBufferSize}})
     return dataset
 
 

--- a/sql/template_elasticdl.go
+++ b/sql/template_elasticdl.go
@@ -185,12 +185,14 @@ def dataset_fn(dataset, mode):
                 {{end}}
             }
         parsed_example = tf.io.parse_single_example(record, feature_description)
-        label = tf.cast(parsed_example["{{.LabelColName}}"], tf.int32)
-        del parsed_example["{{.LabelColName}}"]
+
         if mode == Mode.PREDICTION:
             return parsed_example
+        {{if .IsTraining}}
         else:
-            return parsed_example, label
+            del parsed_example["{{.LabelColName}}"]
+            return parsed_example, tf.cast(parsed_example["{{.LabelColName}}"], tf.int32)
+        {{end}}
 
     dataset = dataset.map(_parse_data)
 

--- a/sql/template_elasticdl.go
+++ b/sql/template_elasticdl.go
@@ -192,8 +192,11 @@ def dataset_fn(dataset, mode):
 
     dataset = dataset.map(_parse_data)
 
+    {{if .IsTraining}}
     if mode != Mode.PREDICTION and "{{.TrainClause.EnableShuffle}}" == "true":
         dataset = dataset.shuffle(buffer_size={{.TrainClause.ShuffleBufferSize}})
+    {{end}}
+
     return dataset
 
 

--- a/sql/template_elasticdl.go
+++ b/sql/template_elasticdl.go
@@ -175,21 +175,20 @@ def dataset_fn(dataset, mode):
     def _parse_data(record):
         if mode == Mode.PREDICTION:
             feature_description = {
-                "image": tf.io.FixedLenFeature([32, 32, 3], tf.float32)
+                {{.FEATURES_DESCRIPTION}}
             }
         else:
             feature_description = {
-                "image": tf.io.FixedLenFeature([32, 32, 3], tf.float32),
-                "label": tf.io.FixedLenFeature([1], tf.int64),
+                {{.FEATURES_DESCRIPTION}}
+                "{{.LabelColName}}": tf.io.FixedLenFeature([1], tf.int64),
             }
-        r = tf.io.parse_single_example(record, feature_description)
-        features = {
-            "image": tf.math.divide(tf.cast(r["image"], tf.float32), 255.0)
-        }
+        parsed_example = tf.io.parse_single_example(record, feature_description)
+        label = tf.cast(parsed_example["{{.LabelColName}}"], tf.int32)
+        del parsed_example["{{.LabelColName}}"]
         if mode == Mode.PREDICTION:
-            return features
+            return parsed_example
         else:
-            return features, tf.cast(r["label"], tf.int32)
+            return parsed_example, label
 
     dataset = dataset.map(_parse_data)
 

--- a/sql/template_elasticdl.go
+++ b/sql/template_elasticdl.go
@@ -180,7 +180,9 @@ def dataset_fn(dataset, mode):
         else:
             feature_description = {
                 {{.FeaturesDescription}}
+                {{if .IsTraining}}
                 "{{.LabelColName}}": tf.io.FixedLenFeature([1], tf.int64),
+                {{end}}
             }
         parsed_example = tf.io.parse_single_example(record, feature_description)
         label = tf.cast(parsed_example["{{.LabelColName}}"], tf.int32)


### PR DESCRIPTION
Part of #664, including the following:
* Add `genFeaturesDescription` to generate the feature description used in `tf.io.parse_single_example`.
* Generate `dataset_fn` for both training and prediction.
* Support data shuffling during training.