### PR TITLE
Replace <img> tag with the equivalent GFM tag.

### DIFF
--- a/doc/design/design_clustermodel.md
+++ b/doc/design/design_clustermodel.md
@@ -9,7 +9,7 @@ This design document introduced how to support the `Cluster Model` in SQLFlow.
 
 The figure below demonstrates the overall workflow for cluster model training, which include both the pre_train autoencoder model and the clustering model.(Reference https://www.dlology.com/blog/how-to-do-unsupervised-clustering-with-keras/)
 
-<div align=center> <img width="460" height="550" src="../figures/cluster_model_train_overview.png"> </div>
+![](../figures/cluster_model_train_overview.png)
 
 1. The first part is used to load a pre_trained model. We use the output of the trained encoder layer as the input to the clustering model. 
 2. Then, the clustering model starts training with randomly initialized weights, and generate clusters after multiple iterations.


### PR DESCRIPTION
Continue fixing #1071 This .md file is missed in the last commit #1084 .
The image seems somewhat larger after this change, [see it in my fork](https://github.com/shendiaomo/sqlflow/blob/fix_img_tags/doc/design/design_clustermodel.md)
Maybe we can consider replacing it with another image later, which is smaller and without grid lines :-) @typhoonzero 