### PR TITLE
add verbose attribute

### DIFF
--- a/sql/codegen.go
+++ b/sql/codegen.go
@@ -49,6 +49,7 @@ type modelConfig struct {
 	Epochs              int
 	Save                string
 	IsKerasModel        bool
+	Verbose             int
 }
 
 // FeatureMeta describes feature column meta data
@@ -107,6 +108,7 @@ func newFiller(pr *extendedSelect, ds *trainAndValDataset, fts fieldTypes, db *D
 			EstimatorCode: modelClassString,
 			BatchSize:     1,
 			Epochs:        1,
+			Verbose:       0,
 			Save:          pr.save,
 			IsKerasModel:  isKerasModel,
 		},
@@ -130,6 +132,7 @@ func newFiller(pr *extendedSelect, ds *trainAndValDataset, fts fieldTypes, db *D
 	}
 	r.modelConfig.BatchSize = trainResolved.BatchSize
 	r.modelConfig.Epochs = trainResolved.Epoch
+	r.modelConfig.Verbose = trainResolved.Verbose
 
 	featureColumnsCode := make(map[string][]string)
 	for target, columnsExpr := range pr.columns {

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -145,7 +145,8 @@ WITH
 model.n_classes = 3,
 model.hidden_units = [10, 20],
 train.epoch = 200,
-train.batch_size = 10
+train.batch_size = 10,
+train.verbose = 1
 COLUMN NUMERIC(dense, 4)
 LABEL class
 INTO sqlflow_models.my_dense_dnn_model

--- a/sql/expression_resolver.go
+++ b/sql/expression_resolver.go
@@ -45,6 +45,7 @@ type resolvedTrainClause struct {
 	ModelName                     string
 	ModelConstructorParams        map[string]*attribute
 	BatchSize                     int
+	Verbose                       int
 	EvalBatchSize                 int
 	DropRemainder                 bool
 	EnableCache                   bool
@@ -161,6 +162,7 @@ func resolveTrainClause(tc *trainClause, slct *standardSelect, connConfig *conne
 	}
 	epoch := getIntAttr(attrs, "train.epoch", 1)
 	shard := getIntAttr(attrs, "train.shard", 1)
+	verbose := getIntAttr(attrs, "train.verbose", 0)
 	maxSteps := getIntAttr(attrs, "train.max_steps", -1)
 
 	gradsToWait := getIntAttr(attrs, "train.grads_to_wait", 2)
@@ -256,6 +258,7 @@ func resolveTrainClause(tc *trainClause, slct *standardSelect, connConfig *conne
 		CustomModule:                  customModel,
 		FeatureColumnInfered:          fcInfered,
 		ColumnSpecInfered:             csInfered,
+		Verbose:                       verbose,
 	}, nil
 }
 

--- a/sql/template_tf.go
+++ b/sql/template_tf.go
@@ -34,7 +34,7 @@ tf.get_logger().setLevel(logging.ERROR)
 
 BATCHSIZE = {{.BatchSize}}
 EPOCHS = {{.Epochs}}
-VERBOSE = 0
+VERBOSE = {{.Verbose}}
 
 driver="{{.Driver}}"
 database=""


### PR DESCRIPTION
Users can use the `train.verbose` attribute to debug the training.
