### PR TITLE
Enable CI for clustering model

### DIFF
--- a/sql/codegen_analyze.go
+++ b/sql/codegen_analyze.go
@@ -39,11 +39,9 @@ func newAnalyzeFiller(pr *extendedSelect, db *DB, fms []*FeatureMeta, label, mod
 		return nil, err
 	}
 	return &analyzeFiller{
-		connectionConfig: conn,
-		X:                fms,
-		Label:            label,
-		// TODO(weiguo): test if it needs TrimSuffix(SQL, ";") on hive,
-		// or we trim it in pr(*extendedSelect)
+		connectionConfig:   conn,
+		X:                  fms,
+		Label:              label,
 		AnalyzeDatasetSQL:  pr.standardSelect.String(),
 		ModelFile:          modelPath,
 		ShapSummaryParames: summaryAttrs,

--- a/sql/codegen_test.go
+++ b/sql/codegen_test.go
@@ -44,7 +44,9 @@ USING sqlflow_models.my_dnn_model;
 	testClusteringTrain = testSelectIris + `
 TRAIN sqlflow_models.DeepEmbeddingClusterModel
 WITH
-  model.pretrain_dims = [4,10,3],
+  model.pretrain_dims = [10,10],
+  model.n_clusters = 3,
+  model.pretrain_lr = 0.001,
   train.batch_size = 1
 COLUMN sepal_length, sepal_width, petal_length, petal_width
 INTO sqlflow_models.my_clustering_model;

--- a/sql/executor_test.go
+++ b/sql/executor_test.go
@@ -118,10 +118,6 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 	})
 }
 
-// NOTE(wangkuiyi): Temporarily disable this test case, which fails in
-//    https://sqlflow.org/sqlflow/issues/877.
-// TODO(weiguo): Re-enable it after the clustering feature is well developed.
-/*
 func TestExecutorTrainAndPredictClusteringLocalFS(t *testing.T) {
 	a := assert.New(t)
 	modelDir, e := ioutil.TempDir("/tmp", "sqlflow_models")
@@ -134,7 +130,6 @@ func TestExecutorTrainAndPredictClusteringLocalFS(t *testing.T) {
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
-*/
 
 func TestExecutorTrainAndPredictDNNLocalFS(t *testing.T) {
 	a := assert.New(t)


### PR DESCRIPTION
The root cause is the default value of `model.pretrain_lr` is too large for a small dataset.
Error message:

![image](https://user-images.githubusercontent.com/6634907/65497053-21aaca80-deec-11e9-921c-b2cc5488b7fd.png)
