### PR TITLE
Fix the model repo version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ ARG WITH_SQLFLOW_MODELS="ON"
 #       we can skip installing sqlflow_models if using the older Tensorflow.
 RUN if [ "${WITH_SQLFLOW_MODELS:-ON}" = "ON" ]; then \
   git clone https://github.com/sql-machine-learning/models.git && \
-  git checkout 58f4c137129e2bc749320bafcc8fddb7c737fed9 && \
   cd models && \
+  git checkout 58f4c137129e2bc749320bafcc8fddb7c737fed9 && \
   bash -c "source activate sqlflow-dev && python setup.py install" && \
   cd .. && \
   rm -rf models; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ ARG WITH_SQLFLOW_MODELS="ON"
 #       we can skip installing sqlflow_models if using the older Tensorflow.
 RUN if [ "${WITH_SQLFLOW_MODELS:-ON}" = "ON" ]; then \
   git clone https://github.com/sql-machine-learning/models.git && \
+  git checkout 58f4c137129e2bc749320bafcc8fddb7c737fed9 && \
   cd models && \
   bash -c "source activate sqlflow-dev && python setup.py install" && \
   cd .. && \


### PR DESCRIPTION
[Our develop branch is failing](https://travis-ci.com/sql-machine-learning/sqlflow/jobs/254708069) after the merge of the PR in sqf-machine-learning/models repo https://github.com/sql-machine-learning/models/pull/24.

So I am fixing the model repo version by checking out a specific git commit as I did for EDL.
https://github.com/sql-machine-learning/sqlflow/blob/376631cc41718e7aa65e4d3dda683935b9a25d40/scripts/docker/install-elasticdl.bash#L23

The commit hash in this PR is before the merge of https://github.com/sql-machine-learning/models/pull/24.