### PR TITLE
Fix broken link

### DIFF
--- a/doc/quick_start.md
+++ b/doc/quick_start.md
@@ -10,8 +10,8 @@ It's quite simple to try out SQLFlow using [Docker](https://docs.docker.com/).
 
 For advanced usage, you might want to go on reading
 
-- [Language Guide](/doc/language_guide.md)
-- [Run Locally with Docker](/doc/run/docker.md)
-- [Run on Google Cloud](/doc/run/gcp.md)
-- [Run on Kubernetes](/doc/run/kubernetes.md)
-- [Run in REPL Mode](/doc/run/repl.md)
+- [Language Guide](language_guide.md)
+- [Run Locally with Docker](run/docker.md)
+- [Run on Google Cloud](run/gcp.md)
+- [Run on Kubernetes](run/kubernetes.md)
+- [Run in REPL Mode](run/repl.md)

--- a/doc/run/repl.md
+++ b/doc/run/repl.md
@@ -75,3 +75,12 @@ SELECT * from iris.predict limit 3;
 ```
 
 Congratulations! Now you have successfully completed a session using SQLFlow syntax to train model using DNNClassifier and make a quick prediction.
+
+## REPL Command Line Options
+
+|             Option                      | Description |
+|-----------------------------------------|-------------|
+| -e \<quoted-query-string\>              | Execute from command line without entering interactive mode. e.g. <br>`-e "SELECT * FROM iris.train TRAIN DNNClassifier..." `<br>does the same thing as the training example above.|
+| -f \<filename\>                         | Execute from file without entering interactive mode. e.g. <br>`-f ./my_sqlflow.sql`<br>does the same thing as<br>`< ./my_sqlflow.sql` and `cat ./my_sqlflow.sql \| REPL...` |
+| -model_dir \<local-directory\>          | Save model to a local directory. e.g. `-model_dir "./models/"` |
+| -datasource \<database-connection-url\> | Connect to the specified database. e.g. `-datasource "mysql://root:root@tcp(host.docker.internal:3306)/" ` |


### PR DESCRIPTION
Fix #1053 partly.
Each link on the bottom of https://sqlflow.org/sqlflow/doc/quick_start/ points to the original .md files, which leads a 404 error.
This commit changes absolute links to relative ones, and the next commit will modify sql-machine-learning.github.io to convert relative links to Markdown files to their rendered equivalents.