### PR TITLE
Add DEST_FOLDER env in convert_markdown_to_ipynb script

### DIFF
--- a/scripts/convert_markdown_into_ipynb.sh
+++ b/scripts/convert_markdown_into_ipynb.sh
@@ -24,6 +24,7 @@ if [[ $GOPATH == "" ]]; then
 fi
 
 SRC_FOLDER=${SRC_FOLDER:-doc/tutorial}
+DEST_FOLDER=${DEST_FOLDER-/workspace}
 
 go get -u github.com/wangkuiyi/ipynb/markdown-to-ipynb
 
@@ -33,7 +34,7 @@ cd $cur_path/../
 # convert markdown to ipynb
 for file in ${SRC_FOLDER}/*.md; do
     filename=$(basename -- "$file")
-    $GOPATH/bin/markdown-to-ipynb --code-block-type=sql < $file > /workspace/${filename%.*}."ipynb"
+    $GOPATH/bin/markdown-to-ipynb --code-block-type=sql < $file > $DEST_FOLDER/${filename%.*}."ipynb"
     if [ $? -ne 0 ]; then
         echo >&2 "markdown-to-ipynb $file error"
         exit 1

--- a/scripts/convert_markdown_into_ipynb.sh
+++ b/scripts/convert_markdown_into_ipynb.sh
@@ -24,7 +24,7 @@ if [[ $GOPATH == "" ]]; then
 fi
 
 SRC_FOLDER=${SRC_FOLDER:-doc/tutorial}
-DEST_FOLDER=${DEST_FOLDER-/workspace}
+DEST_FOLDER=${DEST_FOLDER:-/workspace}
 
 go get -u github.com/wangkuiyi/ipynb/markdown-to-ipynb
 


### PR DESCRIPTION
This PR added the `DEST_FOLDER` environment variable so that we can convert the markdown into a specified folder instead of the hard-code `/workspace`