### PR TITLE
set default batch size to 1

### DIFF
--- a/sql/expression_resolver.go
+++ b/sql/expression_resolver.go
@@ -150,7 +150,7 @@ func resolveTrainClause(tc *trainClause, slct *standardSelect, connConfig *conne
 	modelParams := attrFilter(attrs, "model", true)
 	engineParams := attrFilter(attrs, "engine", true)
 
-	batchSize := getIntAttr(attrs, "train.batch_size", 512)
+	batchSize := getIntAttr(attrs, "train.batch_size", 1)
 	dropRemainder := getBoolAttr(attrs, "train.drop_remainder", true, false)
 	cachePath := ""
 	var enableCache bool


### PR DESCRIPTION
The sample SQL to train iris dataset ends with low accuracy:
```
%%sqlflow
SELECT *
FROM iris.train
TRAIN DNNClassifier
WITH
  model.n_classes = 3,
  model.hidden_units = [10, 20],
  train.epoch = 100,
COLUMN sepal_length, sepal_width, petal_length, petal_width
LABEL class
INTO sqlflow_models.my_dnn_model;
```

it seems that it's the default batch size configuration effect this.