### PR TITLE
enhancement failed log message

### DIFF
--- a/pkg/sql/codegen/xgboost/template_train.go
+++ b/pkg/sql/codegen/xgboost/template_train.go
@@ -39,7 +39,6 @@ feature_column_name = sorted([k["name"] for k in feature_field_meta])
 label_name = label_field_meta["name"]
 
 feature_spec = {k['name']: k for k in feature_field_meta}
-
 conn = connect_with_data_source('''{{.DataSource}}''')
 
 def xgb_dataset(fn, dataset_sql):

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -568,10 +568,10 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 	defer cw.Close()
 	cmd := sqlflowCmd(cwd, db.driverName)
 	cmd.Env = append(os.Environ())
-	cmd.Stdin = &buf
+	cmd.Stdin = &program
 	cmd.Stdout = w
 	cmd.Stderr = w
-	if err := cmd.Run(); err != nil {
+	if e := cmd.Run(); e != nil {
 		log.Errorf("predict failed: %v, details: %s", e, buf.String())
 		return fmt.Errorf("predict failed: %v", e)
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -460,7 +460,7 @@ func train(wr *PipeWriter, tr *extendedSelect, db *DB, cwd string, modelDir stri
 
 	cw := &logChanWriter{wr: wr}
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("\n========== Program ======\n%s\n=======Error Message===========\n", program.String()))
+	buf.WriteString(fmt.Sprintf("\n==========Program======\n%s\n=======Program Output===========\n", program.String()))
 
 	w := io.MultiWriter(cw, &buf)
 	defer cw.Close()
@@ -469,8 +469,7 @@ func train(wr *PipeWriter, tr *extendedSelect, db *DB, cwd string, modelDir stri
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if e := cmd.Run(); e != nil {
-		log.Errorf("sqlflowcmd failed: %v, details: %s", e, buf.String())
-		return fmt.Errorf("training failed %v", e)
+		return fmt.Errorf("predict failed: %v\n %s", e, buf.String())
 	}
 	m := model{workDir: cwd, TrainSelect: slct}
 	if modelDir != "" {
@@ -561,7 +560,7 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("\n========== Program ======\n%s\n=======Error Message===========\n", program.String()))
+	buf.WriteString(fmt.Sprintf("\n==========Program======\n%s\n=======Program Output===========\n", program.String()))
 
 	cw := &logChanWriter{wr: wr}
 	w := io.MultiWriter(cw, &buf)
@@ -572,8 +571,7 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if e := cmd.Run(); e != nil {
-		log.Errorf("predict failed: %v, details: %s", e, buf.String())
-		return fmt.Errorf("predict failed: %v", e)
+		return fmt.Errorf("predict failed: %v\n %s", e, buf.String())
 	}
 	return nil
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -460,7 +460,7 @@ func train(wr *PipeWriter, tr *extendedSelect, db *DB, cwd string, modelDir stri
 
 	cw := &logChanWriter{wr: wr}
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("program: %s", program.String()))
+	buf.WriteString(fmt.Sprintf("\n========== Program ======\n%s\n=======Error Message===========\n", program.String()))
 
 	w := io.MultiWriter(cw, &buf)
 	defer cw.Close()
@@ -561,7 +561,7 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("program: %s", program.String()))
+	buf.WriteString(fmt.Sprintf("\n========== Program ======\n%s\n=======Error Message===========\n", program.String()))
 
 	cw := &logChanWriter{wr: wr}
 	w := io.MultiWriter(cw, &buf)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -458,12 +459,17 @@ func train(wr *PipeWriter, tr *extendedSelect, db *DB, cwd string, modelDir stri
 	}
 
 	cw := &logChanWriter{wr: wr}
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("program: %s", program.String()))
+
+	w := io.MultiWriter(cw, &buf)
 	defer cw.Close()
 	cmd := sqlflowCmd(cwd, db.driverName)
 	cmd.Stdin = &program
-	cmd.Stdout = cw
-	cmd.Stderr = cw
+	cmd.Stdout = w
+	cmd.Stderr = w
 	if e := cmd.Run(); e != nil {
+		log.Errorf("sqlflowcmd failed: %v, details: %s", e, buf.String())
 		return fmt.Errorf("training failed %v", e)
 	}
 	m := model{workDir: cwd, TrainSelect: slct}
@@ -511,7 +517,7 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 		return fmt.Errorf("loadModelMeta %v", e)
 	}
 
-	var buf bytes.Buffer
+	var program bytes.Buffer
 	if isXGBoostModel(pr.estimator) {
 		if enableIR() {
 			ir, err := generatePredictIR(pr, db.String(), cwd, modelDir)
@@ -526,9 +532,9 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 			if err != nil {
 				return err
 			}
-			buf.WriteString(code)
+			program.WriteString(code)
 		} else {
-			if e := genXGBoost(&buf, pr, nil, fts, db, session); e != nil {
+			if e := genXGBoost(&program, pr, nil, fts, db, session); e != nil {
 				return fmt.Errorf("genXGBoost %v", e)
 			}
 		}
@@ -546,22 +552,30 @@ func pred(wr *PipeWriter, pr *extendedSelect, db *DB, cwd string, modelDir strin
 			if err != nil {
 				return err
 			}
-			buf.WriteString(code)
+			program.WriteString(code)
 		} else {
-			if e := genTF(&buf, pr, nil, fts, db, session); e != nil {
+			if e := genTF(&program, pr, nil, fts, db, session); e != nil {
 				return fmt.Errorf("genTF %v", e)
 			}
 		}
 	}
 
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("program: %s", program.String()))
+
 	cw := &logChanWriter{wr: wr}
+	w := io.MultiWriter(cw, &buf)
 	defer cw.Close()
 	cmd := sqlflowCmd(cwd, db.driverName)
 	cmd.Env = append(os.Environ())
 	cmd.Stdin = &buf
-	cmd.Stdout = cw
-	cmd.Stderr = cw
-	return cmd.Run()
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		log.Errorf("predict failed: %v, details: %s", e, buf.String())
+		return fmt.Errorf("predict failed: %v", e)
+	}
+	return nil
 }
 
 func analyze(wr *PipeWriter, pr *extendedSelect, db *DB, cwd, modelDir string) error {


### PR DESCRIPTION
fixed #1101 

SQLFLow server would print the program and stack trace if the execution was failied:

``` text
=======Program===========

....

bst = xgb.train(params, dtrain, **train_args)
bst.save_model("sqlflow_models.my_xgb_regression_model")

=======Error Message===========
Traceback (most recent call last):
  File "<stdin>", line 172, in <module>
  File "<stdin>", line 165, in xgb_dataset
  File "/miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/sqlflow_submitter/db.py", line 188, in reader
    feature = read_feature(row[field_names.index(name)], feature_specs[name], name)
ValueError: 'chas1' is not in list  package=sql
```