### PR TITLE
Add predict clause resolver

### DIFF
--- a/sql/codegen_elasticdl_test.go
+++ b/sql/codegen_elasticdl_test.go
@@ -46,7 +46,6 @@ func TestTrainElasticDLFiller(t *testing.T) {
 			eval.start_delay_secs = 100,
 			eval.throttle_secs = 0,
 			eval.checkpoint_filename_for_init = "",
-			predict.checkpoint_filename_for_init = "",
 			engine.docker_image_prefix = "",
 			engine.master_resource_request = "cpu=400m,memory=1024Mi",
 			engine.master_resource_limit = "cpu=400m,memory=1024Mi",

--- a/sql/expression_resolver.go
+++ b/sql/expression_resolver.go
@@ -256,6 +256,15 @@ func getEngineSpec(attrs map[string]*attribute) engineSpec {
 	}
 }
 
+func trimQuotes(s string) string {
+	if len(s) >= 2 {
+		if s[0] == '"' && s[len(s)-1] == '"' {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
 func resolveTrainClause(tc *trainClause) (*resolvedTrainClause, error) {
 	modelName := tc.estimator
 	preMadeModel := !strings.ContainsAny(modelName, ".")
@@ -266,14 +275,6 @@ func resolveTrainClause(tc *trainClause) (*resolvedTrainClause, error) {
 	err = ValidateAttributes(attrs)
 	if err != nil {
 		return nil, err
-	}
-	trimQuotes := func(s string) string {
-		if len(s) >= 2 {
-			if s[0] == '"' && s[len(s)-1] == '"' {
-				return s[1 : len(s)-1]
-			}
-		}
-		return s
 	}
 	getIntAttr := func(key string, defaultValue int) int {
 		if p, ok := attrs[key]; ok {
@@ -427,14 +428,6 @@ func resolvePredictClause(pc *predictClause) (*resolvedPredictClause, error) {
 	err = ValidateAttributes(attrs)
 	if err != nil {
 		return nil, err
-	}
-	trimQuotes := func(s string) string {
-		if len(s) >= 2 {
-			if s[0] == '"' && s[len(s)-1] == '"' {
-				return s[1 : len(s)-1]
-			}
-		}
-		return s
 	}
 	getStringAttr := func(key string, defaultValue string) string {
 		if p, ok := attrs[key]; ok {

--- a/sql/expression_resolver.go
+++ b/sql/expression_resolver.go
@@ -70,33 +70,39 @@ type gitLabModule struct {
 }
 
 type resolvedTrainClause struct {
-	IsPreMadeModel                   bool
-	ModelName                        string
-	ModelConstructorParams           map[string]*attribute
-	BatchSize                        int
-	EvalBatchSize                    int
-	DropRemainder                    bool
-	EnableCache                      bool
-	CachePath                        string
-	Epoch                            int
-	Shard                            int
-	EnableShuffle                    bool
-	ShuffleBufferSize                int
-	MaxSteps                         int
-	GradsToWait                      int
-	TensorboardLogDir                string
-	CheckpointSteps                  int
-	CheckpointDir                    string
-	KeepCheckpointMax                int
-	EvalSteps                        int
-	EvalStartDelay                   int
-	EvalThrottle                     int
-	EvalCheckpointFilenameForInit    string
-	PredictCheckpointFilenameForInit string
-	FeatureColumns                   map[string][]featureColumn
-	ColumnSpecs                      map[string][]*columnSpec
-	EngineParams                     engineSpec
-	CustomModule                     *gitLabModule
+	IsPreMadeModel                bool
+	ModelName                     string
+	ModelConstructorParams        map[string]*attribute
+	BatchSize                     int
+	EvalBatchSize                 int
+	DropRemainder                 bool
+	EnableCache                   bool
+	CachePath                     string
+	Epoch                         int
+	Shard                         int
+	EnableShuffle                 bool
+	ShuffleBufferSize             int
+	MaxSteps                      int
+	GradsToWait                   int
+	TensorboardLogDir             string
+	CheckpointSteps               int
+	CheckpointDir                 string
+	KeepCheckpointMax             int
+	EvalSteps                     int
+	EvalStartDelay                int
+	EvalThrottle                  int
+	EvalCheckpointFilenameForInit string
+	FeatureColumns                map[string][]featureColumn
+	ColumnSpecs                   map[string][]*columnSpec
+	EngineParams                  engineSpec
+	CustomModule                  *gitLabModule
+}
+
+type resolvedPredictClause struct {
+	ModelName                 string
+	ModelConstructorParams    map[string]*attribute
+	CheckpointFilenameForInit string
+	EngineParams              engineSpec
 }
 
 // featureColumn is an interface that all types of feature columns and
@@ -253,7 +259,7 @@ func getEngineSpec(attrs map[string]*attribute) engineSpec {
 func resolveTrainClause(tc *trainClause) (*resolvedTrainClause, error) {
 	modelName := tc.estimator
 	preMadeModel := !strings.ContainsAny(modelName, ".")
-	attrs, err := resolveTrainAttribute(&tc.trainAttrs)
+	attrs, err := resolveAttribute(&tc.trainAttrs)
 	if err != nil {
 		return nil, err
 	}
@@ -347,8 +353,6 @@ func resolveTrainClause(tc *trainClause) (*resolvedTrainClause, error) {
 	evalThrottleSecs := getIntAttr("eval.throttle_secs", 600)
 	evalCheckpointFilenameForInit := getStringAttr("eval.checkpoint_filename_for_init", "")
 
-	predictCheckpointFilenameForInit := getStringAttr("predict.checkpoint_filename_for_init", "")
-
 	customModel := func() *gitLabModule {
 		if preMadeModel == false {
 			project := getStringAttr("gitlab.project", "")
@@ -386,33 +390,77 @@ func resolveTrainClause(tc *trainClause) (*resolvedTrainClause, error) {
 	}
 
 	return &resolvedTrainClause{
-		IsPreMadeModel:                   preMadeModel,
-		ModelName:                        modelName,
-		ModelConstructorParams:           modelParams,
-		BatchSize:                        batchSize,
-		EvalBatchSize:                    evalBatchSize,
-		DropRemainder:                    dropRemainder,
-		EnableCache:                      enableCache,
-		CachePath:                        cachePath,
-		Epoch:                            epoch,
-		Shard:                            shard,
-		EnableShuffle:                    enableShuffle,
-		ShuffleBufferSize:                shuffleBufferSize,
-		MaxSteps:                         maxSteps,
-		GradsToWait:                      gradsToWait,
-		TensorboardLogDir:                tensorboardLogDir,
-		CheckpointSteps:                  checkpointSteps,
-		CheckpointDir:                    checkpointDir,
-		KeepCheckpointMax:                keepCheckpointMax,
-		EvalSteps:                        evalSteps,
-		EvalStartDelay:                   evalStartDecaySecs,
-		EvalThrottle:                     evalThrottleSecs,
-		EvalCheckpointFilenameForInit:    evalCheckpointFilenameForInit,
-		PredictCheckpointFilenameForInit: predictCheckpointFilenameForInit,
-		FeatureColumns:                   fcMap,
-		ColumnSpecs:                      csMap,
-		EngineParams:                     getEngineSpec(engineParams),
-		CustomModule:                     customModel}, nil
+		IsPreMadeModel:                preMadeModel,
+		ModelName:                     modelName,
+		ModelConstructorParams:        modelParams,
+		BatchSize:                     batchSize,
+		EvalBatchSize:                 evalBatchSize,
+		DropRemainder:                 dropRemainder,
+		EnableCache:                   enableCache,
+		CachePath:                     cachePath,
+		Epoch:                         epoch,
+		Shard:                         shard,
+		EnableShuffle:                 enableShuffle,
+		ShuffleBufferSize:             shuffleBufferSize,
+		MaxSteps:                      maxSteps,
+		GradsToWait:                   gradsToWait,
+		TensorboardLogDir:             tensorboardLogDir,
+		CheckpointSteps:               checkpointSteps,
+		CheckpointDir:                 checkpointDir,
+		KeepCheckpointMax:             keepCheckpointMax,
+		EvalSteps:                     evalSteps,
+		EvalStartDelay:                evalStartDecaySecs,
+		EvalThrottle:                  evalThrottleSecs,
+		EvalCheckpointFilenameForInit: evalCheckpointFilenameForInit,
+		FeatureColumns:                fcMap,
+		ColumnSpecs:                   csMap,
+		EngineParams:                  getEngineSpec(engineParams),
+		CustomModule:                  customModel}, nil
+}
+
+func resolvePredictClause(pc *predictClause) (*resolvedPredictClause, error) {
+	modelName := pc.model
+	attrs, err := resolveAttribute(&pc.predAttrs)
+	if err != nil {
+		return nil, err
+	}
+	err = ValidateAttributes(attrs)
+	if err != nil {
+		return nil, err
+	}
+	trimQuotes := func(s string) string {
+		if len(s) >= 2 {
+			if s[0] == '"' && s[len(s)-1] == '"' {
+				return s[1 : len(s)-1]
+			}
+		}
+		return s
+	}
+	getStringAttr := func(key string, defaultValue string) string {
+		if p, ok := attrs[key]; ok {
+			strVal, _ := p.Value.(string)
+			defer delete(attrs, p.FullName)
+			if err == nil {
+				return trimQuotes(strVal)
+			}
+			fmt.Printf("ignore invalid %s=%s, default is %v", key, p.Value, defaultValue)
+		}
+		return defaultValue
+	}
+	modelParams := filter(attrs, "model", true)
+	engineParams := filter(attrs, "engine", true)
+
+	checkpointFilenameForInit := getStringAttr("predict.checkpoint_filename_for_init", "")
+
+	if len(attrs) > 0 {
+		return nil, fmt.Errorf("unsupported parameters: %v", attrs)
+	}
+
+	return &resolvedPredictClause{
+		ModelName:                 modelName,
+		ModelConstructorParams:    modelParams,
+		CheckpointFilenameForInit: checkpointFilenameForInit,
+		EngineParams:              getEngineSpec(engineParams)}, nil
 }
 
 // resolveTrainColumns resolve columns from SQL statement,
@@ -938,7 +986,7 @@ func (ec *embeddingColumn) GetInputShape() string {
 	return ec.CategoryColumn.(featureColumn).GetInputShape()
 }
 
-func resolveTrainAttribute(attrs *attrs) (map[string]*attribute, error) {
+func resolveAttribute(attrs *attrs) (map[string]*attribute, error) {
 	ret := make(map[string]*attribute)
 	for k, v := range *attrs {
 		subs := strings.SplitN(k, ".", 2)

--- a/sql/expression_resolver.go
+++ b/sql/expression_resolver.go
@@ -436,7 +436,6 @@ func resolvePredictClause(pc *predictClause) (*resolvedPredictClause, error) {
 			if err == nil {
 				return trimQuotes(strVal)
 			}
-			fmt.Printf("ignore invalid %s=%s, default is %v", key, p.Value, defaultValue)
 		}
 		return defaultValue
 	}

--- a/sql/expression_resolver_test.go
+++ b/sql/expression_resolver_test.go
@@ -262,7 +262,7 @@ func TestAttrs(t *testing.T) {
 	s := statementWithAttrs("estimator.hidden_units = [10, 20]")
 	r, e := parser.Parse(s)
 	a.NoError(e)
-	attrs, err := resolveTrainAttribute(&r.trainAttrs)
+	attrs, err := resolveAttribute(&r.trainAttrs)
 	a.NoError(err)
 	attr := attrs["estimator.hidden_units"]
 	a.Equal("estimator", attr.Prefix)
@@ -272,7 +272,7 @@ func TestAttrs(t *testing.T) {
 	s = statementWithAttrs("dataset.name = hello")
 	r, e = parser.Parse(s)
 	a.NoError(e)
-	attrs, err = resolveTrainAttribute(&r.trainAttrs)
+	attrs, err = resolveAttribute(&r.trainAttrs)
 	a.NoError(err)
 	attr = attrs["dataset.name"]
 	a.Equal("dataset", attr.Prefix)
@@ -286,7 +286,7 @@ func TestExecResource(t *testing.T) {
 	s := statementWithAttrs("exec.worker_num = 2")
 	r, e := parser.Parse(s)
 	a.NoError(e)
-	attrs, err := resolveTrainAttribute(&r.trainAttrs)
+	attrs, err := resolveAttribute(&r.trainAttrs)
 	a.NoError(err)
 	attr := attrs["exec.worker_num"]
 	fmt.Println(attr)


### PR DESCRIPTION
This is a necessary change that will help the ElasticDL integration work in https://github.com/sql-machine-learning/sqlflow/issues/664. Currently predict clause uses the same resolver as train clause. It has several problems:
* It makes it difficult to tell which fields are required for prediction or training. 
* Since predict clause contains less keywords than train clause, `resolveTrainClause` would throw an error when resolving predict clause.
* It is currently not trivial to obtain additional parameters that is necessary for engine-specific parameters in predict clause via `WITH` (we have to go through `predAttrs` in `predictClause`), which is not easy for submitters to use directly.

This PR includes the following changes:

* Add `resolvedPredictClause` and `resolvePredictClause` that will be used to resolve fields from prediction clause.
* Move `trimQuotes` and renamed `resolveTrainAttribute` to `resolveAttribute` so they can be reused by both train and predict clause resolver.
* Removed `PredictCheckpointFilenameForInit` from `resolvedTrainClause` since predict now has its own resolver.

A subsequent PR will be submitted later to use this in ElasticDL prediction job submission.