### PR TITLE
[ElasticDL] Expose job_name and image_base in engine spec to users

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -839,7 +839,7 @@ WITH
 			engine.docker_image_repository = "",
 			engine.envs = "",
 			engine.job_name = "test-odps",
-			engine.image_base = "elasticdl:ci",
+			engine.image_base = "elasticdl:ci"
 COLUMN
 			sepal_length, sepal_width, petal_length, petal_width
 LABEL class

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -837,7 +837,9 @@ WITH
 			engine.cluster_spec = "",
 			engine.num_minibatches_per_task = 2,
 			engine.docker_image_repository = "",
-			engine.envs = ""
+			engine.envs = "",
+			engine.job_name = "test-odps",
+			engine.image_base = "elasticdl:ci",
 COLUMN
 			sepal_length, sepal_width, petal_length, petal_width
 LABEL class

--- a/pkg/sql/attribute.go
+++ b/pkg/sql/attribute.go
@@ -56,6 +56,8 @@ type engineSpec struct {
 	numMinibatchesPerTask int
 	dockerImageRepository string
 	envs                  string
+	jobName               string
+	imageBase             string
 }
 
 func getEngineSpec(attrs map[string]*attribute) engineSpec {
@@ -111,6 +113,8 @@ func getEngineSpec(attrs map[string]*attribute) engineSpec {
 	numMinibatchesPerTask := getInt("num_minibatches_per_task", 10)
 	dockerImageRepository := getString("docker_image_repository", "")
 	envs := getString("envs", "")
+	jobName := getString("job_name", "")
+	imageBase := getString("image_base", "")
 
 	return engineSpec{
 		etype:                 engineType,
@@ -133,6 +137,8 @@ func getEngineSpec(attrs map[string]*attribute) engineSpec {
 		numMinibatchesPerTask: numMinibatchesPerTask,
 		dockerImageRepository: dockerImageRepository,
 		envs:                  envs,
+		jobName:               jobName,
+		imageBase:             imageBase,
 	}
 }
 

--- a/pkg/sql/codegen_elasticdl.go
+++ b/pkg/sql/codegen_elasticdl.go
@@ -232,10 +232,8 @@ func elasticdlTrainCmd(cwd string, filler *elasticDLFiller) (cmd *exec.Cmd) {
 	if hasDocker() {
 		cmd = exec.Command(
 			"elasticdl", "train",
-			"--image_base", "elasticdl:ci",
-			// TODO: This is hard-coded for now for testing purposes.
-			// We need to allow users to configure this or generating this dynamically.
-			"--job_name", "test-odps",
+			"--image_base", filler.TrainClause.EngineParams.imageBase,
+			"--job_name", filler.TrainClause.EngineParams.jobName,
 			"--model_zoo", modelZooPath,
 			"--model_def", modelDefModule,
 			"--training_data", filler.TrainInputTable,
@@ -309,10 +307,8 @@ func elasticdlPredictCmd(cwd string, filler *elasticDLFiller) (cmd *exec.Cmd) {
 	if hasDocker() && hasElasticDLCmd() {
 		cmd = exec.Command(
 			"elasticdl", "predict",
-			"--image_base", "elasticdl:ci",
-			// TODO: This is hard-coded for now for testing purposes.
-			// We need to allow users to configure this or generating this dynamically.
-			"--job_name", "test-odps",
+			"--image_base", filler.PredictClause.EngineParams.imageBase,
+			"--job_name", filler.PredictClause.EngineParams.jobName,
 			"--model_zoo", modelZooPath,
 			"--model_def", modelDefModule,
 			"--prediction_data", filler.PredictInputTable,


### PR DESCRIPTION
These two arguments were hard-coded earlier for testing purposes only.
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>