### PR TITLE
Avoid docker build twice on deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,12 +32,12 @@ if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
 
     echo "docker push sqlflow/sqlflow:$DOCKER_TAG"
     echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-    docker build -t sqlflow/sqlflow:$DOCKER_TAG -f ./Dockerfile .
+    docker tag sqlflow:latest sqlflow/sqlflow:$DOCKER_TAG
     docker push sqlflow/sqlflow:$DOCKER_TAG
 elif [[ "$TRAVIS_TAG" != "" ]]; then
     echo "docker push sqlflow/sqlflow:$TRAVIS_TAG"
     echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-    docker build -t sqlflow/sqlflow:$TRAVIS_TAG -f ./Dockerfile .
+    docker tag sqlflow:latest sqlflow/sqlflow:$TRAVIS_TAG
     docker push sqlflow/sqlflow:$TRAVIS_TAG
 else
     echo "Nothing to docker push"


### PR DESCRIPTION
Avoid docker build twice on deployment. Some develop branch builds are failed due to exceeding 50 mins time limit. [ref](https://travis-ci.com/sql-machine-learning/sqlflow/builds/128681234)

After merging a pull request, TravisCI will test the latest develop branch. If the test passes, TravisCI will build a new Docker image and push it to DockerHub. However, we could reuse the Docker image built for the tests.

