### PR TITLE
Update gohive container startup sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ script:
   - set -e
   - df -h
   - ls -lah
+  - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
   - docker build -t sqlflow:latest -f Dockerfile .
   - docker run --rm -v $GOPATH/src:/go/src -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest pre-commit run -a
   - docker run --rm -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test.sh
-  - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
   - docker run --rm -v $GOPATH:/go --net=container:hive --entrypoint bash -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest scripts/test_hive.sh
   - bash scripts/setup_k8s_env.sh
   - docker run --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v /home/$USER/.minikube/:/home/$USER/.minikube/ -v $GOPATH:/go -w /go/src/github.com/sql-machine-learning/sqlflow sqlflow:latest bash scripts/test_e2e.sh


### PR DESCRIPTION
The gohive container takes the time to prepare the  Hadoop environment and popularize the test data, launch it at the begging can  reduce the CI job duration time about 5min.