### PR TITLE
[ElasticDL] Update ElasticDL specific engine parameters

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -798,7 +798,9 @@ WITH
 			engine.minibatch_size = 64,
 			engine.master_pod_priority = "",
 			engine.cluster_spec = "",
-			engine.records_per_task = 100
+			engine.num_minibatches_per_task = 10,
+			engine.docker_image_repository = "",
+			engine.envs = ""
 LABEL class
 INTO trained_elasticdl_keras_classifier;`, caseDB, caseTrainTable)
 

--- a/doc/design/design_elasticdl_on_sqlflow.md
+++ b/doc/design/design_elasticdl_on_sqlflow.md
@@ -58,7 +58,7 @@ WITH
   runtime.master_resource_limit = "cpu=400m,memory=1024Mi",
   runtime.worker_resource_request = "cpu=400m,memory=2048Mi",
   runtime.worker_resource_limit = "cpu=1,memory=3072Mi",
-  runtime.records_per_task = 100,
+  runtime.num_minibatches_per_task = 10,
   runtime.num_workers = 2
 COLUMN
   c1, c2, c3, c4
@@ -128,7 +128,7 @@ elasticdl train \
 --worker_resource_request="cpu=400m,memory=2048Mi" \
 --worker_resource_limit="cpu=1,memory=3072Mi" \
 --minibatch_size=64 \
---records_per_task=100 \
+--num_minibatches_per_task=10 \
 --num_workers=2 \
 --checkpoint_steps=10 \
 --evaluation_steps=15 \

--- a/pkg/sql/attribute.go
+++ b/pkg/sql/attribute.go
@@ -53,7 +53,9 @@ type engineSpec struct {
 	minibatchSize         int
 	masterPodPriority     string
 	clusterSpec           string
-	recordsPerTask        int
+	numMinibatchesPerTask int
+	dockerImageRepository string
+	envs                  string
 }
 
 func getEngineSpec(attrs map[string]*attribute) engineSpec {
@@ -106,7 +108,9 @@ func getEngineSpec(attrs map[string]*attribute) engineSpec {
 	minibatchSize := getInt("minibatch_size", 64)
 	masterPodPriority := getString("master_pod_priority", "")
 	clusterSpec := getString("cluster_spec", "")
-	recordsPerTask := getInt("records_per_task", 100)
+	numMinibatchesPerTask := getInt("num_minibatches_per_task", 10)
+	dockerImageRepository := getString("docker_image_repository", "")
+	envs := getString("envs", "")
 
 	return engineSpec{
 		etype:                 engineType,
@@ -126,7 +130,9 @@ func getEngineSpec(attrs map[string]*attribute) engineSpec {
 		minibatchSize:         minibatchSize,
 		masterPodPriority:     masterPodPriority,
 		clusterSpec:           clusterSpec,
-		recordsPerTask:        recordsPerTask,
+		numMinibatchesPerTask: numMinibatchesPerTask,
+		dockerImageRepository: dockerImageRepository,
+		envs:                  envs,
 	}
 }
 

--- a/pkg/sql/codegen_elasticdl.go
+++ b/pkg/sql/codegen_elasticdl.go
@@ -238,8 +238,7 @@ func elasticdlTrainCmd(cwd, modelDefFilePath string, filler *elasticDLFiller) (c
 			"--minibatch_size", string(filler.TrainClause.EngineParams.minibatchSize),
 			"--master_pod_priority", filler.TrainClause.EngineParams.masterPodPriority,
 			"--cluster_spec", filler.TrainClause.EngineParams.clusterSpec,
-			// TODO: Update to use `num_minibatches_per_task` instead
-			"--records_per_task", string(filler.TrainClause.EngineParams.recordsPerTask),
+			"--num_minibatches_per_task", string(filler.TrainClause.EngineParams.numMinibatchesPerTask),
 			"--log_level", "INFO",
 			"--output", filler.ModelDir,
 			"--checkpoint_steps", string(filler.TrainClause.CheckpointSteps),
@@ -248,7 +247,8 @@ func elasticdlTrainCmd(cwd, modelDefFilePath string, filler *elasticDLFiller) (c
 			"--tensorboard_log_dir", filler.TrainClause.TensorboardLogDir,
 			"--checkpoint_dir", filler.TrainClause.CheckpointDir,
 			"--keep_checkpoint_max", string(filler.TrainClause.KeepCheckpointMax),
-			// TODO: Append ODPS related environment variables to "--envs"
+			"--docker_image_repository", string(filler.TrainClause.EngineParams.dockerImageRepository),
+			"--envs", string(filler.TrainClause.EngineParams.envs),
 			"--data_reader_params", `'columns=`+string(filler.FeaturesList+`'`),
 		)
 		cmd.Dir = cwd
@@ -314,9 +314,10 @@ func elasticdlPredictCmd(cwd, modelDefFilePath string, filler *elasticDLFiller) 
 			"--minibatch_size", string(filler.PredictClause.EngineParams.minibatchSize),
 			"--master_pod_priority", filler.PredictClause.EngineParams.masterPodPriority,
 			"--cluster_spec", filler.PredictClause.EngineParams.clusterSpec,
-			"--records_per_task", string(filler.PredictClause.EngineParams.recordsPerTask),
+			"--num_minibatches_per_task", string(filler.PredictClause.EngineParams.numMinibatchesPerTask),
 			"--log_level", "INFO",
-			// TODO: Append ODPS related environment variables to "--envs"
+			"--docker_image_repository", string(filler.TrainClause.EngineParams.dockerImageRepository),
+			"--envs", string(filler.TrainClause.EngineParams.envs),
 			"--data_reader_params", `'columns=`+string(filler.FeaturesList+`'`),
 		)
 		cmd.Dir = cwd

--- a/pkg/sql/codegen_elasticdl_test.go
+++ b/pkg/sql/codegen_elasticdl_test.go
@@ -59,7 +59,9 @@ func TestTrainElasticDLFiller(t *testing.T) {
 			engine.minibatch_size = 64,
 			engine.master_pod_priority = "",
 			engine.cluster_spec = "",
-			engine.records_per_task = 100
+			engine.num_minibatches_per_task = 10,
+			engine.docker_image_repository = "",
+			engine.envs = ""
 		COLUMN
 			sepal_length, sepal_width, petal_length, petal_width
 		LABEL class

--- a/python/test_magic_elasticdl.py
+++ b/python/test_magic_elasticdl.py
@@ -48,7 +48,9 @@ class TestSQLFlowMagic(unittest.TestCase):
 			engine.namespace = "default",
 			engine.master_pod_priority = "",
 			engine.cluster_spec = "",
-			engine.records_per_task = 100
+			engine.num_minibatches_per_task = 10,
+			engine.docker_image_repository = "",
+			engine.envs = ""
 		COLUMN
 			sepal_length, sepal_width, petal_length, petal_width
 		LABEL class


### PR DESCRIPTION
* Renamed `records_per_task` to `num_minibatches_per_task`.
* Added `docker_image_repository` and `envs`.