### PR TITLE
Make RunSQLProgram takes a single string

### DIFF
--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -117,7 +117,7 @@ func runStmt(stmt string, isTerminal bool, modelDir string, db *sql.DB, ds strin
 	}
 	defer os.RemoveAll(cwd)
 
-	stream := sql.RunSQLProgram([]string{stmt}, db, modelDir, &pb.Session{})
+	stream := sql.RunSQLProgram(stmt, db, modelDir, &pb.Session{})
 	for rsp := range stream.ReadAll() {
 		isTable = render(rsp, table)
 

--- a/pkg/server/sqlflowserver.go
+++ b/pkg/server/sqlflowserver.go
@@ -33,13 +33,13 @@ import (
 )
 
 // NewServer returns a server instance
-func NewServer(run func([]string, *sf.DB, string, *pb.Session) *sf.PipeReader, modelDir string) *Server {
+func NewServer(run func(string, *sf.DB, string, *pb.Session) *sf.PipeReader, modelDir string) *Server {
 	return &Server{run: run, modelDir: modelDir}
 }
 
 // Server is the instance will be used to connect to DB and execute training
 type Server struct {
-	run      func(sql []string, db *sf.DB, modelDir string, session *pb.Session) *sf.PipeReader
+	run      func(sql string, db *sf.DB, modelDir string, session *pb.Session) *sf.PipeReader
 	modelDir string
 }
 
@@ -55,7 +55,7 @@ func (s *Server) Run(req *pb.Request, stream pb.SQLFlow_RunServer) error {
 	if err != nil {
 		return err
 	}
-	rd := s.run(sqlStatements, db, s.modelDir, req.Session)
+	rd := s.run(req.Sql, db, s.modelDir, req.Session)
 	defer rd.Close()
 
 	for r := range rd.ReadAll() {

--- a/pkg/server/sqlflowserver_test.go
+++ b/pkg/server/sqlflowserver_test.go
@@ -46,9 +46,9 @@ const (
 
 var testServerAddress string
 
-func mockRun(sql []string, db *sf.DB, modelDir string, session *pb.Session) *sf.PipeReader {
+func mockRun(sql string, db *sf.DB, modelDir string, session *pb.Session) *sf.PipeReader {
 	rd, wr := sf.Pipe()
-	singleSQL := sql[0]
+	singleSQL := sql
 	go func() {
 		defer wr.Close()
 		switch singleSQL {
@@ -125,12 +125,13 @@ func TestSQL(t *testing.T) {
 	_, err = stream.Recv()
 	a.Equal(status.Error(codes.Unknown, "Lex: Unknown problem ..."), err)
 
-	testMultipleSQL := fmt.Sprintf("%s %s", testQuerySQL, testExtendedSQL)
-	for _, s := range []string{testQuerySQL, testExecuteSQL, testExtendedSQL, testExtendedSQLWithSpace, testExtendedSQLNoSemicolon, testMultipleSQL} {
+	for _, s := range []string{testQuerySQL, testExecuteSQL, testExtendedSQL, testExtendedSQLWithSpace, testExtendedSQLNoSemicolon} {
+		fmt.Println(s)
 		stream, err := c.Run(ctx, &pb.Request{Sql: s, Session: &pb.Session{DbConnStr: mockDBConnStr}})
 		a.NoError(err)
 		for {
-			_, err := stream.Recv()
+			i, err := stream.Recv()
+			fmt.Println(i, err)
 			if err == io.EOF {
 				break
 			}

--- a/pkg/server/sqlflowserver_test.go
+++ b/pkg/server/sqlflowserver_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -131,6 +132,9 @@ func TestSQL(t *testing.T) {
 		for {
 			_, err := stream.Recv()
 			a.NoError(err)
+			if err == io.EOF {
+				break
+			}
 			// NOTE(tony): a.NoError won't terminate the function, and since it is inside a for loop,
 			// _, err := stream.Recv() could be called thousands of times with err != nil, so we need
 			// to do the following check.

--- a/pkg/server/sqlflowserver_test.go
+++ b/pkg/server/sqlflowserver_test.go
@@ -126,15 +126,14 @@ func TestSQL(t *testing.T) {
 	a.Equal(status.Error(codes.Unknown, "Lex: Unknown problem ..."), err)
 
 	for _, s := range []string{testQuerySQL, testExecuteSQL, testExtendedSQL, testExtendedSQLWithSpace, testExtendedSQLNoSemicolon} {
-		fmt.Println(s)
 		stream, err := c.Run(ctx, &pb.Request{Sql: s, Session: &pb.Session{DbConnStr: mockDBConnStr}})
 		a.NoError(err)
 		for {
 			_, err := stream.Recv()
-			a.NoError(err)
 			if err == io.EOF {
 				break
 			}
+			a.NoError(err)
 			// NOTE(tony): a.NoError won't terminate the function, and since it is inside a for loop,
 			// _, err := stream.Recv() could be called thousands of times with err != nil, so we need
 			// to do the following check.

--- a/pkg/server/sqlflowserver_test.go
+++ b/pkg/server/sqlflowserver_test.go
@@ -16,7 +16,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"os"
@@ -130,12 +129,14 @@ func TestSQL(t *testing.T) {
 		stream, err := c.Run(ctx, &pb.Request{Sql: s, Session: &pb.Session{DbConnStr: mockDBConnStr}})
 		a.NoError(err)
 		for {
-			i, err := stream.Recv()
-			fmt.Println(i, err)
-			if err == io.EOF {
+			_, err := stream.Recv()
+			a.NoError(err)
+			// NOTE(tony): a.NoError won't terminate the function, and since it is inside a for loop,
+			// _, err := stream.Recv() could be called thousands of times with err != nil, so we need
+			// to do the following check.
+			if err != nil {
 				break
 			}
-			a.NoError(err)
 		}
 	}
 }

--- a/pkg/sql/executor_ir_test.go
+++ b/pkg/sql/executor_ir_test.go
@@ -103,11 +103,11 @@ func TestExecuteXGBoost(t *testing.T) {
 	a := assert.New(t)
 	modelDir := ""
 	a.NotPanics(func() {
-		stream := RunSQLProgram([]string{testXGBoostTrainSelectIris}, testDB, modelDir, getDefaultSession())
+		stream := RunSQLProgram(testXGBoostTrainSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testAnalyzeTreeModelSelectIris}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testAnalyzeTreeModelSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testXGBoostPredictIris}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testXGBoostPredictIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -116,11 +116,11 @@ func TestExecuteXGBoostRegression(t *testing.T) {
 	a := assert.New(t)
 	modelDir := ""
 	a.NotPanics(func() {
-		stream := RunSQLProgram([]string{testXGBoostTrainSelectHousing}, testDB, modelDir, getDefaultSession())
+		stream := RunSQLProgram(testXGBoostTrainSelectHousing, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testAnalyzeTreeModelSelectIris}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testAnalyzeTreeModelSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testXGBoostPredictHousing}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testXGBoostPredictHousing, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -129,9 +129,9 @@ func TestExecutorTrainAndPredictDNN(t *testing.T) {
 	a := assert.New(t)
 	modelDir := ""
 	a.NotPanics(func() {
-		stream := RunSQLProgram([]string{testTrainSelectIris}, testDB, modelDir, getDefaultSession())
+		stream := RunSQLProgram(testTrainSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testPredictSelectIris}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testPredictSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -142,9 +142,9 @@ func TestExecutorTrainAndPredictClusteringLocalFS(t *testing.T) {
 	a.Nil(e)
 	defer os.RemoveAll(modelDir)
 	a.NotPanics(func() {
-		stream := RunSQLProgram([]string{testClusteringTrain}, testDB, modelDir, getDefaultSession())
+		stream := RunSQLProgram(testClusteringTrain, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testClusteringPredict}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testClusteringPredict, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -155,9 +155,9 @@ func TestExecutorTrainAndPredictDNNLocalFS(t *testing.T) {
 	a.Nil(e)
 	defer os.RemoveAll(modelDir)
 	a.NotPanics(func() {
-		stream := RunSQLProgram([]string{testTrainSelectIris}, testDB, modelDir, getDefaultSession())
+		stream := RunSQLProgram(testTrainSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
-		stream = RunSQLProgram([]string{testPredictSelectIris}, testDB, modelDir, getDefaultSession())
+		stream = RunSQLProgram(testPredictSelectIris, testDB, modelDir, getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 	})
 }
@@ -179,14 +179,14 @@ train.verbose = 1
 COLUMN NUMERIC(dense, 4)
 LABEL class
 INTO sqlflow_models.my_dense_dnn_model;`
-		stream := RunSQLProgram([]string{trainSQL}, testDB, "", getDefaultSession())
+		stream := RunSQLProgram(trainSQL, testDB, "", getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 
 		predSQL := `SELECT * FROM iris.test_dense
 TO PREDICT iris.predict_dense.class
 USING sqlflow_models.my_dense_dnn_model
 ;`
-		stream = RunSQLProgram([]string{predSQL}, testDB, "", getDefaultSession())
+		stream = RunSQLProgram(predSQL, testDB, "", getDefaultSession())
 		a.True(goodStream(stream.ReadAll()))
 	})
 }

--- a/pkg/sql/executor_standard_sql_test.go
+++ b/pkg/sql/executor_standard_sql_test.go
@@ -85,7 +85,7 @@ func TestStandardSQL(t *testing.T) {
 
 func TestSQLLexerError(t *testing.T) {
 	a := assert.New(t)
-	stream := RunSQLProgram([]string{"SELECT * FROM ``?[] AS WHERE LIMIT;"}, testDB, "", nil)
+	stream := RunSQLProgram("SELECT * FROM ``?[] AS WHERE LIMIT;", testDB, "", nil)
 	a.False(goodStream(stream.ReadAll()))
 }
 

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -178,12 +178,12 @@ USING sqlflow_models.mymodel;`
 	modelDir, e := ioutil.TempDir("/tmp", "sqlflow_models")
 	a.Nil(e)
 	defer os.RemoveAll(modelDir)
-	stream := RunSQLProgram([]string{`SELECT * FROM iris.train
+	stream := RunSQLProgram(`SELECT * FROM iris.train
 TO TRAIN DNNClassifier
 WITH model.n_classes=3, model.hidden_units=[10,20]
 COLUMN sepal_length, sepal_width, petal_length, petal_width
 LABEL class
-INTO sqlflow_models.mymodel;`}, testDB, modelDir, nil)
+INTO sqlflow_models.mymodel;`, testDB, modelDir, nil)
 	a.True(goodStream(stream.ReadAll()))
 
 	predIR, err := generatePredictIR(r, connStr, modelDir)
@@ -207,7 +207,7 @@ func TestGenerateAnalyzeIR(t *testing.T) {
 	modelDir, e := ioutil.TempDir("/tmp", "sqlflow_models")
 	a.Nil(e)
 	defer os.RemoveAll(modelDir)
-	stream := RunSQLProgram([]string{`SELECT * FROM iris.train
+	stream := RunSQLProgram(`SELECT * FROM iris.train
 TO TRAIN xgboost.gbtree
 WITH
 	objective="multi:softprob",
@@ -217,7 +217,7 @@ WITH
 COLUMN sepal_length, sepal_width, petal_length, petal_width
 LABEL class
 INTO sqlflow_models.my_xgboost_model;
-`}, testDB, modelDir, nil)
+`, testDB, modelDir, nil)
 	a.NoError(e)
 	a.True(goodStream(stream.ReadAll()))
 


### PR DESCRIPTION
Part of #1126.

The RunSQLProgram is the only entrance of the `sql` package, it should take a SQL program and the subsequent parsing will split the program into a list of statements.