### PR TITLE
refine output columns preprocessing in codegen_xgboost

### DIFF
--- a/sql/codegen_xgboost.go
+++ b/sql/codegen_xgboost.go
@@ -268,7 +268,6 @@ var xgbTrainAttrSetterMap = map[string]func(*map[string][]string, *xgboostFiller
 var xgbPredAttrSetterMap = map[string]func(*map[string][]string, *xgboostFiller) error{
 	// xgboost output columns (for prediction)
 	"pred.append_columns":  sListPartial("pred.append_columns", func(r *xgboostFiller) *[]string { return &(r.AppendColumns) }),
-	"pred.result_column":   strPartial("pred.result_column", func(r *xgboostFiller) *string { return &(r.ResultColumn) }),
 	"pred.prob_column":     strPartial("pred.prob_column", func(r *xgboostFiller) *string { return &(r.ProbColumn) }),
 	"pred.detail_column":   strPartial("pred.detail_column", func(r *xgboostFiller) *string { return &(r.DetailColumn) }),
 	"pred.encoding_column": strPartial("pred.encoding_column", func(r *xgboostFiller) *string { return &(r.EncodingColumn) }),
@@ -549,7 +548,7 @@ func xgParseEstimator(pr *extendedSelect, filler *xgboostFiller) error {
 		}
 	case "XGBOOST.MULTICLASSIFIER":
 		if obj := filler.Objective; len(obj) == 0 {
-			filler.Objective = "multi:softmax"
+			filler.Objective = "multi:softprob"
 		} else if !strings.HasPrefix(obj, "multi") {
 			return xgParseEstimatorError(pr.estimator, fmt.Errorf("found non multi-class objective(%s)", obj))
 		}
@@ -577,10 +576,6 @@ func newXGBoostFiller(pr *extendedSelect, ds *trainAndValDataset, fts fieldTypes
 	if e := xgParseAttr(pr, filler); e != nil {
 		return nil, fmt.Errorf("failed to set xgboost attributes: %v", e)
 	}
-	// set default value of result column field in pred mode
-	if !pr.train && len(filler.ResultColumn) == 0 {
-		filler.ResultColumn = "result"
-	}
 
 	if pr.train {
 		// solve keyword: TRAIN (estimator）
@@ -588,11 +583,23 @@ func newXGBoostFiller(pr *extendedSelect, ds *trainAndValDataset, fts fieldTypes
 			return nil, e
 		}
 	} else {
-		// solve keyword: PREDICT (output_table）
-		if len(pr.into) == 0 {
-			return nil, fmt.Errorf("missing output table in xgboost prediction clause")
+		// solve keyword: PREDICT (output_table.result_column）
+		var e error
+		filler.OutputTable, filler.ResultColumn, e = parseTableColumn(pr.into)
+		if e != nil {
+			return nil, fmt.Errorf("invalid predParsed.into, %v", e)
 		}
-		filler.OutputTable = pr.into
+	}
+
+	if !pr.train {
+		// remove detail & prob column field when non-classification objective found
+		classObj := filler.Objective == "binary:logistic" || filler.Objective == "multi:softprob"
+		if len(filler.DetailColumn) > 0 && !classObj {
+			filler.DetailColumn = ""
+		}
+		if len(filler.ProbColumn) > 0 && !classObj {
+			filler.ProbColumn = ""
+		}
 	}
 
 	// solve keyword: COLUMN (column clauses)

--- a/sql/codegen_xgboost.go
+++ b/sql/codegen_xgboost.go
@@ -71,10 +71,10 @@ type xgColumnFields struct {
 }
 
 type xgResultColumnFields struct {
-	ResultColumn   string `json:"result_column,omitempty"`
-	ProbColumn     string `json:"probability_column,omitempty"`
-	DetailColumn   string `json:"detail_column,omitempty"`
-	EncodingColumn string `json:"leaf_column,omitempty"`
+	ResultColumn   string `json:"result_column"`
+	ProbColumn     string `json:"probability_column"`
+	DetailColumn   string `json:"detail_column"`
+	EncodingColumn string `json:"leaf_column"`
 }
 
 type xgFeatureFields struct {

--- a/sql/codegen_xgboost_test.go
+++ b/sql/codegen_xgboost_test.go
@@ -27,7 +27,7 @@ SELECT *
 FROM iris.train
 TRAIN xgboost.Estimator
 WITH
-	train.objective = "multi:softmax",
+	train.objective = "multi:softprob",
 	train.num_class = 3,
 	train.max_depth = 5,
 	train.eta = 0.3,
@@ -40,12 +40,11 @@ LABEL class INTO sqlflow_models.my_xgboost_model;
 	testXGPredSelectIris = `
 SELECT *
 FROM iris.test
-PREDICT iris.predict
+PREDICT iris.predict.result
 WITH
 	pred.append_columns = [sepal_length, sepal_width, petal_length, petal_width],
 	pred.prob_column = prob,
-	pred.detail_column = detail,
-	pred.encoding_column = encoding
+	pred.detail_column = detail
 USING sqlflow_models.my_xgboost_model;
 `
 )
@@ -180,9 +179,8 @@ LABEL e INTO table_123;
 
 	predClause := `
 SELECT a, b, c, d, e FROM table_xx
-PREDICT table_yy
+PREDICT table_yy.prediction_detail
 WITH
-	pred.detail_column = "prediction_detail",
 	pred.prob_column = "prediction_probability",
 	pred.encoding_column = "prediction_leafs",
 	pred.result_column = "prediction_results",

--- a/sql/codegen_xgboost_test.go
+++ b/sql/codegen_xgboost_test.go
@@ -150,7 +150,7 @@ WITH
 	train.colsample_bylevel = 0.6,
 	train.max_bin = 128,
 	train.verbosity = 3,
-	train.num_round = 300,
+	train.num_round = 30,
 	train.auto_train = true
 COLUMN a, b, c, d
 LABEL e INTO table_123;
@@ -174,23 +174,22 @@ LABEL e INTO table_123;
 	assertEq(paramMap, "colsample_bylevel", 0.6)
 	assertEq(paramMap, "max_bin", 128)
 	assertEq(paramMap, "verbosity", 3)
-	assertEq(mapData, "num_boost_round", 300)
+	assertEq(mapData, "num_boost_round", 30)
 	assertEq(mapData, "auto_train", true)
 
 	predClause := `
 SELECT a, b, c, d, e FROM table_xx
-PREDICT table_yy.prediction_detail
+PREDICT table_yy.prediction_results
 WITH
 	pred.prob_column = "prediction_probability",
 	pred.encoding_column = "prediction_leafs",
-	pred.result_column = "prediction_results",
+	pred.detail_column = "prediction_detail",
 	pred.append_columns = ["AA", "BB", "CC"]
 USING sqlflow_models.my_xgboost_model;
 `
 	filler = parseAndFill(predClause)
 	a.EqualValues([]string{"AA", "BB", "CC"}, filler.AppendColumns)
 	a.EqualValues("prediction_probability", filler.ProbColumn)
-	a.EqualValues("prediction_results", filler.ResultColumn)
 	a.EqualValues("prediction_detail", filler.DetailColumn)
 	a.EqualValues("prediction_leafs", filler.EncodingColumn)
 }
@@ -384,4 +383,13 @@ LABEL e INTO model_table;
 
 	filler.StandardSelect, filler.validDataSource.StandardSelect = "", ""
 	a.EqualValues(filler.xgDataSourceFields, filler.validDataSource)
+
+	pr, e = parser.Parse(testPredictSelectIris)
+	a.NoError(e)
+	fts, e = verify(pr, testDB)
+	a.NoError(e)
+	filler, e = newXGBoostFiller(pr, nil, fts, testDB)
+	a.NoError(e)
+	a.Equal("class", filler.ResultColumn)
+	a.Equal("iris.predict", filler.OutputTable)
 }

--- a/sql/python/test_magic_xgboost.py
+++ b/sql/python/test_magic_xgboost.py
@@ -26,7 +26,7 @@ SELECT *
 FROM iris.train
 TRAIN xgboost.Estimator
 WITH
-	train.objective = "multi:softmax",
+	train.objective = "multi:softprob",
 	train.num_class = 3,
 	train.max_depth = 5,
 	train.eta = 0.3,
@@ -38,12 +38,11 @@ LABEL class INTO sqlflow_models.my_xgboost_model;
     pred_statement = """
 SELECT *
 FROM iris.test
-PREDICT iris.predict
+PREDICT iris.predict.result
 WITH
 	pred.append_columns = [sepal_length, sepal_width, petal_length, petal_width],
 	pred.prob_column = prob,
-	pred.detail_column = detail,
-	pred.encoding_column = encoding
+	pred.detail_column = detail
 USING sqlflow_models.my_xgboost_model;
 """
 


### PR DESCRIPTION
try to fix #739

1. Grammar change:  [PREDICT] [TABLE] -> [PREDICT] [TABLE] [RESULT_COLUMN]

2. Remove redundent prob & detail column when xgboost.objective isn't classification ones.