### PR TITLE
Remove head picture from /README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 ## What is SQLFlow?
 
-<p align="center">
-    <img src="doc/figures/SQLFlow_overview.png" width="500px">
-</p>
-
 SQLFlow is a bridge that connects a SQL engine, e.g. MySQL, Hive or [MaxCompute](https://www.aliyun.com/product/odps), with TensorFlow, XGboost and other machine learning toolkits. SQLFlow extends the SQL syntax to enable model training, prediction and model explanation.
 
 ## Motivation


### PR DESCRIPTION
It is not easy to create a concise illustration of the idea behind SQLFlow.

The current figure merges the concept of SQLFlow server and submitter program into a single node labeled SQLFlow. I am afraid that such merge might mislead the audience to ignore the very important distinction between SQLFlow server and the submitters.

Also, as part of the codebase, `/README.md` doesn't have to contain an illustrative figure. Such a figure, if we can create one, is alright to be on the homepage of sqlflow.org.