### PR TITLE
fix the hadoop version

### DIFF
--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -120,7 +120,7 @@ pip install xgboost==0.90
 # pip install xgboost-launcher==0.0.4
 
 # 10. install Hadoop to use as the client when writing CSV to hive tables
-HADOOP_URL=https://archive.apache.org/dist/hadoop/common/stable/hadoop-${HADOOP_VERSION}.tar.gz
+HADOOP_URL=https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
 curl -fsSL "$HADOOP_URL" -o /tmp/hadoop.tar.gz
 tar -xzf /tmp/hadoop.tar.gz -C /opt/
 rm -rf /tmp/hadoop.tar.gz


### PR DESCRIPTION
Using the fixed Hadoop version instead of the stable one, which will be updated on every release. This external update caused our CI to fail. [ref](https://travis-ci.org/sql-machine-learning/sqlflow/builds/588720716).