### PR TITLE
[SHAP]Support parameters for summary_plot

### DIFF
--- a/sql/template_analyze.go
+++ b/sql/template_analyze.go
@@ -66,9 +66,11 @@ def analyzer_dataset():
 
 # 2. load the model
 model_path = "{{.ModelFile}}"
-ptype = {{.PlotType}}
-if len(ptype) == 0:
-    ptype = None
+
+summaryAttrs = {}
+{{ range $k, $v := .ShapSummaryParames }}
+summaryAttrs["{{$k}}"] = {{$v}}
+{{end}}
 
 X,y = analyzer_dataset()
 
@@ -77,7 +79,7 @@ bst.load_model(fname=model_path)
 explainer = shap.TreeExplainer(bst)
 shap_values = explainer.shap_values(X)
 
-shap.summary_plot(shap_values, X, plot_type=ptype)
+shap.summary_plot(shap_values, X, **summaryAttrs)
 plt.savefig('summary')
 `
 


### PR DESCRIPTION
This PR supports specify parameters for [shap.summary_plot(..)](https://github.com/slundberg/shap/blob/263b67a2145404881ee37bc56ac648cadd2e3cba/shap/plots/summary.py#L18-L21) with a prefix `shap_summary.`
Example
``` SQL
SELECT *
FROM iris.train
ANALYZE sqlflow_models.my_xgboost_model
WITH
    shap_summary.plot_type="bar",
    shap_summary.alpha=1,
    shap_summary.sort=True
    -- shap_summary.{k}={v}
USING TreeExplainer;
```