### PR TITLE
fix hadoop version in docker build script

### DIFF
--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -118,7 +118,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 <property><name>hadoop.proxyuser.root.hosts</name><value></value></property>
 <property><name>hadoop.http.staticuser.user</name><value>root</value></property>
 </configuration>
-' > /opt/hadoop-3.2.1/etc/hadoop/core-site.xml
+' > /opt/hadoop-${HADOOP_VERSION}/etc/hadoop/core-site.xml
 
 # 9. Install additional dependencies for ElasticDL, ElasticDL CLI, and build testing images
 apt-get update && apt-get install -y docker.io sudo


### PR DESCRIPTION
A following fix for https://github.com/sql-machine-learning/sqlflow/pull/1073