### PR TITLE
Support type bool in attributes

### DIFF
--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -176,8 +176,8 @@ func inferStringValue(expr string) interface{} {
 		return float32(retFloat)
 	}
 
-	// boolean. We pick the candidates from implementation of
-	// `strconv.ParseBool(expr)` which follow the SQL usage.
+	// boolean. We pick the candidates which following the SQL usage from
+	// implementation of `strconv.ParseBool(expr)`.
 	switch expr {
 	case "true", "TRUE", "True":
 		return true

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -175,12 +175,18 @@ func inferStringValue(expr string) interface{} {
 		// Note(typhoonzero): always use float32 for attributes, we may never use a float64.
 		return float32(retFloat)
 	}
-	if ret, err := strconv.ParseBool(expr); err == nil {
-		return ret
+
+	// boolean. We pick the candidates from implementation of
+	// `strconv.ParseBool(expr)` which follow the SQL usage.
+	switch expr {
+	case "true", "TRUE", "True":
+		return true
+	case "false", "FALSE", "False":
+		return false
 	}
+
 	retString := strings.Trim(expr, "\"")
-	retString = strings.Trim(retString, "'")
-	return retString
+	return strings.Trim(retString, "'")
 }
 
 func parseFeatureColumn(el *exprlist) (codegen.FeatureColumn, error) {

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -175,6 +175,9 @@ func inferStringValue(expr string) interface{} {
 		// Note(typhoonzero): always use float32 for attributes, we may never use a float64.
 		return float32(retFloat)
 	}
+	if ret, err := strconv.ParseBool(expr); err == nil {
+		return ret
+	}
 	retString := strings.Trim(expr, "\"")
 	retString = strings.Trim(retString, "'")
 	return retString

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -196,16 +196,18 @@ INTO sqlflow_models.mymodel;`, testDB, modelDir, nil)
 
 func TestInferStringValue(t *testing.T) {
 	a := assert.New(t)
-	for _, t := range []string{"t", "T", "true", "TRUE", "True"} {
+	for _, t := range []string{"true", "TRUE", "True"} {
 		a.Equal(inferStringValue(t), true)
 		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", t)), t)
 		a.Equal(inferStringValue(fmt.Sprintf("'%s'", t)), t)
 	}
-	for _, t := range []string{"f", "F", "false", "FALSE", "False"} {
+	for _, t := range []string{"false", "FALSE", "False"} {
 		a.Equal(inferStringValue(t), false)
 		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", t)), t)
 		a.Equal(inferStringValue(fmt.Sprintf("'%s'", t)), t)
 	}
+	a.Equal(inferStringValue("t"), "t")
+	a.Equal(inferStringValue("F"), "F")
 	a.Equal(inferStringValue("1"), 1)
 	a.Equal(inferStringValue("\"1\""), "1")
 	a.Equal(inferStringValue("'1'"), "1")

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -196,15 +196,15 @@ INTO sqlflow_models.mymodel;`, testDB, modelDir, nil)
 
 func TestInferStringValue(t *testing.T) {
 	a := assert.New(t)
-	for _, t := range []string{"true", "TRUE", "True"} {
-		a.Equal(inferStringValue(t), true)
-		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", t)), t)
-		a.Equal(inferStringValue(fmt.Sprintf("'%s'", t)), t)
+	for _, s := range []string{"true", "TRUE", "True"} {
+		a.Equal(inferStringValue(s), true)
+		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", s)), s)
+		a.Equal(inferStringValue(fmt.Sprintf("'%s'", s)), s)
 	}
-	for _, t := range []string{"false", "FALSE", "False"} {
-		a.Equal(inferStringValue(t), false)
-		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", t)), t)
-		a.Equal(inferStringValue(fmt.Sprintf("'%s'", t)), t)
+	for _, s := range []string{"false", "FALSE", "False"} {
+		a.Equal(inferStringValue(s), false)
+		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", s)), s)
+		a.Equal(inferStringValue(fmt.Sprintf("'%s'", s)), s)
 	}
 	a.Equal(inferStringValue("t"), "t")
 	a.Equal(inferStringValue("F"), "F")

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -193,3 +193,23 @@ INTO sqlflow_models.mymodel;`, testDB, modelDir, nil)
 	a.True(ok)
 	a.Equal("sepal_length", nc.FieldMeta.Name)
 }
+
+func TestInferStringValue(t *testing.T) {
+	a := assert.New(t)
+	for _, t := range []string{"t", "T", "true", "TRUE", "True"} {
+		a.Equal(inferStringValue(t), true)
+		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", t)), t)
+		a.Equal(inferStringValue(fmt.Sprintf("'%s'", t)), t)
+	}
+	for _, t := range []string{"f", "F", "false", "FALSE", "False"} {
+		a.Equal(inferStringValue(t), false)
+		a.Equal(inferStringValue(fmt.Sprintf("\"%s\"", t)), t)
+		a.Equal(inferStringValue(fmt.Sprintf("'%s'", t)), t)
+	}
+	a.Equal(inferStringValue("1"), 1)
+	a.Equal(inferStringValue("\"1\""), "1")
+	a.Equal(inferStringValue("'1'"), "1")
+	a.Equal(inferStringValue("2.3"), float32(2.3))
+	a.Equal(inferStringValue("\"2.3\""), "2.3")
+	a.Equal(inferStringValue("'2.3'"), "2.3")
+}


### PR DESCRIPTION
fix #1025, Supports SQL likes
```SQL
SELECT *                                                                                                                                                                                                                                                              
FROM iris.train                                                                                                                                                                                                                                                       
ANALYZE sqlflow_models.my_xgboost_model                                                                                                                                                                                                                               
WITH                                                                                                                                                                                                                                                                  
    shap_summary.plot_type="bar",                                                                                                                                                                                                                                     
    shap_summary.alpha=1,                                                                                                                                                                                                                                             
    shap_summary.sort=True  -- boolean                                                                                                                                                                                                                                     
USING TreeExplainer;      
```