### PR TITLE
update document title format

### DIFF
--- a/doc/design/design_alps_submitter.md
+++ b/doc/design/design_alps_submitter.md
@@ -1,4 +1,4 @@
-# _Design:_ ALPS Submitter
+# ALPS Submitter
 
 ALPS (Ant Learning and Prediction Suite) provides a common algorithm-driven framework in Ant Financial, focusing on providing users with an efficient and easy-to-use machine learning programming framework and a financial learning machine learning algorithm solution.
 

--- a/doc/design/design_analyzer.md
+++ b/doc/design/design_analyzer.md
@@ -6,7 +6,7 @@ Although the machine learning model is widely used in many fields, it remains mo
 
 This design doc introduces how to support the `Analyze SQL` in SQLFlow with SHAP as the backend and display the visualization image to the user.
 
-## User interface
+## User Interface
 
 Users usually use a **TRAIN SQL** to train a model and then analyze the model using an **ANALYZE SQL**, the simple pipeline like:
 

--- a/doc/design/design_analyzer.md
+++ b/doc/design/design_analyzer.md
@@ -1,4 +1,4 @@
-# _Design:_ Analyze the Machine Learning Model in SQLFlow
+# Analyze the Machine Learning Model in SQLFlow
 
 ## Concept
 

--- a/doc/design/design_ant_xgboost.md
+++ b/doc/design/design_ant_xgboost.md
@@ -1,4 +1,4 @@
-# _Design:_ ant-xgboost on sqlflow
+# _Design:_ Ant-XGBoost on SQLFlow
 
 **NOTE: ant-xgboost on SQLFlow has moved to [backup_antxgboot_work branch](https://github.com/sql-machine-learning/sqlflow/tree/backup_antxgboost_work)**
 
@@ -22,7 +22,7 @@ which is an optimized distributed gradient boosting library designed to be highl
 often regarded as one of the best GBM frameworks.
 
 
-## _Proposed Solution:_ ant-xgboost on sqlflow
+## _Proposed Solution:_ Ant-XGBoost on SQLFlow
    
 We propose to use [ant-xgboost](https://github.com/alipay/ant-xgboost) as backend,
 which is consistent with [xgboost](https://github.com/dmlc/xgboost) in kernel level. 
@@ -137,7 +137,7 @@ The `code template` roughly includes components as follows:
 * Configure template building and entry point of xgblauncher.
 
 
-#### Running distributed xgboost job on k8s cluster
+#### Running Distributed XGBoost Job on K8S Cluster
 
 Distributed training is supported in xgboost via [rabit](https://github.com/dmlc/rabit), a reliable allreduce and broadcast interface for distributed machine learning.
 To run a distributed xgboost job with `rabit`, all we need to do is setup a distributed environment.  

--- a/doc/design/design_ant_xgboost.md
+++ b/doc/design/design_ant_xgboost.md
@@ -1,4 +1,4 @@
-# _Design:_ Ant-XGBoost on SQLFlow
+# Ant-XGBoost on SQLFlow
 
 **NOTE: ant-xgboost on SQLFlow has moved to [backup_antxgboot_work branch](https://github.com/sql-machine-learning/sqlflow/tree/backup_antxgboost_work)**
 

--- a/doc/design/design_auth.md
+++ b/doc/design/design_auth.md
@@ -1,4 +1,4 @@
-# _Design:_ SQLFlow Authentication and Authorization
+# SQLFlow Authentication and Authorization
 
 ## Concepts
 

--- a/doc/design/design_close_producer_from_consumer.md
+++ b/doc/design/design_close_producer_from_consumer.md
@@ -1,4 +1,4 @@
-# _Design:_ Closing the Producer Goroutine from the Consumer
+# Closing the Producer Goroutine from the Consumer
 
 The producer-and-consumer pattern is well used in Go concurrent programming. When
 the consumer stops, we want to gracefully stop the producer as well.

--- a/doc/design/design_close_producer_from_consumer.md
+++ b/doc/design/design_close_producer_from_consumer.md
@@ -1,4 +1,4 @@
-# _Design:_ Closing the producer goroutine from the consumer
+# _Design:_ Closing the Producer Goroutine from the Consumer
 
 The producer-and-consumer pattern is well used in Go concurrent programming. When
 the consumer stops, we want to gracefully stop the producer as well.
@@ -52,7 +52,7 @@ This problem is important because the leaking goroutine usually owns scarce syst
 resources such as network connection and memory.
 
 
-## Solution: pipeline explicit cancellation
+## Solution: Pipeline Explicit Cancellation
 
 Inspired by this [blog post](https://blog.golang.org/pipelines) section
 *Explicit cancellation*, we can signal the cancellation via closing on a separate

--- a/doc/design/design_clustermodel.md
+++ b/doc/design/design_clustermodel.md
@@ -1,4 +1,4 @@
-# _Design:_ Clustering in SQLFlow to Analyze Patterns in Data
+# Clustering in SQLFlow to Analyze Patterns in Data
 
 ## ClusterModel Introduction
 

--- a/doc/design/design_clustermodel.md
+++ b/doc/design/design_clustermodel.md
@@ -1,6 +1,6 @@
-# _Design:_ Clustering in SQLFlow to analyze patterns in data
+# _Design:_ Clustering in SQLFlow to Analyze Patterns in Data
 
-## ClusterModel introduction
+## ClusterModel Introduction
 
 Most of time when businessman and analyst faced the data, they need not only the supervised learning model to perform classification and prediction, but also unsupervised learning to catch hidden patterns. This can help analysts to draw inferences from datasets consisting of input data without labeled responses, such as grouping users by their behavioral characteristics. 
 
@@ -16,9 +16,9 @@ The figure below demonstrates the overall workflow for cluster model training, w
 3. The overall train process ultimately outputs an unsupervised clustering model.
 
 
-## How to implement ClusterModel it in SQLFlow
+## How to Implement a ClusterModel in SQLFlow
 
-### User interface in SQLFlow 
+### User Interface in SQLFlow 
 
 In this scenario, we focus on the extraction of data patterns in unsupervised learning. 
 

--- a/doc/design/design_customized_model.md
+++ b/doc/design/design_customized_model.md
@@ -1,4 +1,4 @@
-# _Design:_ Define Models for SQLFlow
+# Define Models for SQLFlow
 
 SQLFlow enables SQL programs to call deep learning models defined in Python. This document is about how to define models for SQLFlow.
 

--- a/doc/design/design_database_abstraction_layer.md
+++ b/doc/design/design_database_abstraction_layer.md
@@ -1,4 +1,4 @@
-# _Design:_ Compatibility with Various SQL Engines
+# Compatibility with Various SQL Engines
 
 SQLFlow interacts with SQL engines like MySQL and Hive, while different SQL engines use variants of SQL syntax, it is important for SQLFlow to have an abstraction layer that hides such differences.
 

--- a/doc/design/design_elasticdl_on_sqlflow.md
+++ b/doc/design/design_elasticdl_on_sqlflow.md
@@ -1,4 +1,4 @@
-# _Design:_ ElasticDL on sqlflow
+# _Design:_ ElasticDL on SQLFlow
 
 ## Overview
 

--- a/doc/design/design_elasticdl_on_sqlflow.md
+++ b/doc/design/design_elasticdl_on_sqlflow.md
@@ -1,4 +1,4 @@
-# _Design:_ ElasticDL on SQLFlow
+# ElasticDL on SQLFlow
 
 ## Overview
 

--- a/doc/design/design_feature_derivation.md
+++ b/doc/design/design_feature_derivation.md
@@ -1,4 +1,4 @@
-# _Design:_ Feature Derivation
+# Feature Derivation
 
 This file discusses the details and implementations of "Feature Derivation".
 Please refer to [this](https://medium.com/@SQLFlow/feature-derivation-the-conversion-from-sql-data-to-tensors-833519db1467) blog to

--- a/doc/design/design_intermediate_representation.md
+++ b/doc/design/design_intermediate_representation.md
@@ -1,4 +1,4 @@
-# _Design:_ Intermediate Representation
+# Intermediate Representation
 
 ## Overview
 

--- a/doc/design/design_pipe.md
+++ b/doc/design/design_pipe.md
@@ -53,7 +53,7 @@ In the above figure, from the SQLFlow magic command to the bottom layer are our 
 We have two alternative ideas: multiple streams and a multiplexing stream.
 We decided to use a multiplexing stream because we had a unsuccessful trial with the multiple streams idea: we make the job writes to various Go channels and forward each Go channel to a streaming gRPC call, as the following:
 
-### Multiple streams
+### Multiple Streams
 
 The above figure shows that there are multiple streams between the Jupyter Notebook server and Jupyter kernels.  According to the [document](https://jupyter-client.readthedocs.io/en/stable/messaging.html), there are five: Shell, IOPub, stdin, Control, and Heartbeat.  These streams are ZeroMQ streams.  We don't use ZeroMQ, but we can take the idea of having multiple parallel streams in the pipe.
 

--- a/doc/design/design_pipe.md
+++ b/doc/design/design_pipe.md
@@ -1,4 +1,4 @@
-# _Design:_ Piping Responses
+# Piping Responses
 
 
 ## Streaming Responses

--- a/doc/design/design_sql_parser.md
+++ b/doc/design/design_sql_parser.md
@@ -1,4 +1,4 @@
-# _Design:_ Extended SQL Parser
+# Extended SQL Parser
 
 This documentation explains the technical decision made in building a SQL
 parser in Go. It is used to parsed the extended SELECT syntax of SQL that

--- a/doc/design/design_submitter.md
+++ b/doc/design/design_submitter.md
@@ -68,7 +68,7 @@ type Submitter interface {
 }
 ```
 
-## Register a submitter
+## Register a Submitter
 
 A new submitter can be added as
 

--- a/doc/design/design_submitter.md
+++ b/doc/design/design_submitter.md
@@ -1,4 +1,4 @@
-# _Design:_ Submitter
+# Submitter
 
 A submitter is a pluggable module in SQLFlow that is used to submit an ML job to a third party computation service.
 

--- a/doc/design/design_support_multiple_sql_statements.md
+++ b/doc/design/design_support_multiple_sql_statements.md
@@ -1,4 +1,4 @@
-# _Design:_ Support Multiple SQL Statements
+# Support Multiple SQL Statements
 
 ## Overview
 

--- a/doc/design/design_support_multiple_sql_statements.md
+++ b/doc/design/design_support_multiple_sql_statements.md
@@ -1,4 +1,4 @@
-# _Design:_ Support multiple SQL statements
+# _Design:_ Support Multiple SQL Statements
 
 ## Overview
 
@@ -12,7 +12,7 @@ Currently, our Jupyter magic command `%%sqlflow` only supports to run one statem
 
 There are several design choices to make.
 
-### Splitting Location: Client-side vs Server-side
+### Splitting Location: Client-Side vs Server-Side
 
 While splitting at the client-side is relatively simple to implement. We prefer to split at the server-side for the following reasons.
 1. Loose coupling. SQLFlow server can use its lexer/parser to split SQL statements accurately. 

--- a/doc/design/design_syntax.md
+++ b/doc/design/design_syntax.md
@@ -1,4 +1,4 @@
-# _Design:_ SQLFlow
+# SQLFlow
 
 ## What is SQLFlow
 

--- a/doc/design/design_train_parameters.md
+++ b/doc/design/design_train_parameters.md
@@ -1,4 +1,4 @@
-# _Design:_ Information necessary for code generators in SQLFlow
+# _Design:_ Information Necessary for Code Generators in SQLFlow
 
 SQLFlow extends the syntax of the SELECT statement of SQL to support training a model:
 ```sql
@@ -50,7 +50,7 @@ WITH
     model.hidden_units = [10, 20, 10]
 ```
 
-### Training hyper-parameters
+### Training Hyper-Parameters
 The training hyper-parameters can be also set in the `WITH` block.
 
 <b>Here is the list of hyper-parameters planning to support.</b>
@@ -119,7 +119,7 @@ represents that the `c1` field is the dense format and the `c2` field is the spa
 | embedding  | 1. key (cat_id) <br> 2. dimension (integer) <br> 3. combiner (str)         | embedding(cat_id(c2, 10000), mean) |
 
 
-## Independent module for resolving of training parameters
+## Independent Module for Resolving of Training Parameters
 Since the format of training parameters has been unified, it's better to have an independent module in SQLFlow to do the resolving according to the rules instead of doing it in each `codegen_**.go`.
 
 The advantage of an independent module contains

--- a/doc/design/design_train_parameters.md
+++ b/doc/design/design_train_parameters.md
@@ -1,4 +1,4 @@
-# _Design:_ Information Necessary for Code Generators in SQLFlow
+# Information Necessary for Code Generators in SQLFlow
 
 SQLFlow extends the syntax of the SELECT statement of SQL to support training a model:
 ```sql

--- a/doc/design/design_training_and_validation.md
+++ b/doc/design/design_training_and_validation.md
@@ -9,7 +9,7 @@ SQLFlow generates a temporary table following the user-specific table, trains an
 
 Notice, we talk about the **train** process in this post.
 
-## Generate a temporary table
+## Generate a Temporary Table
 Splitting the training table into training data and validation data is the key point. We suppose SQLFlow are dealing with the following SQL to train an ML model:
 
 ```SQL
@@ -89,7 +89,7 @@ SQLFlow creates an own database as workspace, like `sqlflow_workspace`, then cre
   Notice: Why doesn't SQLFlow [create TEMPORARY table](https://dev.mysql.com/doc/refman/8.0/en/create-temporary-table.html) to act the *TempTable*?   
   Because SQLFlow creates *TempTable* in Go and read the contents in Python. They are different sessions, which means the *TempTable* is invisible to each other.
 
-## How to split
+## How to Split
 
 **We fetch the training/validation data using two different queries respectively.** 
    
@@ -108,7 +108,7 @@ type extendedSelect struct {
 ## Codegen
 For TensorFlow submitter, SQLFlow generate training data set and validation data set according to `extendedSelect.training` and `extendedSelect.validation`.
 
-## Release the temporary table
+## Release the Temporary Table
 In the end, SQLFlow remove the temporary table to release resources. 
 
 - For Maxcompute  

--- a/doc/design/design_training_and_validation.md
+++ b/doc/design/design_training_and_validation.md
@@ -1,4 +1,4 @@
-# _Design:_ Training and Validation
+# Training and Validation
 
 A common ML training job usually involves two kinds of data sets: training data and validation data. These two data sets will be generated automatically by SQLFlow through randomly splitting the select results.
 

--- a/doc/design/design_xgboost_on_sqlflow.md
+++ b/doc/design/design_xgboost_on_sqlflow.md
@@ -1,4 +1,4 @@
-# _Design:_ XGBoost on SQLFlow
+# XGBoost on SQLFlow
 
 ## Introduction
 

--- a/doc/run/docker.md
+++ b/doc/run/docker.md
@@ -15,7 +15,7 @@ You can use this Docker image for either local trying out or production deployme
    docker pull sqlflow/sqlflow
    ```
 
-## Try Out SQLFlow using Notebook
+## Try Out SQLFlow Using Notebook
 
 1. Type the below command to start the container:
 

--- a/doc/run/gcp.md
+++ b/doc/run/gcp.md
@@ -116,7 +116,7 @@ This tutorial will walk you through the steps of:
     It should show a cluster name like 'gke_${YOUR_GCP_PROJECT_ID}'-central1-a_sqlflow-gke-cluster
 
 
-## Deploy SQLFlow services
+## Deploy SQLFlow Services
 
 You can refer to the [Running SQLFlow on Kubernetes](/doc/run_on_kubernetes.md)
 tutorial for a more comprehensive guide on deploying SQLFlow on Kubernetes
@@ -154,7 +154,7 @@ server and Jupyter Notebook server.
     sqlflow-populate-demo-dataset-8qdtd                 0/1     Completed   0          9m30s
     ```
 
-## Run your Query in SQLFlow
+## Run Your Query in SQLFlow
 
 1. Get the external ip address for the sqlflow service
     ``` bash

--- a/doc/run/kubernetes.md
+++ b/doc/run/kubernetes.md
@@ -45,7 +45,7 @@ Docker image](/doc/build.md).
     sqlflow-all-in-one-9b57566c9-8xkpk   1/1     Running   0          60s
     ```
 
-### Running your Query in SQLFlow 
+### Running Your Query in SQLFlow 
 
 1. Copy the node IP of the sqlflow Pod on minikube as the follows command:
     ``` bash

--- a/doc/run_with_hive.md
+++ b/doc/run_with_hive.md
@@ -1,8 +1,8 @@
-# How SQLFlow connects with Hive
+# How SQLFlow Connects with Hive
 
 This document is a tutorial on how SQLFlow connects Hive via [HiveServer2](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Overview).
 
-## Connect Existing Hive server
+## Connect Existing Hive Server
 
 To connect an existing Hive server instance, we only need to configure a `datasource` string in the format of
 
@@ -30,11 +30,11 @@ SQLFLOW_SERVER=localhost:50051 jupyter notebook --ip=0.0.0.0 --port=8888 --allow
 
 Then you can open a web browser and go to `localhost:8888`. There are many SQLFlow tutorials, e.g. `tutorial_dnn_iris.ipynb`. You can follow the tutorials and substitute the data for your own use.
 
-## Connect standalone Hive server for testing
+## Connect Standalone Hive Server for Testing
 
 We also pack a standalone Hive server Docker image for testing.
 
-### Connect Hive server with NOSASL Transport
+### Connect Hive Server with NOSASL Transport
 
 Launch your standalone hive server Docker container by running:
 

--- a/doc/run_with_maxcompute.md
+++ b/doc/run_with_maxcompute.md
@@ -1,8 +1,8 @@
-# How to connect MaxCompute with SQLFlow
+# How to Connect MaxCompute with SQLFlow
 
 This tutorial explains how to connect SQLFlow with [MaxCompute (a.k.a ODPS)](https://www.alibabacloud.com/product/maxcompute).
 
-## Connect Existing MaxCompute server
+## Connect Existing MaxCompute Server
 
 To connect an existed MaxCompute server instance, we need to configure a `datasource` string in the format of   
 `maxcompute://{accesskey_id}:{accesskey_secret}@{endpoint}?curr_project={curr_project}&scheme={scheme}`
@@ -24,7 +24,7 @@ SQLFLOW_SERVER=localhost:50051 jupyter notebook --ip=0.0.0.0 --port=8888 --allow
 
 Open `localhost:8888` through a web browser, you will find there are many SQLFlow tutorials, e.g. `iris-dnn.ipynb`. Please follow the tutorials and substitute the data for your use.
 
-## Create a MaxCompute instance for testing
+## Create a MaxCompute Instance for Testing
 Aliyun supplies a development version that is suitable as a testing environment. Follow the tutorial [Create Workspace](https://www.alibabacloud.com/help/doc-detail/74293.htm), we could create a MaxCompute instance for testing. The development version has some capacity limitations. If you wanna play the testing on a large dataset, please turn to the standard version.
 
 Then, according to the above section, we could build a `datasource` and launch a container.

--- a/doc/run_with_mysql.md
+++ b/doc/run_with_mysql.md
@@ -1,8 +1,8 @@
-# How to connect MySQL with SQLFlow
+# How to Connect MySQL with SQLFlow
 
 This tutorial explains how to connect SQLFlow with [MySQL](https://en.wikipedia.org/wiki/MySQL).
 
-## Connect Existing MySQL server
+## Connect Existing MySQL Server
 
 To connect an existed MySQL server instance, we need to configure a `datasource` string in the format of   
 ```
@@ -31,7 +31,7 @@ Open `localhost:8888` through a web browser, and you will find there are many SQ
 
 If you are running MySQL on remote, please be aware that MySQL only allows connections from localhost by default. The fix can be found [here](https://stackoverflow.com/questions/14779104/how-to-allow-remote-connection-to-mysql).
 
-## Create a MySQL server locally for testing
+## Create a MySQL Server Locally for Testing
 
 Our official Docker image has installed a `mysql` server. We can start it by `docker run --rm -it sqlflow/sqlflow bash`, then type `service mysql start` in the console. We should be able to see
 

--- a/doc/tutorial/didi/carprice_xgboost/README.md
+++ b/doc/tutorial/didi/carprice_xgboost/README.md
@@ -91,7 +91,7 @@ LABEL msrp
 INTO sqlflow_models.my_xgb_regression_model;
 ```
 
-# Predict the car's price
+# Predict the Car's Price
 After training the regression model, let's predict the car price using the trained model.
 
 First, we can specify the trained model by USING clause:

--- a/doc/tutorial/housing-analyze.md
+++ b/doc/tutorial/housing-analyze.md
@@ -1,4 +1,4 @@
-# Analyzing model on SQLFlow Tutorial
+# Analyzing Model on SQLFlow Tutorial
 
 The [Analyzer](../../doc/analyzer_design.md) is designed to explain the machine learning model in SQLFlow. In this tutorial, you will learn how to,
 
@@ -25,12 +25,12 @@ USING TreeExplainer;
 - By `WITH`, we specify the parameters to [summary_plot](https://github.com/slundberg/shap/blob/master/shap/plots/summary.py#L18-L43) with a prefix `shap_summary.`
   like: `shap_summary.plot_type=\"bar\"`.
 
-## The dataset
+## The Dataset
 
 We use the [boston housing](https://www.kaggle.com/c/boston-housing) as the demonstration dataset.
 First, we train a model to fit the dataset. Next, we write an `ANALYZE` SQL to get an overview of which features are most important for the model.
 
-## Train a model
+## Train a Model
 
 ```sql
 %%sqlflow
@@ -44,7 +44,7 @@ LABEL medv
 INTO sqlflow_models.my_xgb_regression_model;
 ```
 
-## Analyze the model
+## Analyze the Model
 
 We can plot the SHAP values of every feature for every sample.
 

--- a/doc/tutorial/housing-xgboost.md
+++ b/doc/tutorial/housing-xgboost.md
@@ -86,7 +86,7 @@ LABEL medv
 INTO sqlflow_models.my_xgb_regression_model;
 ```
 
-### Predict the housing price
+### Predict the Housing Price
 After training the regression model, let's predict the house price using the trained model.
 
 First, we can specify the trained model by `USING clause`: 


### PR DESCRIPTION
Update title format of capitalization in all documents.
Remove `Design: ` in all design doc so that sqlflow.org's document tree will be cleaner.