### PR TITLE
Move LogChanWriter

### DIFF
--- a/pkg/sql/executor_ir.go
+++ b/pkg/sql/executor_ir.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	pb "sqlflow.org/sqlflow/pkg/server/proto"
@@ -468,6 +469,48 @@ func loadModelMeta(pr *extendedSelect, db *DB, cwd, modelDir, modelName string) 
 	}
 
 	return pr, fts, nil
+}
+
+type logChanWriter struct {
+	wr *PipeWriter
+
+	m    sync.Mutex
+	buf  bytes.Buffer
+	prev string
+}
+
+func (cw *logChanWriter) Write(p []byte) (n int, err error) {
+	// Both cmd.Stdout and cmd.Stderr are writing to cw
+	cw.m.Lock()
+	defer cw.m.Unlock()
+
+	n, err = cw.buf.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	for {
+		line, err := cw.buf.ReadString('\n')
+		cw.prev = cw.prev + line
+		// ReadString returns err != nil if and only if the returned Data
+		// does not end in delim.
+		if err != nil {
+			break
+		}
+
+		if err := cw.wr.Write(cw.prev); err != nil {
+			return len(cw.prev), err
+		}
+		cw.prev = ""
+	}
+	return n, nil
+}
+
+func (cw *logChanWriter) Close() {
+	if len(cw.prev) > 0 {
+		cw.wr.Write(cw.prev)
+		cw.prev = ""
+	}
 }
 
 // ----------------------- useful for testing --------------------------

--- a/pkg/sql/executor_standard_sql_test.go
+++ b/pkg/sql/executor_standard_sql_test.go
@@ -101,30 +101,6 @@ func TestIsQuery(t *testing.T) {
 	a.False(isQuery("drop table"))
 }
 
-func TestLogChanWriter_Write(t *testing.T) {
-	a := assert.New(t)
-	rd, wr := Pipe()
-	go func() {
-		defer wr.Close()
-		cw := &logChanWriter{wr: wr}
-		cw.Write([]byte("hello\n世界"))
-		cw.Write([]byte("hello\n世界"))
-		cw.Write([]byte("\n"))
-		cw.Write([]byte("世界\n世界\n世界\n"))
-	}()
-
-	c := rd.ReadAll()
-
-	a.Equal("hello\n", <-c)
-	a.Equal("世界hello\n", <-c)
-	a.Equal("世界\n", <-c)
-	a.Equal("世界\n", <-c)
-	a.Equal("世界\n", <-c)
-	a.Equal("世界\n", <-c)
-	_, more := <-c
-	a.False(more)
-}
-
 func TestParseTableColumn(tg *testing.T) {
 	a := assert.New(tg)
 	t, c, e := parseTableColumn("a.b.c")


### PR DESCRIPTION
`LogChanWriter` is used in `executor_ir.go` instead of `executor_standard_sql.go`.