### PR TITLE
[ElasticDL] Update codegen to support latestest version of ElasticDL

### DIFF
--- a/pkg/sql/codegen_elasticdl.go
+++ b/pkg/sql/codegen_elasticdl.go
@@ -145,16 +145,15 @@ func newElasticDLTrainFiller(pr *extendedSelect, db *DB, session *pb.Session, ds
 		trainInput, evalInput = pr.tables[0], pr.tables[0]
 	}
 	return &elasticDLFiller{
-		IsTraining:          true,
-		TrainInputTable:     trainInput,
-		EvalInputTable:      evalInput,
-		FeaturesDescription: genFeaturesDescription(featureNames),
-		FeaturesList:        makePythonListCode(append(featureNames, pr.label)),
-		LabelColName:        pr.label,
-		TrainClause:         resolved,
-		ModelDir:            pr.trainClause.save,
-		InputShape:          len(featureNames),
-		OutputShape:         getElasticDLModelSpec(resolved.ModelConstructorParams).NumClasses,
+		IsTraining:      true,
+		TrainInputTable: trainInput,
+		EvalInputTable:  evalInput,
+		FeaturesList:    makePythonListCode(append(featureNames, pr.label)),
+		LabelColName:    pr.label,
+		TrainClause:     resolved,
+		ModelDir:        pr.trainClause.save,
+		InputShape:      len(featureNames),
+		OutputShape:     getElasticDLModelSpec(resolved.ModelConstructorParams).NumClasses,
 	}, err
 }
 
@@ -169,15 +168,14 @@ func newElasticDLPredictFiller(pr *extendedSelect, db *DB) (*elasticDLFiller, er
 		return nil, err
 	}
 	return &elasticDLFiller{
-		IsTraining:          false,
-		PredictInputTable:   pr.tables[0],
-		PredictOutputTable:  resolved.OutputTable,
-		PredictInputModel:   resolved.ModelName,
-		OutputShape:         getElasticDLModelSpec(resolved.ModelConstructorParams).NumClasses,
-		FeaturesDescription: genFeaturesDescription(featureNames),
-		FeaturesList:        makePythonListCode(append(featureNames, pr.label)),
-		InputShape:          len(featureNames),
-		PredictClause:       resolved,
+		IsTraining:         false,
+		PredictInputTable:  pr.tables[0],
+		PredictOutputTable: resolved.OutputTable,
+		PredictInputModel:  resolved.ModelName,
+		OutputShape:        getElasticDLModelSpec(resolved.ModelConstructorParams).NumClasses,
+		FeaturesList:       makePythonListCode(append(featureNames, pr.label)),
+		InputShape:         len(featureNames),
+		PredictClause:      resolved,
 	}, err
 }
 

--- a/pkg/sql/codegen_elasticdl_test.go
+++ b/pkg/sql/codegen_elasticdl_test.go
@@ -84,10 +84,8 @@ func TestTrainElasticDLFiller(t *testing.T) {
 	code := program.String()
 	a.True(strings.Contains(code, `if mode != Mode.PREDICTION and "true" == "true":`), code)
 	a.True(strings.Contains(code, `dataset = dataset.shuffle(buffer_size=120)`), code)
-	a.True(strings.Contains(code, `"class": tf.io.FixedLenFeature([1], tf.int64),`), code)
-	a.True(strings.Contains(code, `"petal_length": tf.io.FixedLenFeature([1], tf.float32), "petal_width": tf.io.FixedLenFeature([1], tf.float32), "sepal_length": tf.io.FixedLenFeature([1], tf.float32), "sepal_width": tf.io.FixedLenFeature([1], tf.float32),`), code)
-	a.True(strings.Contains(code, `labels = tf.cast(parsed_example["class"], tf.int64)`), code)
-	a.True(strings.Contains(code, `return parsed_example, labels`), code)
+	a.True(strings.Contains(code, `label_col_name = "class"`), code)
+	a.True(strings.Contains(code, `features_shape = (4, 1)`), code)
 	a.True(strings.Contains(code, `inputs = tf.keras.layers.Input(shape=(4, 1), name="input")`), code)
 	a.True(strings.Contains(code, `outputs = tf.keras.layers.Dense(10, name="output")(inputs)`), code)
 }
@@ -121,7 +119,7 @@ func TestPredElasticDLFiller(t *testing.T) {
 	a.True(strings.Contains(code, `columns=["pred_" + str(i) for i in range(10)]`), code)
 	a.True(strings.Contains(code, `column_types=["double" for _ in range(10)]`), code)
 	a.True(strings.Contains(code, `table="prediction_results_table"`), code)
-	a.True(strings.Contains(code, `"petal_length": tf.io.FixedLenFeature([1], tf.float32), "petal_width": tf.io.FixedLenFeature([1], tf.float32), "sepal_length": tf.io.FixedLenFeature([1], tf.float32), "sepal_width": tf.io.FixedLenFeature([1], tf.float32),`), code)
+	a.True(strings.Contains(code, `tf.reshape(record, features_shape)`), code)
 	a.True(strings.Contains(code, `inputs = tf.keras.layers.Input(shape=(4, 1), name="input")`), code)
 }
 


### PR DESCRIPTION
Changes include:
* Updated the ElasticDL codegen so the associated `dataset_fn` supports reading from ODPS data source directly.
* Updated other components in the template to use dummy versions for now. We will need to update codegen to support loading real model spec from model zoo later on.
