### PR TITLE
 [ElasticDL] Set up dependencies and infra for ElasticDL tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ script:
   - docker run --rm -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test.sh
   - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
   - docker run --rm -v $GOPATH:/go --net=container:hive --entrypoint bash -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest scripts/test_hive.sh
-  - docker run --rm -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_e2e.sh
   - bash scripts/setup_k8s_env.sh
-  - docker run -e MAXCOMPUTE_AK=$MAXCOMPUTE_AK -e MAXCOMPUTE_SK=$MAXCOMPUTE_SK --rm -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_maxcompute.sh
+  - docker run --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_e2e.sh
+  - docker run -e MAXCOMPUTE_AK=$MAXCOMPUTE_AK -e MAXCOMPUTE_SK=$MAXCOMPUTE_SK --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_maxcompute.sh
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ script:
   - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
   - docker run --rm -v $GOPATH:/go --net=container:hive --entrypoint bash -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest scripts/test_hive.sh
   - bash scripts/setup_k8s_env.sh
-  - docker run --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_e2e.sh
-  - docker run -e MAXCOMPUTE_AK=$MAXCOMPUTE_AK -e MAXCOMPUTE_SK=$MAXCOMPUTE_SK --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_maxcompute.sh
+  - docker run --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v /home/$USER/.minikube/:/home/$USER/.minikube/ -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_e2e.sh
+  - docker run -e MAXCOMPUTE_AK=$MAXCOMPUTE_AK -e MAXCOMPUTE_SK=$MAXCOMPUTE_SK --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v /home/$USER/.minikube/:/home/$USER/.minikube/ -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_maxcompute.sh
 
 deploy:
   skip_cleanup: true

--- a/scripts/image_build.sh
+++ b/scripts/image_build.sh
@@ -131,4 +131,6 @@ apt install -y docker.io
 # cd elasticdl
 # pip install -r elasticdl/requirements.txt
 # python setup.py install
+# docker build -t elasticdl:dev -f elasticdl/docker/Dockerfile.dev .
+# docker build -t elasticdl:ci -f elasticdl/docker/Dockerfile.ci .
 # cd ..

--- a/scripts/image_build.sh
+++ b/scripts/image_build.sh
@@ -123,3 +123,12 @@ curl -fsSL "$HADOOP_URL" -o /tmp/hadoop.tar.gz
 tar -xzf /tmp/hadoop.tar.gz -C /opt/
 rm -rf /tmp/hadoop.tar.gz
 rm -rf /opt/hadoop-${HADOOP_VERSION}/share/doc
+
+# 11. Install additional dependencies for ElasticDL
+apt install -y docker.io
+# TODO(terrytangyuan): Uncomment once ElasticDL is open sourced
+# git clone https://github.com/wangkuiyi/elasticdl.git
+# cd elasticdl
+# pip install -r elasticdl/requirements.txt
+# python setup.py install
+# cd ..

--- a/scripts/image_build.sh
+++ b/scripts/image_build.sh
@@ -124,8 +124,9 @@ tar -xzf /tmp/hadoop.tar.gz -C /opt/
 rm -rf /tmp/hadoop.tar.gz
 rm -rf /opt/hadoop-${HADOOP_VERSION}/share/doc
 
-# 11. Install additional dependencies for ElasticDL
-apt install -y docker.io
+# 11. Install additional dependencies for ElasticDL, ElasticDL CLI, and build testing images
+apt-get install -y docker.io sudo
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # TODO(terrytangyuan): Uncomment once ElasticDL is open sourced
 # git clone https://github.com/wangkuiyi/elasticdl.git
 # cd elasticdl

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -46,7 +46,11 @@ DATASOURCE="mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"
 export PYTHONPATH=$GOPATH/src/github.com/sql-machine-learning/sqlflow/sql/python
 
 sqlflowserver --datasource=${DATASOURCE} &
-# e2e test for standar SQL
+# e2e test for standard SQL
 SQLFLOW_SERVER=localhost:50051 ipython sql/python/test_magic.py
 # e2e test for xgboost train and prediciton SQL.
 SQLFLOW_SERVER=localhost:50051 ipython sql/python/test_magic_xgboost.py
+# TODO(terrytangyuan): Enable this when ElasticDL is open sourced
+# e2e test for ElasticDL SQL
+# export SQLFLOW_submitter=elasticdl
+# SQLFLOW_SERVER=localhost:50051 ipython sql/python/test_magic_elasticdl.py

--- a/sql/cmd.go
+++ b/sql/cmd.go
@@ -47,6 +47,10 @@ func hasDocker() bool {
 	return tryRun("docker", "version")
 }
 
+func hasElasticDLCmd() bool {
+	return tryRun("elasticdl", "-h")
+}
+
 func hasDockerImage(image string) bool {
 	b, e := exec.Command("docker", "images", "-q", image).Output()
 	if e != nil || len(b) == 0 {

--- a/sql/codegen_elasticdl.go
+++ b/sql/codegen_elasticdl.go
@@ -348,7 +348,7 @@ func elasticDLPredict(w *PipeWriter, pr *extendedSelect, db *DB, cwd string, ses
 }
 
 func elasticdlPredictCmd(cwd, modelDefFilePath string, recordIODataDir string, filler *elasticDLFiller) (cmd *exec.Cmd) {
-	if hasDocker() {
+	if hasDocker() && hasElasticDLCmd() {
 		cmd = exec.Command(
 			"elasticdl", "predict",
 			"--image_base", "elasticdl:ci",
@@ -377,7 +377,7 @@ func elasticdlPredictCmd(cwd, modelDefFilePath string, recordIODataDir string, f
 		)
 		cmd.Dir = cwd
 	} else {
-		log.Fatalf("Docker has to be installed to run ElasticDL command")
+		log.Fatalf("Docker and ElasticDL CLI have to be installed to run ElasticDL")
 	}
 	return cmd
 }

--- a/sql/python/test_magic_elasticdl.py
+++ b/sql/python/test_magic_elasticdl.py
@@ -1,0 +1,63 @@
+# Copyright 2019 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from io import StringIO
+from IPython import get_ipython
+import unittest
+
+
+ipython = get_ipython()
+
+
+class TestSQLFlowMagic(unittest.TestCase):
+    train_statement = """SELECT * FROM iris.train
+		TRAIN ElasticDLKerasClassifier 
+		WITH
+			model.num_classes = 10,
+			train.shuffle = 120,
+			train.epoch = 2,
+			train.grads_to_wait = 2,
+			train.tensorboard_log_dir = "",
+			train.checkpoint_steps = 0,
+			train.checkpoint_dir = "",
+			train.keep_checkpoint_max = 0,
+			eval.steps = 0,
+			eval.start_delay_secs = 100,
+			eval.throttle_secs = 0,
+			eval.checkpoint_filename_for_init = "",
+			engine.docker_image_prefix = "",
+			engine.master_resource_request = "cpu=1,memory=4096Mi,ephemeral-storage=10240Mi",
+			engine.worker_resource_request = "cpu=1,memory=4096Mi,ephemeral-storage=10240Mi",
+			engine.minibatch_size = 10,
+			engine.num_workers = 2,
+			engine.volume = "",
+			engine.image_pull_policy = "Always",
+			engine.restart_policy = "Never",
+			engine.extra_pypi_index = "",
+			engine.namespace = "default",
+			engine.master_pod_priority = "",
+			engine.cluster_spec = "",
+			engine.records_per_task = 100
+		COLUMN
+			sepal_length, sepal_width, petal_length, petal_width
+		LABEL class
+		INTO trained_elasticdl_keras_classifier;
+"""
+
+    def test_elasticdl(self):
+        ipython.run_cell_magic("sqlflow", "", self.train_statement)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #664. This PR includes:
* Mount necessary paths (for docker, kubernetes, and minikube) when running e2e and maxcompute tests in the container. Use host network in the container.
* Install additional dependencies for ElasticDL, ElasticDL CLI, and build some necessary images for testing.
* Add `sql/python/test_magic_elasticdl.py` for testing SQLFlow magic command in ipython.
* Add `hasElasticDLCmd()` to check whether ElasticDL CLI has been installed.

Note that some of these is commented out until ElasticDL has been open sourced.