### PR TITLE
Replace all <img> tags to github markdown links

### DIFF
--- a/doc/design/design_high-available_sqlflow_server.md
+++ b/doc/design/design_high-available_sqlflow_server.md
@@ -22,7 +22,7 @@ We recommend using `KubernetesJobRunner` in the production environment.
 
 The high-availabe SQLFlow job workflow is as follows:
 
-<img src="figures/cluster_job_runner.png">
+![](figures/cluster_job_runner.png)
 
 1. SQLFlow client sends the SQL statement via a gRPC call to the SQLFlow server.
 1. For the `LocalJobRunner`:

--- a/doc/design/design_training_and_validation.md
+++ b/doc/design/design_training_and_validation.md
@@ -5,7 +5,7 @@ A common ML training job usually involves two kinds of data sets: training data 
 ## Overall
 SQLFlow generates a temporary table following the user-specific table, trains and evaluates a model.
 
-<img src="../figures/training_and_validation.png" width="60%">
+![](../figures/training_and_validation.png)
 
 Notice, we talk about the **train** process in this post.
 

--- a/doc/tutorial/aspara2019/carprice_xgboost/README.md
+++ b/doc/tutorial/aspara2019/carprice_xgboost/README.md
@@ -165,7 +165,7 @@ WITH
 USING TreeExplainer;
 ```
 
-<img src="./imgs/shap0.png">
+![](./imgs/shap0.png)
 
 The plot above sorts features by the sum of SHAP value magnitudes over all samples, and use SHAP values to show the distribution of the impacts each feature has on the model output. The color represents the feature values(red high, blue low). For example, a low engine_hp lowers the predicted car price.
 
@@ -184,4 +184,4 @@ WITH
 USING TreeExplainer;
 ```
 
-<img src="./imgs/shap1.png">
+![](./imgs/shap1.png)


### PR DESCRIPTION
This pull request is to make sure markdown files involved show images properly in sqlflow.org. See #1071 .
A disadvantage is that the GitHub Flavored Markdown cannot control image width as an \<img\> tag. 