### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ script:
   - docker pull --help
   - docker pull sqlflow/gohive:dev && docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
   - docker pull sqlflow/sqlflow:latest && docker build --cache-from sqlflow/sqlflow:latest -t sqlflow:latest -f Dockerfile .
-  - docker run --rm -v $GOPATH/src:/go/src -w /go/src/sqlflow.org/sqlflow sqlflow:latest pre-commit run -a
   - docker run --rm -v $GOPATH:/go -w /go/src/sqlflow.org/sqlflow sqlflow:latest bash scripts/test_units.sh
+  - docker run --rm -v $GOPATH/src:/go/src -w /go/src/sqlflow.org/sqlflow sqlflow:latest pre-commit run -a
   - docker run --rm -v $GOPATH:/go --net=container:hive --entrypoint bash -w /go/src/sqlflow.org/sqlflow sqlflow:latest scripts/test_hive.sh
   - bash scripts/setup_k8s_env.sh
   - docker run --rm --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v /home/$USER/.minikube/:/home/$USER/.minikube/ -v $GOPATH:/go -w /go/src/sqlflow.org/sqlflow sqlflow:latest bash scripts/test_ipython.sh

--- a/cmd/sqlflowserver/main.go
+++ b/cmd/sqlflowserver/main.go
@@ -65,7 +65,7 @@ func start(datasource, modelDir, caCrt, caKey string, enableSession bool, port i
 	} else {
 		db, err := sql.NewDB(datasource)
 		if err != nil {
-			log.Fatalf("create DB failed: %v", err)
+			log.Fatalf("create DB failed: %v ", err)
 		}
 		defer db.Close()
 		proto.RegisterSQLFlowServer(s, server.NewServer(sql.Run, db, modelDir, enableSession))

--- a/cmd/sqlflowserver/main.go
+++ b/cmd/sqlflowserver/main.go
@@ -65,7 +65,7 @@ func start(datasource, modelDir, caCrt, caKey string, enableSession bool, port i
 	} else {
 		db, err := sql.NewDB(datasource)
 		if err != nil {
-			log.Fatalf("create DB failed: %v ", err)
+			log.Fatalf("create DB failed: %v", err)
 		}
 		defer db.Close()
 		proto.RegisterSQLFlowServer(s, server.NewServer(sql.Run, db, modelDir, enableSession))


### PR DESCRIPTION
Cause:

1. Pre-commit hook depends on `go run docgen`
1. `go run docgen` depends on `go generate` of `/go/src/sqlflow.org/sqlflow/pkg/server/proto`.
1. Pre-commit hook test was run **before** go generate.

Solution:

Run pre-commit hook test **after** go generate.