### PR TITLE
[Clustering Model] Fix template to support clustering model

### DIFF
--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -33,14 +33,21 @@ WITH
   model.hidden_units = [10, 20]
 COLUMN sepal_length, sepal_width, petal_length, petal_width
 LABEL class
-INTO sqlflow_models.my_dnn_model
-;
+INTO sqlflow_models.my_dnn_model;
 `
 	testPredictSelectIris = `
 SELECT *
 FROM iris.test
 predict iris.predict.class
 USING sqlflow_models.my_dnn_model;
+`
+	testClusteringTrain = testSelectIris + `
+TRAIN sqlflow_models.DeepEmbeddingClusterModel
+WITH
+  model.pretrain_dims = [4,500,500,2000,10]
+COLUMN sepal_length, sepal_width, petal_length, petal_width
+LABEL class
+INTO sqlflow_models.my_clustering_model;
 `
 )
 

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -44,7 +44,8 @@ USING sqlflow_models.my_dnn_model;
 	testClusteringTrain = testSelectIris + `
 TRAIN sqlflow_models.DeepEmbeddingClusterModel
 WITH
-  model.pretrain_dims = [4,500,500,2000,10]
+  model.pretrain_dims = [4,10,3],
+  train.batch_size = 1
 COLUMN sepal_length, sepal_width, petal_length, petal_width
 LABEL class
 INTO sqlflow_models.my_clustering_model;

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -49,6 +49,12 @@ COLUMN sepal_length, sepal_width, petal_length, petal_width
 LABEL class
 INTO sqlflow_models.my_clustering_model;
 `
+	testClusteringPredict = `
+SELECT *
+FROM iris.test
+PREDICT iris.predict.class
+USING sqlflow_models.my_clustering_model;
+`
 )
 
 func TestCodeGenTrain(t *testing.T) {

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -118,9 +118,11 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 	})
 }
 
-func TestExecutorTrainAndPredictClustering(t *testing.T) {
+func TestExecutorTrainAndPredictClusteringLocalFS(t *testing.T) {
 	a := assert.New(t)
-	modelDir := ""
+	modelDir, e := ioutil.TempDir("/tmp", "sqlflow_models")
+	a.Nil(e)
+	defer os.RemoveAll(modelDir)
 	a.NotPanics(func() {
 		stream := runExtendedSQL(testClusteringTrain, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -115,8 +115,14 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 		a.True(goodStream(stream.ReadAll()))
 		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
+	})
+}
 
-		stream = runExtendedSQL(testClusteringTrain, testDB, modelDir, nil)
+func TestExecutorTrainAndPredictClustering(t *testing.T) {
+	a := assert.New(t)
+	modelDir := ""
+	a.NotPanics(func() {
+		stream := runExtendedSQL(testClusteringTrain, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 		stream = runExtendedSQL(testClusteringPredict, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -116,6 +116,9 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 
 		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
+
+		stream = runExtendedSQL(testClusteringTrain, testDB, modelDir, nil)
+		a.True(goodStream(stream.ReadAll()))
 	})
 }
 

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -113,11 +113,12 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 	a.NotPanics(func() {
 		stream := runExtendedSQL(testTrainSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
-
 		stream = runExtendedSQL(testPredictSelectIris, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 
 		stream = runExtendedSQL(testClusteringTrain, testDB, modelDir, nil)
+		a.True(goodStream(stream.ReadAll()))
+		stream = runExtendedSQL(testClusteringPredict, testDB, modelDir, nil)
 		a.True(goodStream(stream.ReadAll()))
 	})
 }

--- a/sql/template_tf.go
+++ b/sql/template_tf.go
@@ -127,9 +127,12 @@ def validate_input_fn(batch_size):
 classifier.compile(optimizer=classifier.default_optimizer(),
     loss=classifier.default_loss(),
     metrics=["accuracy"])
-classifier.fit(train_input_fn(BATCHSIZE),
-    epochs=EPOCHS if EPOCHS else classifier.default_training_epochs(),
-    verbose=VERBOSE)
+if hasattr(classifier, 'cluster_train_loop'):
+    classifier.cluster_train_loop(train_input_fn(BATCHSIZE))
+else:
+    classifier.fit(train_input_fn(BATCHSIZE),
+        epochs=EPOCHS if EPOCHS else classifier.default_training_epochs(),
+        verbose=VERBOSE)
 classifier.save_weights("{{.Save}}", save_format="h5")
 eval_result = classifier.evaluate(validate_input_fn(BATCHSIZE), verbose=VERBOSE)
 print("Training set accuracy: {accuracy:0.5f}".format(**{"accuracy": eval_result[1]}))


### PR DESCRIPTION
1. TRAIN
```SQL
SELECT *
FROM iris.train
TRAIN sqlflow_models.DeepEmbeddingClusterModel
WITH
    model.n_clusters = 5,
    model.run_pretrain = false,
    model.pretrain_dims = [4,500,500,2000,10]
COLUMN sepal_length, sepal_width, petal_length, petal_width
LABEL class   -- unnecessary
INTO sqlflow_models.my_clustering_model;
```
Right now, `LABEL` is required in the `TRAIN` SQL which is not reasonable here. 
I filed [another issue](https://github.com/sql-machine-learning/sqlflow/issues/839) about this.

2. PREDICT
```SQL
SELECT *
FROM iris.test
PREDICT iris.predict.class
USING sqlflow_models.my_clustering_model;
```