### PR TITLE
Minor refactoring attribute checkers

### DIFF
--- a/doc/model_parameter.md
+++ b/doc/model_parameter.md
@@ -35,7 +35,7 @@ INTO sqlflow_models.my_xgb_regression_model;
 <tr>
 	<td>num_class</td>
 	<td>Int</td>
-	<td>Number of classes.<br>range: [1, Infinity]</td>
+	<td>Number of classes.<br>range: [2, Infinity]</td>
 </tr>
 <tr>
 	<td>objective</td>

--- a/pkg/sql/codegen/attribute/checker.go
+++ b/pkg/sql/codegen/attribute/checker.go
@@ -17,87 +17,90 @@ import (
 	"fmt"
 )
 
-func newFloat32(f float32) *float32 {
-	return &f
-}
+var equalSign = map[bool]string{true: "=", false: ""}
 
-// Float32RangeChecker is a helper function to generate range checkers on attribute.
+// Float32RangeChecker is a helper functions to generate range checkers on attributes.
 // lower/upper indicates the lower bound and upper bound of the attribute value.
-// If lower/upper is nil, it means no boundary.
 // includeLower/includeUpper indicates the inclusion of the bound.
-func Float32RangeChecker(lower, upper *float32, includeLower, includeUpper bool) func(interface{}) error {
-
-	checker := func(e interface{}) error {
-		f, ok := e.(float32)
-		if !ok {
-			return fmt.Errorf("expected type float32, received %T", e)
+func Float32RangeChecker(lower, upper float32, includeLower, includeUpper bool) func(interface{}) error {
+	return func(attr interface{}) error {
+		if f, ok := attr.(float32); ok {
+			e := Float32LowerBoundChecker(lower, includeLower)(f)
+			if e == nil {
+				e = Float32UpperBoundChecker(upper, includeUpper)(f)
+			}
+			return e
 		}
-
-		// NOTE(tony): nil means no boundary
-		if lower != nil {
-			if includeLower && !(*lower <= f) {
-				return fmt.Errorf("range check %v <= %v failed", *lower, f)
-			}
-			if !includeLower && !(*lower < f) {
-				return fmt.Errorf("range check %v < %v failed", *lower, f)
-			}
-		}
-
-		// NOTE(tony): nil means no boundary
-		if upper != nil {
-			if includeUpper && !(f <= *upper) {
-				return fmt.Errorf("range check %v <= %v failed", f, *upper)
-			}
-			if !includeUpper && !(f < *upper) {
-				return fmt.Errorf("range check %v < %v failed", f, *upper)
-			}
-		}
-
-		return nil
+		return fmt.Errorf("expected type float32, received %T", attr)
 	}
-
-	return checker
 }
 
-func newInt(i int) *int {
-	return &i
+// Float32LowerBoundChecker returns a range checker that only checks the lower bound
+func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}) error {
+	return func(attr interface{}) error {
+		if f, ok := attr.(float32); ok {
+			if f > lower || includeLower && f == lower {
+				return nil
+			}
+			return fmt.Errorf("range check %v <%v %v failed", lower, equalSign[includeLower], f)
+		}
+		return fmt.Errorf("expected type float32, received %T", attr)
+	}
 }
 
-// IntRangeChecker is a helper function to generate range checkers on attribute.
+// Float32UpperBoundChecker returns a range checker that only checks the upper bound
+func Float32UpperBoundChecker(upper float32, includeUpper bool) func(interface{}) error {
+	return func(attr interface{}) error {
+		if f, ok := attr.(float32); ok {
+			if f < upper || includeUpper && f == upper {
+				return nil
+			}
+			return fmt.Errorf("range check %v >%v %v failed", upper, equalSign[includeUpper], f)
+		}
+		return fmt.Errorf("expected type float32, received %T", attr)
+	}
+}
+
+// IntRangeChecker is a helper functions to generate range checkers on attributes.
 // lower/upper indicates the lower bound and upper bound of the attribute value.
-// If lower/upper is nil, it means no boundary.
 // includeLower/includeUpper indicates the inclusion of the bound.
-func IntRangeChecker(lower, upper *int, includeLower, includeUpper bool) func(interface{}) error {
-	checker := func(e interface{}) error {
-		i, ok := e.(int)
-		if !ok {
-			return fmt.Errorf("expected type float32, received %T", e)
+func IntRangeChecker(lower, upper int, includeLower, includeUpper bool) func(interface{}) error {
+	return func(attr interface{}) error {
+		if f, ok := attr.(int); ok {
+			e := IntLowerBoundChecker(lower, includeLower)(f)
+			if e == nil {
+				e = IntUpperBoundChecker(upper, includeUpper)(f)
+			}
+			return e
 		}
-
-		// NOTE(tony): nil means no boundary
-		if lower != nil {
-			if includeLower && !(*lower <= i) {
-				return fmt.Errorf("range check %v <= %v failed", *lower, i)
-			}
-			if !includeLower && !(*lower < i) {
-				return fmt.Errorf("range check %v < %v failed", *lower, i)
-			}
-		}
-
-		// NOTE(tony): nil means no boundary
-		if upper != nil {
-			if includeUpper && !(i <= *upper) {
-				return fmt.Errorf("range check %v <= %v failed", i, *upper)
-			}
-			if !includeUpper && !(i < *upper) {
-				return fmt.Errorf("range check %v < %v failed", i, *upper)
-			}
-		}
-
-		return nil
+		return fmt.Errorf("expected type int, received %T", attr)
 	}
+}
 
-	return checker
+// IntLowerBoundChecker returns a range checker that only checks the lower bound
+func IntLowerBoundChecker(lower int, includeLower bool) func(interface{}) error {
+	return func(attr interface{}) error {
+		if f, ok := attr.(int); ok {
+			if f > lower || includeLower && f == lower {
+				return nil
+			}
+			return fmt.Errorf("range check %v <%v %v failed", lower, equalSign[includeLower], f)
+		}
+		return fmt.Errorf("expected type int, received %T", attr)
+	}
+}
+
+// IntUpperBoundChecker returns a range checker that only checks the upper bound
+func IntUpperBoundChecker(upper int, includeUpper bool) func(interface{}) error {
+	return func(attr interface{}) error {
+		if f, ok := attr.(int); ok {
+			if f < upper || includeUpper && f == upper {
+				return nil
+			}
+			return fmt.Errorf("range check %v >%v %v failed", upper, equalSign[includeUpper], f)
+		}
+		return fmt.Errorf("expected type int, received %T", attr)
+	}
 }
 
 // EmptyChecker returns a checker function that do **not** check the input.

--- a/pkg/sql/codegen/attribute/checker.go
+++ b/pkg/sql/codegen/attribute/checker.go
@@ -39,7 +39,7 @@ func Float32RangeChecker(lower, upper float32, includeLower, includeUpper bool) 
 func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}) error {
 	return func(attr interface{}) error {
 		if f, ok := attr.(float32); ok {
-			if f > lower || includeLower && f == lower {
+			if (!includeLower && f > lower) || (includeLower && f >= lower) {
 				return nil
 			}
 			return fmt.Errorf("range check %v <%v %v failed", lower, equalSign[includeLower], f)
@@ -52,7 +52,7 @@ func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}
 func Float32UpperBoundChecker(upper float32, includeUpper bool) func(interface{}) error {
 	return func(attr interface{}) error {
 		if f, ok := attr.(float32); ok {
-			if f < upper || includeUpper && f == upper {
+			if (!includeUpper && f < upper) || (includeUpper && f <= upper) {
 				return nil
 			}
 			return fmt.Errorf("range check %v >%v %v failed", upper, equalSign[includeUpper], f)

--- a/pkg/sql/codegen/attribute/checker.go
+++ b/pkg/sql/codegen/attribute/checker.go
@@ -19,7 +19,7 @@ import (
 
 var equalSign = map[bool]string{true: "=", false: ""}
 
-// Float32RangeChecker is a helper functions to generate range checkers on attributes.
+// Float32RangeChecker is a helper function to generate range checkers on attributes.
 // lower/upper indicates the lower bound and upper bound of the attribute value.
 // includeLower/includeUpper indicates the inclusion of the bound.
 func Float32RangeChecker(lower, upper float32, includeLower, includeUpper bool) func(interface{}) error {
@@ -35,7 +35,7 @@ func Float32RangeChecker(lower, upper float32, includeLower, includeUpper bool) 
 	}
 }
 
-// Float32LowerBoundChecker returns a range checker that only checks the lower bound
+// Float32LowerBoundChecker returns a range checker that only checks the lower bound.
 func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}) error {
 	return func(attr interface{}) error {
 		if f, ok := attr.(float32); ok {
@@ -48,7 +48,7 @@ func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}
 	}
 }
 
-// Float32UpperBoundChecker returns a range checker that only checks the upper bound
+// Float32UpperBoundChecker returns a range checker that only checks the upper bound.
 func Float32UpperBoundChecker(upper float32, includeUpper bool) func(interface{}) error {
 	return func(attr interface{}) error {
 		if f, ok := attr.(float32); ok {
@@ -61,7 +61,7 @@ func Float32UpperBoundChecker(upper float32, includeUpper bool) func(interface{}
 	}
 }
 
-// IntRangeChecker is a helper functions to generate range checkers on attributes.
+// IntRangeChecker is a helper function to generate range checkers on attributes.
 // lower/upper indicates the lower bound and upper bound of the attribute value.
 // includeLower/includeUpper indicates the inclusion of the bound.
 func IntRangeChecker(lower, upper int, includeLower, includeUpper bool) func(interface{}) error {
@@ -77,7 +77,7 @@ func IntRangeChecker(lower, upper int, includeLower, includeUpper bool) func(int
 	}
 }
 
-// IntLowerBoundChecker returns a range checker that only checks the lower bound
+// IntLowerBoundChecker returns a range checker that only checks the lower bound.
 func IntLowerBoundChecker(lower int, includeLower bool) func(interface{}) error {
 	return func(attr interface{}) error {
 		if f, ok := attr.(int); ok {
@@ -90,7 +90,7 @@ func IntLowerBoundChecker(lower int, includeLower bool) func(interface{}) error 
 	}
 }
 
-// IntUpperBoundChecker returns a range checker that only checks the upper bound
+// IntUpperBoundChecker returns a range checker that only checks the upper bound.
 func IntUpperBoundChecker(upper int, includeUpper bool) func(interface{}) error {
 	return func(attr interface{}) error {
 		if f, ok := attr.(int); ok {

--- a/pkg/sql/codegen/attribute/checker_test.go
+++ b/pkg/sql/codegen/attribute/checker_test.go
@@ -21,14 +21,16 @@ import (
 func TestFloat32RangeChecker(t *testing.T) {
 	a := assert.New(t)
 
-	checker := Float32RangeChecker(newFloat32(0.0), newFloat32(1.0), true, true)
+	checker := Float32RangeChecker(0.0, 1.0, true, true)
+	a.Error(checker(1))
 	a.Error(checker(float32(-1)))
 	a.NoError(checker(float32(0)))
 	a.NoError(checker(float32(0.5)))
 	a.NoError(checker(float32(1)))
 	a.Error(checker(float32(2)))
 
-	checker2 := Float32RangeChecker(newFloat32(0.0), newFloat32(1.0), false, false)
+	checker2 := Float32RangeChecker(0.0, 1.0, false, false)
+	a.Error(checker(1))
 	a.Error(checker2(float32(-1)))
 	a.Error(checker2(float32(0)))
 	a.NoError(checker2(float32(0.5)))
@@ -39,14 +41,16 @@ func TestFloat32RangeChecker(t *testing.T) {
 func TestIntRangeChecker(t *testing.T) {
 	a := assert.New(t)
 
-	checker := IntRangeChecker(newInt(0), newInt(2), true, true)
+	checker := IntRangeChecker(0, 2, true, true)
+	a.Error(checker(1.0))
 	a.Error(checker(int(-1)))
 	a.NoError(checker(int(0)))
 	a.NoError(checker(int(1)))
 	a.NoError(checker(int(2)))
 	a.Error(checker(int(3)))
 
-	checker2 := IntRangeChecker(newInt(0), newInt(2), false, false)
+	checker2 := IntRangeChecker(0, 2, false, false)
+	a.Error(checker(1.0))
 	a.Error(checker2(int(-1)))
 	a.Error(checker2(int(0)))
 	a.NoError(checker2(int(1)))

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -24,21 +24,13 @@ import (
 	"sqlflow.org/sqlflow/pkg/sql/codegen/attribute"
 )
 
-func newFloat32(f float32) *float32 {
-	return &f
-}
-
-func newInt(i int) *int {
-	return &i
-}
-
 var attributeDictionary = attribute.Dictionary{
 	"train.batch_size": {attribute.Int, `[default=1]
 The training batch size.
-range: [0,Infinity]`, attribute.IntRangeChecker(newInt(0), nil, false, false)},
+range: [1,Infinity]`, attribute.IntLowerBoundChecker(1, true)},
 	"train.epoch": {attribute.Int, `[default=1]
 Number of epochs the training will run.
-range: [1, Infinity]`, attribute.IntRangeChecker(newInt(0), nil, false, false)},
+range: [1, Infinity]`, attribute.IntLowerBoundChecker(1, true)},
 	"model.*": {attribute.Unknown, `parameters defined by the model implementation, e.g. https://www.tensorflow.org/api_docs/python/tf/estimator/DNNClassifier#__init__, customized model example: https://github.com/sql-machine-learning/models/blob/develop/sqlflow_models/dnnclassifier.py#L4`,
 		attribute.EmptyChecker()},
 }

--- a/pkg/sql/codegen/xgboost/codegen.go
+++ b/pkg/sql/codegen/xgboost/codegen.go
@@ -24,27 +24,19 @@ import (
 	"sqlflow.org/sqlflow/pkg/sql/codegen/attribute"
 )
 
-func newFloat32(f float32) *float32 {
-	return &f
-}
-
-func newInt(i int) *int {
-	return &i
-}
-
 // TODO(tony): complete model parameter and training parameter list
 // model parameter list: https://xgboost.readthedocs.io/en/latest/parameter.html#general-parameters
 // training parameter list: https://github.com/dmlc/xgboost/blob/b61d53447203ca7a321d72f6bdd3f553a3aa06c4/python-package/xgboost/training.py#L115-L117
 var attributeDictionary = attribute.Dictionary{
 	"eta": {attribute.Float, `[default=0.3, alias: learning_rate]
 Step size shrinkage used in update to prevents overfitting. After each boosting step, we can directly get the weights of new features, and eta shrinks the feature weights to make the boosting process more conservative.
-range: [0,1]`, attribute.Float32RangeChecker(newFloat32(0), newFloat32(1), true, true)},
+range: [0,1]`, attribute.Float32RangeChecker(0, 1, true, true)},
 	"num_class": {attribute.Int, `Number of classes.
-range: [1, Infinity]`, attribute.IntRangeChecker(newInt(0), nil, false, false)},
+range: [2, Infinity]`, attribute.IntLowerBoundChecker(2, true)},
 	"objective": {attribute.String, `Learning objective`, nil},
 	"train.num_boost_round": {attribute.Int, `[default=10]
 The number of rounds for boosting.
-range: [1, Infinity]`, attribute.IntRangeChecker(newInt(0), nil, false, false)},
+range: [1, Infinity]`, attribute.IntLowerBoundChecker(1, true)},
 }
 
 func resolveModelType(estimator string) (string, error) {


### PR DESCRIPTION
1. Add lower/upper bound checkers for convenience
1. Remove all the newInt or newFloat utility functions
1. Modify boolean arithmetic to make code slightly clearer