### PR TITLE
[Don't Merge] Experiment Calcite & HiveQL parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *~
 *.test
-test
 /Gopkg.lock
 /Gopkg.toml
 /vendor/

--- a/parser/java/parser/.gitignore
+++ b/parser/java/parser/.gitignore
@@ -1,0 +1,2 @@
+.idea
+target

--- a/parser/java/parser/Dockerfile
+++ b/parser/java/parser/Dockerfile
@@ -1,0 +1,10 @@
+# Note: I used the official maven Docker image to build this package.
+# However, Maven complains it cannot find tools.jar. I verified that
+# I'd have to yum install java-8-openjdk in that Docker image to make
+# Maven works.  However, I'd follow this alternative to create a
+# Docker image from Ubuntu instead of Oracle Linux.
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y openjdk-8-jdk maven openjfx
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+

--- a/parser/java/parser/README.md
+++ b/parser/java/parser/README.md
@@ -1,0 +1,44 @@
+# Build and Test Third Party Parsers
+
+We build and test two third party parsers:
+
+- hiveql
+- calcite
+
+## Development Environment
+
+To make sure that all developers use the same version and configuration of development tools like JDK and Maven, we install all of them into a Docker image.
+
+To build the image, type the following command:
+
+```bash
+docker build -t sqlflow:mvn .
+```
+
+The suffix `:mvn` refers to Maven.  We use Maven to build and run the gRPC servers in Java.
+
+
+## Build the Parsers
+
+To start a Docker container that runs the above image, we can type the following command:
+
+```bash
+docker run --rm -it -v $HOME:/root -v $PWD:/work -w /work sqlflow:mvn bash
+```
+
+Please be aware the `-v $HOME:/root` binds the `$HOME` directory on the host to the `/root`, the home directory, in the container, so that when we run Maven in the container, it saves the downloaded jars into `$HOME/.m2`.
+
+In the container, we can type the following command to test the package
+
+```bash
+$ mvn test
+```
+
+In the container, we can type the following command to build the package into a `.jar` file.
+
+```bash
+$ mvn package
+```
+
+You can find the `.jar` file at `target/parser-1.0-SNAPSHOT.jar`.
+

--- a/parser/java/parser/pom.xml
+++ b/parser/java/parser/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sqlflow</groupId>
+    <artifactId>parser</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>1.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+
+        <!-- Disable annoying error message: Failed to load class "org.slf4j.impl.StaticLoggerBinder". -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/parser/java/parser/pom.xml
+++ b/parser/java/parser/pom.xml
@@ -20,6 +20,11 @@
             <version>1.19.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>

--- a/parser/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
+++ b/parser/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
@@ -1,0 +1,123 @@
+package org.sqlflow.parser;
+
+import java.util.ArrayList;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.log4j.Logger;
+
+public class CalciteParserAdaptor {
+
+  static final Logger logger = Logger.getLogger(CalciteParserAdaptor.class);
+
+  class ParseResult {
+    public ArrayList<String> Statements;
+    public int Position;
+    public String Error;
+  };
+
+  public CalciteParserAdaptor() {}
+
+  // ParseAndSplit calls Calcite parser to parse a SQL program and returns a ParseResult.
+  //
+  // It returns <statements, -1, ""> if Calcite parser accepts the SQL program.
+  //     input:  "select 1; select 1;"
+  //     output: {"select 1;", "select 1;"}, -1 , nil
+  // It returns <statements, idx, ""> if Calcite parser accepts part of the SQL program, indicated
+  // by idx.
+  //     input:  "select 1; select 1 to train; select 1"
+  //     output: {"select 1;", "select 1"}, 19, nil
+  // It returns <nil, -1, error> if an error is occurred.
+  public ParseResult ParseAndSplit(String sql) {
+    ParseResult parse_result = new ParseResult();
+    parse_result.Statements = new ArrayList<String>();
+    parse_result.Position = -1;
+    parse_result.Error = "";
+
+    int accumulated_position = 0;
+    while (true) {
+      try {
+        SqlParser parser = SqlParser.create(sql);
+        SqlNode sqlnode = parser.parseQuery();
+        logger.debug("1 ----------------");
+        logger.debug(sql);
+        parse_result.Statements.add(sql);
+        return parse_result;
+      } catch (SqlParseException e) {
+        int line = e.getPos().getLineNum();
+        int column = e.getPos().getColumnNum();
+        int pos = posToIndex(sql, line, column);
+
+        try {
+          SqlParser parser = SqlParser.create(sql.substring(0, pos));
+          SqlNode sqlnode = parser.parseQuery();
+
+          // parseQuery doesn't throw exception
+          parse_result.Statements.add(sql.substring(0, pos));
+
+          // multiple SQL statements
+          if (sql.charAt(pos) == ';') {
+            logger.debug("2.1 -----------------");
+            logger.debug(sql.substring(0, pos));
+
+            sql = sql.substring(pos + 1);
+            accumulated_position += pos + 1;
+
+            // FIXME(tony): trim is not enough to handle statements
+            // like "select 1; select 1; -- this is a comment"
+            if (sql.trim().equals("")) {
+              return parse_result;
+            }
+
+            continue;
+          }
+
+          // Make sure the left hand side is a select statement, so that
+          // we can try parse the right hand side with the SQLFlow parser
+          if (sqlnode.getKind() != SqlKind.SELECT) {
+            // return original error
+            parse_result.Statements = new ArrayList<String>();
+            parse_result.Position = -1;
+            parse_result.Error = e.getCause().getMessage();
+            return parse_result;
+          }
+
+          logger.debug("2.2 -----------------");
+          logger.debug(sql.substring(0, pos));
+          parse_result.Position = accumulated_position + pos;
+          return parse_result;
+        } catch (SqlParseException ee) {
+          logger.debug("3 -----------------");
+
+          // return original error
+          parse_result.Statements = new ArrayList<String>();
+          parse_result.Position = -1;
+          parse_result.Error = e.getCause().getMessage();
+
+          return parse_result;
+        }
+      }
+    }
+  }
+
+  // posToIndex converts line and column number into string index.
+  private static int posToIndex(String query, int line, int column) {
+    int l = 0, c = 0;
+
+    for (int i = 0; i < query.length(); i++) {
+      if (l == line - 1 && c == column - 1) {
+        return i;
+      }
+
+      if (query.charAt(i) == '\n') {
+        l++;
+        c = 0;
+      } else {
+        c++;
+      }
+    }
+
+    return query.length();
+  }
+}

--- a/parser/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
+++ b/parser/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
@@ -41,25 +41,26 @@ public class CalciteParserAdaptor {
       } catch (SqlParseException e) {
         int line = e.getPos().getLineNum();
         int column = e.getPos().getColumnNum();
-        int pos = posToIndex(sql, line, column);
+        int epos = posToIndex(sql, line, column);
 
         try {
-          SqlParser parser = SqlParser.create(sql.substring(0, pos));
+          SqlParser parser = SqlParser.create(sql.substring(0, epos));
           SqlNode sqlnode = parser.parseQuery();
 
           // parseQuery doesn't throw exception
-          parse_result.Statements.add(sql.substring(0, pos));
+          parse_result.Statements.add(sql.substring(0, epos));
 
           // multiple SQL statements
-          if (sql.charAt(pos) == ';') {
+          if (sql.charAt(epos) == ';') {
             logger.debug("2.1 -----------------");
-            logger.debug(sql.substring(0, pos));
+            logger.debug(sql.substring(0, epos));
 
-            sql = sql.substring(pos + 1);
-            accumulated_position += pos + 1;
+            sql = sql.substring(epos + 1);
+            accumulated_position += epos + 1;
 
             // FIXME(tony): trim is not enough to handle statements
             // like "select 1; select 1; -- this is a comment"
+            // So maybe we need some preprocessors to remove all the comments first.
             if (sql.trim().equals("")) {
               return parse_result;
             }
@@ -78,8 +79,8 @@ public class CalciteParserAdaptor {
           }
 
           logger.debug("2.2 -----------------");
-          logger.debug(sql.substring(0, pos));
-          parse_result.Position = accumulated_position + pos;
+          logger.debug(sql.substring(0, epos));
+          parse_result.Position = accumulated_position + epos;
           return parse_result;
         } catch (SqlParseException ee) {
           logger.debug("3 -----------------");

--- a/parser/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
+++ b/parser/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
@@ -11,12 +11,6 @@ public class CalciteParserAdaptor {
 
   static final Logger logger = Logger.getLogger(CalciteParserAdaptor.class);
 
-  class ParseResult {
-    public ArrayList<String> Statements;
-    public int Position;
-    public String Error;
-  };
-
   public CalciteParserAdaptor() {}
 
   // ParseAndSplit calls Calcite parser to parse a SQL program and returns a ParseResult.

--- a/parser/java/parser/src/main/java/org/sqlflow/parser/HiveQLParserAdaptor.java
+++ b/parser/java/parser/src/main/java/org/sqlflow/parser/HiveQLParserAdaptor.java
@@ -1,0 +1,130 @@
+package org.sqlflow.parser;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import org.antlr.runtime.RecognitionException;
+import org.apache.hadoop.hive.ql.Context;
+import org.apache.hadoop.hive.ql.parse.ParseDriver;
+import org.apache.hadoop.hive.ql.parse.ParseError;
+import org.apache.hadoop.hive.ql.parse.ParseException;
+
+public class HiveQLParserAdaptor {
+
+  public HiveQLParserAdaptor() {}
+
+  private ParseResult parseResultError(String error) {
+    ParseResult parse_result = new ParseResult();
+    parse_result.Statements = new ArrayList<String>();
+    parse_result.Position = -1;
+    parse_result.Error = error;
+
+    return parse_result;
+  }
+
+  // ParseAndSplit calls Calcite parser to parse a SQL program and returns a ParseResult.
+  //
+  // It returns <statements, -1, ""> if Calcite parser accepts the SQL program.
+  //     input:  "select 1; select 1;"
+  //     output: {"select 1;", "select 1;"}, -1 , nil
+  // It returns <statements, idx, ""> if Calcite parser accepts part of the SQL program, indicated
+  // by idx.
+  //     input:  "select 1; select 1 to train; select 1"
+  //     output: {"select 1;", "select 1"}, 19, nil
+  // It returns <nil, -1, error> if an error is occurred.
+  public ParseResult ParseAndSplit(String sql) {
+    ParseResult parse_result = new ParseResult();
+    parse_result.Statements = new ArrayList<String>();
+    parse_result.Position = -1;
+    parse_result.Error = "";
+
+    int accumulated_position = 0;
+    while (true) {
+      try {
+        ParseDriver pd = new ParseDriver();
+        pd.parse(sql); // Possibly throw ParseException
+
+        parse_result.Statements.add(sql);
+        return parse_result;
+      } catch (ParseException e) {
+        // Find error position
+        int epos = -1;
+        try {
+          Field errorsField = ParseException.class.getDeclaredField("errors");
+          errorsField.setAccessible(true);
+          ArrayList<ParseError> errors = (ArrayList<ParseError>) errorsField.get(e);
+          Field reField = ParseError.class.getDeclaredField("re");
+          reField.setAccessible(true);
+          RecognitionException re = (RecognitionException) reField.get(errors.get(0));
+
+          // Note(tony): Calcite parser raise error at the first letter of the error word,
+          // while HiveQL parser raise error on the position right before the error word.
+          // Consider select 1 to train, Calcite parser raise error at letter t of "to",
+          // while HiveQL parser raise error at the white space before "to". As a result,
+          // we put `+ 1` on the `epos`.
+          epos = posToIndex(sql, re.line, re.charPositionInLine) + 1;
+        } catch (Exception all) {
+          return parseResultError("Cannot parse the error message from HiveQL parser");
+        }
+
+        try {
+          ParseDriver pd = new ParseDriver();
+          String sub_sql = sql.substring(0, epos);
+
+          pd.parse(sub_sql); // Possibly throws ParseException
+
+          parse_result.Statements.add(sub_sql);
+
+          // multiple SQL statements
+          if (sql.charAt(epos) == ';') {
+            sql = sql.substring(epos + 1);
+            accumulated_position += epos + 1;
+
+            // FIXME(tony): trim is not enough to handle statements
+            // like "select 1; select 1; -- this is a comment".
+            // So maybe we need some preprocessors to remove all the comments first.
+            if (sql.trim().equals("")) {
+              return parse_result;
+            }
+
+            continue;
+          }
+
+          // Make sure the left hand side is a select statement, so that
+          // we can try parse the right hand side with the SQLFlow parser
+          try {
+            // If it is not a select statement, ParseException will be thrown
+            pd.parseSelect(sub_sql, (Context) null);
+          } catch (ParseException ee) {
+            // return original error
+            return parseResultError(e.getMessage());
+          }
+          parse_result.Position = accumulated_position + epos;
+          return parse_result;
+        } catch (ParseException ee) {
+          // return original error
+          return parseResultError(e.getMessage());
+        }
+      }
+    }
+  }
+
+  // posToIndex converts line and column number into string index.
+  private static int posToIndex(String query, int line, int column) {
+    int l = 0, c = 0;
+
+    for (int i = 0; i < query.length(); i++) {
+      if (l == line - 1 && c == column - 1) {
+        return i;
+      }
+
+      if (query.charAt(i) == '\n') {
+        l++;
+        c = 0;
+      } else {
+        c++;
+      }
+    }
+
+    return query.length();
+  }
+}

--- a/parser/java/parser/src/main/java/org/sqlflow/parser/ParseResult.java
+++ b/parser/java/parser/src/main/java/org/sqlflow/parser/ParseResult.java
@@ -1,0 +1,9 @@
+package org.sqlflow.parser;
+
+import java.util.ArrayList;
+
+public class ParseResult {
+  public ArrayList<String> Statements;
+  public int Position;
+  public String Error;
+}

--- a/parser/java/parser/src/test/java/org/sqlflow/parser/ParserTest.java
+++ b/parser/java/parser/src/test/java/org/sqlflow/parser/ParserTest.java
@@ -1,0 +1,111 @@
+package org.sqlflow.parser;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import org.apache.log4j.BasicConfigurator;
+import org.junit.Test;
+import org.sqlflow.parser.CalciteParserAdaptor.ParseResult;
+
+public class ParserTest {
+  @Test
+  public void testParseAndSplit() {
+    // FIXME(tony): Move logger configuration to unit test initializer
+    BasicConfigurator.configure();
+
+    ArrayList<String> standard_select = new ArrayList<String>();
+    standard_select.add("select 1");
+    standard_select.add("select * from my_table");
+    standard_select.add(
+        "SELECT\n"
+            + "customerNumber,  \n"
+            + "    customerName \n"
+            + "FROM \n"
+            + "    customers \n"
+            + "WHERE \n"
+            + "    EXISTS( SELECT  \n"
+            + "            orderNumber, SUM(priceEach * quantityOrdered) \n"
+            + "        FROM \n"
+            + "            orderdetails \n"
+            + "                INNER JOIN \n"
+            + "            orders USING (orderNumber) \n"
+            + "        WHERE \n"
+            + "            customerNumber = customers.customerNumber \n"
+            + "        GROUP BY orderNumber \n"
+            + "        HAVING SUM(priceEach * quantityOrdered) > 60000)");
+
+    // one standard SQL statement
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;", sql);
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(-1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(1, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+    }
+
+    // two standard SQL statements
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;%s;", sql, sql);
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(-1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(2, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+      assertEquals(sql, parse_result.Statements.get(1));
+    }
+
+    // two SQL statements, the first one is extendedSQL
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s to train;%s;", sql, sql);
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(sql.length() + 1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(1, parse_result.Statements.size());
+      assertEquals(sql + " ", parse_result.Statements.get(0));
+    }
+
+    // two SQL statements, the second one is extendedSQL
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;%s to train;", sql, sql);
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(sql.length() + 1 + sql.length() + 1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(2, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+      assertEquals(sql + " ", parse_result.Statements.get(1));
+    }
+
+    { // two SQL statements, the first standard SQL has an error.
+      String sql_program = "select select 1; select 1 to train;";
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(0, parse_result.Statements.size());
+      assertEquals(-1, parse_result.Position);
+      assertTrue(parse_result.Error.startsWith("Encountered \"select\" at line 1, column 8."));
+    }
+
+    // two SQL statements, the second standard SQL has an error.
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;select select 1;", sql);
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(0, parse_result.Statements.size());
+      assertEquals(-1, parse_result.Position);
+      assertTrue(parse_result.Error.startsWith("Encountered \"select\" at line 1, column 8."));
+    }
+
+    { // non select statement before to train
+      String sql_program = "describe table to train;";
+      CalciteParserAdaptor parser = new CalciteParserAdaptor();
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(0, parse_result.Statements.size());
+      assertEquals(-1, parse_result.Position);
+      assertTrue(parse_result.Error.startsWith("Encountered \"to\" at line 1, column 16."));
+    }
+  }
+}

--- a/parser/java/parser/src/test/java/org/sqlflow/parser/ParserTest.java
+++ b/parser/java/parser/src/test/java/org/sqlflow/parser/ParserTest.java
@@ -3,15 +3,11 @@ package org.sqlflow.parser;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
-import org.apache.log4j.BasicConfigurator;
 import org.junit.Test;
 
 public class ParserTest {
   @Test
   public void testCalciteParseAndSplit() {
-    // FIXME(tony): Move logger configuration to unit test initializer
-    BasicConfigurator.configure();
-
     ArrayList<String> standard_select = new ArrayList<String>();
     standard_select.add("select 1");
     standard_select.add("select * from my_table");
@@ -98,6 +94,103 @@ public class ParserTest {
       assertEquals(0, parse_result.Statements.size());
       assertEquals(-1, parse_result.Position);
       assertTrue(parse_result.Error.startsWith("Encountered \"to\" at line 1, column 16."));
+    }
+  }
+
+  @Test
+  public void testHiveQLParseAndSplit() {
+    HiveQLParserAdaptor parser = new HiveQLParserAdaptor();
+    ArrayList<String> standard_select = new ArrayList<String>();
+    standard_select.add("select 1");
+    standard_select.add("select * from my_table");
+    standard_select.add("select * from\n" + "my_table");
+    standard_select.add(
+        "SELECT\n"
+            + "customerNumber,  \n"
+            + "    customerName \n"
+            + "FROM \n"
+            + "    customers \n"
+            + "WHERE \n"
+            + "    EXISTS( SELECT  \n"
+            + "            orderNumber, SUM(priceEach * quantityOrdered) \n"
+            + "        FROM \n"
+            + "            orderdetails \n"
+            + "                INNER JOIN \n"
+            + "            orders USING (orderNumber) \n"
+            + "        WHERE \n"
+            + "            customerNumber = customers.customerNumber \n"
+            + "        GROUP BY orderNumber \n"
+            + "        HAVING SUM(priceEach * quantityOrdered) > 60000)");
+
+    // one standard SQL statement
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;", sql);
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(-1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(1, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+    }
+
+    // two standard SQL statements
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;%s;", sql, sql);
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(-1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(2, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+      assertEquals(sql, parse_result.Statements.get(1));
+    }
+
+    // two SQL statements, the first one is extendedSQL
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s to train;%s;", sql, sql);
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(sql.length() + 1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(1, parse_result.Statements.size());
+      assertEquals(sql + " ", parse_result.Statements.get(0));
+    }
+
+    // two SQL statements, the second one is extendedSQL
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;%s to train;", sql, sql);
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(sql.length() + 1 + sql.length() + 1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(2, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+      assertEquals(sql + " ", parse_result.Statements.get(1));
+    }
+
+    { // two SQL statements, the first standard SQL has an error.
+      String sql_program = "select select 1; select 1 to train;";
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(0, parse_result.Statements.size());
+      assertEquals(-1, parse_result.Position);
+      assertTrue(
+          parse_result.Error.startsWith(
+              "line 1:7 cannot recognize input near 'select' '1' ';' in select clause"));
+    }
+
+    // two SQL statements, the second standard SQL has an error.
+    for (String sql : standard_select) {
+      String sql_program = String.format("%s;select select 1;", sql);
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(0, parse_result.Statements.size());
+      assertEquals(-1, parse_result.Position);
+      assertTrue(
+          parse_result.Error.startsWith(
+              "line 1:7 cannot recognize input near 'select' '1' ';' in select clause"));
+    }
+
+    { // non select statement before to train
+      String sql_program = "describe my_table to train;";
+      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      assertEquals(0, parse_result.Statements.size());
+      assertEquals(-1, parse_result.Position);
+      assertTrue(parse_result.Error.startsWith("line 1:18 missing EOF at 'to' near 'my_table"));
     }
   }
 }

--- a/parser/java/parser/src/test/java/org/sqlflow/parser/ParserTest.java
+++ b/parser/java/parser/src/test/java/org/sqlflow/parser/ParserTest.java
@@ -5,11 +5,10 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import org.apache.log4j.BasicConfigurator;
 import org.junit.Test;
-import org.sqlflow.parser.CalciteParserAdaptor.ParseResult;
 
 public class ParserTest {
   @Test
-  public void testParseAndSplit() {
+  public void testCalciteParseAndSplit() {
     // FIXME(tony): Move logger configuration to unit test initializer
     BasicConfigurator.configure();
 
@@ -37,8 +36,7 @@ public class ParserTest {
     // one standard SQL statement
     for (String sql : standard_select) {
       String sql_program = String.format("%s;", sql);
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(-1, parse_result.Position);
       assertEquals("", parse_result.Error);
       assertEquals(1, parse_result.Statements.size());
@@ -48,8 +46,7 @@ public class ParserTest {
     // two standard SQL statements
     for (String sql : standard_select) {
       String sql_program = String.format("%s;%s;", sql, sql);
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(-1, parse_result.Position);
       assertEquals("", parse_result.Error);
       assertEquals(2, parse_result.Statements.size());
@@ -60,8 +57,7 @@ public class ParserTest {
     // two SQL statements, the first one is extendedSQL
     for (String sql : standard_select) {
       String sql_program = String.format("%s to train;%s;", sql, sql);
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(sql.length() + 1, parse_result.Position);
       assertEquals("", parse_result.Error);
       assertEquals(1, parse_result.Statements.size());
@@ -71,8 +67,7 @@ public class ParserTest {
     // two SQL statements, the second one is extendedSQL
     for (String sql : standard_select) {
       String sql_program = String.format("%s;%s to train;", sql, sql);
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(sql.length() + 1 + sql.length() + 1, parse_result.Position);
       assertEquals("", parse_result.Error);
       assertEquals(2, parse_result.Statements.size());
@@ -82,8 +77,7 @@ public class ParserTest {
 
     { // two SQL statements, the first standard SQL has an error.
       String sql_program = "select select 1; select 1 to train;";
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(0, parse_result.Statements.size());
       assertEquals(-1, parse_result.Position);
       assertTrue(parse_result.Error.startsWith("Encountered \"select\" at line 1, column 8."));
@@ -92,8 +86,7 @@ public class ParserTest {
     // two SQL statements, the second standard SQL has an error.
     for (String sql : standard_select) {
       String sql_program = String.format("%s;select select 1;", sql);
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(0, parse_result.Statements.size());
       assertEquals(-1, parse_result.Position);
       assertTrue(parse_result.Error.startsWith("Encountered \"select\" at line 1, column 8."));
@@ -101,8 +94,7 @@ public class ParserTest {
 
     { // non select statement before to train
       String sql_program = "describe table to train;";
-      CalciteParserAdaptor parser = new CalciteParserAdaptor();
-      ParseResult parse_result = parser.ParseAndSplit(sql_program);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
       assertEquals(0, parse_result.Statements.size());
       assertEquals(-1, parse_result.Position);
       assertTrue(parse_result.Error.startsWith("Encountered \"to\" at line 1, column 16."));


### PR DESCRIPTION
Verify
1. `TO TRAIN` is enough to split an extended SQL statement to a standard clause and an extended clause.
1. The third-party parser is sufficient to split a SQL program to a list of SQL statements.

Progress:
- [x] Calcite
- [x] HiveQL

Related: https://github.com/sql-machine-learning/sqlflow/issues/1091