### PR TITLE
Remove unused intermediate representation switch function

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -648,10 +648,6 @@ func isXGBoostModel(estimator string) bool {
 	return strings.HasPrefix(strings.ToUpper(estimator), `XGBOOST.`)
 }
 
-func enableIR() bool {
-	return os.Getenv("SQLFLOW_codegen") == "ir"
-}
-
 func parseTableColumn(s string) (string, string, error) {
 	pos := strings.LastIndex(s, ".")
 	if pos == -1 || pos == len(s)-1 {


### PR DESCRIPTION
The intermediate representation is enabled by default.