### PR TITLE
Rename several members to be more consistent

### DIFF
--- a/pkg/sql/codegen/pai/codegen_test.go
+++ b/pkg/sql/codegen/pai/codegen_test.go
@@ -113,7 +113,7 @@ func TestWrapperCodegen(t *testing.T) {
 
 func TestTrainCodegen(t *testing.T) {
 	a := assert.New(t)
-	ir := mockTrainIR()
+	ir := mockTrainClause()
 
 	paiTfCode, err := doTrain(ir, "my_dnn_model")
 	a.NoError(err)
@@ -152,7 +152,7 @@ func TestPredictCodegen(t *testing.T) {
 	a.False(hasUnknownParameters(tfCode, knownPredictParams))
 }
 
-func mockTrainIR() *ir.TrainClause {
+func mockTrainClause() *ir.TrainClause {
 	_ = `SELECT * FROM iris_train TO TRAIN DNNClassifier
          WITH train.batch_size=4,
 		      train.epoch=3,
@@ -190,6 +190,6 @@ func mockPredIR() *ir.PredictClause {
 		Select:      "select * from iris_test;",
 		ResultTable: "iris_predict",
 		Attributes:  make(map[string]interface{}),
-		TrainIR:     mockTrainIR(),
+		TrainClause: mockTrainClause(),
 	}
 }

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -237,7 +237,7 @@ func Train(trainIR *ir.TrainClause) (string, error) {
 // Pred generates a Python program for predict using a TensorFlow model.
 func Pred(predIR *ir.PredictClause, session *pb.Session) (string, error) {
 	modelParams := make(map[string]interface{})
-	for attrKey, attr := range predIR.TrainIR.Attributes {
+	for attrKey, attr := range predIR.TrainClause.Attributes {
 		if strings.HasPrefix(attrKey, "model.") {
 			modelParams[strings.Replace(attrKey, "model.", "", 1)] = attr
 		}
@@ -245,7 +245,7 @@ func Pred(predIR *ir.PredictClause, session *pb.Session) (string, error) {
 	featureColumnsCode := []string{}
 	perTargetFeatureColumnsCode := []string{}
 	fieldMetas := []*ir.FieldMeta{}
-	for target, fcList := range predIR.TrainIR.Features {
+	for target, fcList := range predIR.TrainClause.Features {
 		for _, fc := range fcList {
 			fcCode, err := generateFeatureColumnCode(fc)
 			if err != nil {
@@ -261,8 +261,8 @@ func Pred(predIR *ir.PredictClause, session *pb.Session) (string, error) {
 		featureColumnsCode = append(featureColumnsCode,
 			fmt.Sprintf("\"%s\": [%s]", target, strings.Join(perTargetFeatureColumnsCode, ",\n")))
 	}
-	isKeras, estimatorStr := IsKerasModel(predIR.TrainIR.Estimator)
-	labelFM := predIR.TrainIR.Label.GetFieldMeta()[0]
+	isKeras, estimatorStr := IsKerasModel(predIR.TrainClause.Estimator)
+	labelFM := predIR.TrainClause.Label.GetFieldMeta()[0]
 	if labelFM.Name == "" {
 		log.Printf("clustering model, got result table: %s, result column: %s", predIR.ResultTable, predIR.ResultColumn)
 		// no label in train SQL means a clustering model, generate a fieldmeta using result table's column

--- a/pkg/sql/codegen/tensorflow/codegen_test.go
+++ b/pkg/sql/codegen/tensorflow/codegen_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestTrainCodegen(t *testing.T) {
 	a := assert.New(t)
-	tir := mockTrainIR()
+	tir := mockTrainClause()
 	_, err := Train(tir)
 	a.NoError(err)
 
@@ -51,7 +51,7 @@ func TestTrainCodegen(t *testing.T) {
 	a.Equal(r.FindStringSubmatch(code)[1], "sqlflow_pass")
 }
 
-func mockTrainIR() *ir.TrainClause {
+func mockTrainClause() *ir.TrainClause {
 	cfg := &mysql.Config{
 		User:                 "root",
 		Passwd:               "root",
@@ -88,12 +88,12 @@ func mockTrainIR() *ir.TrainClause {
 		Label: &ir.NumericColumn{&ir.FieldMeta{"class", ir.Int, "", []int{1}, false, nil, 0}}}
 }
 
-func mockPredIR(trainIR *ir.TrainClause) *ir.PredictClause {
+func mockPredIR(trainCl *ir.TrainClause) *ir.PredictClause {
 	return &ir.PredictClause{
-		DataSource:  trainIR.DataSource,
+		DataSource:  trainCl.DataSource,
 		Select:      "select * from iris.test;",
 		ResultTable: "iris.predict",
 		Attributes:  make(map[string]interface{}),
-		TrainIR:     trainIR,
+		TrainClause: trainCl,
 	}
 }

--- a/pkg/sql/codegen/xgboost/codegen.go
+++ b/pkg/sql/codegen/xgboost/codegen.go
@@ -147,7 +147,7 @@ func Train(ir *ir.TrainClause) (string, error) {
 
 // Pred generates a Python program for predict a xgboost model.
 func Pred(ir *ir.PredictClause, session *pb.Session) (string, error) {
-	featureFieldMeta, labelFieldMeta, err := getFieldMeta(ir.TrainIR.Features["feature_columns"], ir.TrainIR.Label)
+	featureFieldMeta, labelFieldMeta, err := getFieldMeta(ir.TrainClause.Features["feature_columns"], ir.TrainClause.Label)
 	f, err := json.Marshal(featureFieldMeta)
 	if err != nil {
 		return "", err

--- a/pkg/sql/codegen/xgboost/codegen_analyze.go
+++ b/pkg/sql/codegen/xgboost/codegen_analyze.go
@@ -36,7 +36,7 @@ func Analyze(ir *ir.AnalyzeClause) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	xs, y, err := getFieldMeta(ir.TrainIR.Features["feature_columns"], ir.TrainIR.Label)
+	xs, y, err := getFieldMeta(ir.TrainClause.Features["feature_columns"], ir.TrainClause.Label)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/codegen/xgboost/codegen_analyze_test.go
+++ b/pkg/sql/codegen/xgboost/codegen_analyze_test.go
@@ -31,7 +31,7 @@ func TestAnalyze(t *testing.T) {
 			"shap_summary.plot_type": "dot",
 			"others.type":            "bar",
 		},
-		TrainIR: tir,
+		TrainClause: tir,
 	}
 	_, err := Analyze(air)
 	a.NoError(err)

--- a/pkg/sql/codegen/xgboost/codegen_test.go
+++ b/pkg/sql/codegen/xgboost/codegen_test.go
@@ -56,7 +56,7 @@ func mockPrdcIR(trainIR *ir.TrainClause) *ir.PredictClause {
 		DataSource:  trainIR.DataSource,
 		Select:      "select * from iris.test;",
 		ResultTable: "iris.predict",
-		TrainIR:     trainIR,
+		TrainClause: trainIR,
 	}
 }
 func mockTrainIR() *ir.TrainClause {

--- a/pkg/sql/executor_ir.go
+++ b/pkg/sql/executor_ir.go
@@ -260,10 +260,10 @@ func runPredictIR(predIR *ir.PredictClause, wr *PipeWriter, db *DB, modelDir str
 
 		program.WriteString(code)
 	} else {
-		if err := recoverModelDir(db, cwd, modelDir, predIR.TrainIR.Into); err != nil {
+		if err := recoverModelDir(db, cwd, modelDir, predIR.TrainClause.Into); err != nil {
 			return err
 		}
-		if isXGBoostModel(predIR.TrainIR.Estimator) {
+		if isXGBoostModel(predIR.TrainClause.Estimator) {
 			code, err := xgboost.Pred(predIR, session)
 			if err != nil {
 				return err
@@ -312,15 +312,15 @@ func runAnalyzeIR(analyzeIR *ir.AnalyzeClause, wr *PipeWriter, db *DB, modelDir 
 	defer os.RemoveAll(cwd)
 
 	// load the model for analyze
-	if err := recoverModelDir(db, cwd, modelDir, analyzeIR.TrainIR.Into); err != nil {
+	if err := recoverModelDir(db, cwd, modelDir, analyzeIR.TrainClause.Into); err != nil {
 		return err
 	}
 
 	cmd := exec.Command("python", "-u")
 	cmd.Dir = cwd
 
-	if !strings.HasPrefix(strings.ToUpper(analyzeIR.TrainIR.Estimator), `XGBOOST.`) {
-		return fmt.Errorf("unsupported model %s", analyzeIR.TrainIR.Estimator)
+	if !strings.HasPrefix(strings.ToUpper(analyzeIR.TrainClause.Estimator), `XGBOOST.`) {
+		return fmt.Errorf("unsupported model %s", analyzeIR.TrainClause.Estimator)
 	}
 	code, err := xgboost.Analyze(analyzeIR)
 	if err != nil {

--- a/pkg/sql/ir/ir.go
+++ b/pkg/sql/ir/ir.go
@@ -109,7 +109,7 @@ type TrainClause struct {
 }
 
 // IsIR is used only for restrict the IR struct types
-func (trainIR *TrainClause) IsIR() {}
+func (*TrainClause) IsIR() {}
 
 // PredictClause is the intermediate representation for code generation of a prediction job
 //
@@ -131,12 +131,12 @@ type PredictClause struct {
 	// "select ... predict ... with predict.batch_size = 32 into ...",
 	// the Attributes will be {"predict.batch_size": 32}
 	Attributes map[string]interface{}
-	// TrainIR is the TrainIR used for generating the training job of the corresponding model
-	TrainIR *TrainClause
+	// TrainClause is the TrainClause used for generating the training job of the corresponding model
+	TrainClause *TrainClause
 }
 
 // IsIR is used only for restrict the IR struct types
-func (predictIR *PredictClause) IsIR() {}
+func (*PredictClause) IsIR() {}
 
 // AnalyzeClause is the intermediate representation for code generation of a analysis job
 type AnalyzeClause struct {
@@ -153,15 +153,15 @@ type AnalyzeClause struct {
 	Attributes map[string]interface{}
 	// Explainer types. For example TreeExplainer.
 	Explainer string
-	// TrainIR is the TrainIR used for generating the training job of the corresponding model
-	TrainIR *TrainClause
+	// TrainClause is the TrainClause used for generating the training job of the corresponding model
+	TrainClause *TrainClause
 }
 
 // IsIR is used only for restrict the IR struct types
-func (analyzeIR *AnalyzeClause) IsIR() {}
+func (*AnalyzeClause) IsIR() {}
 
 // StandardSQL is a string of a standard SQL statement that can run on the database system.
 type StandardSQL string
 
 // IsIR is used only for restrict the IR struct types
-func (sql *StandardSQL) IsIR() {}
+func (*StandardSQL) IsIR() {}

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -215,9 +215,9 @@ INTO sqlflow_models.mymodel;`, testDB, modelDir, nil)
 
 	a.Equal(connStr, predIR.DataSource)
 	a.Equal("iris.predict", predIR.ResultTable)
-	a.Equal("class", predIR.TrainIR.Label.GetFieldMeta()[0].Name)
-	a.Equal("DNNClassifier", predIR.TrainIR.Estimator)
-	nc, ok := predIR.TrainIR.Features["feature_columns"][0].(*ir.NumericColumn)
+	a.Equal("class", predIR.TrainClause.Label.GetFieldMeta()[0].Name)
+	a.Equal("DNNClassifier", predIR.TrainClause.Estimator)
+	nc, ok := predIR.TrainClause.Features["feature_columns"][0].(*ir.NumericColumn)
 	a.True(ok)
 	a.Equal("sepal_length", nc.FieldMeta.Name)
 }
@@ -267,7 +267,7 @@ INTO sqlflow_models.my_xgboost_model;
 	a.Equal(AnalyzeIR.Attributes["shap_summary.plot_type"], "bar")
 	a.Equal(AnalyzeIR.Attributes["shap_summary.alpha"], 1)
 
-	nc, ok := AnalyzeIR.TrainIR.Features["feature_columns"][0].(*ir.NumericColumn)
+	nc, ok := AnalyzeIR.TrainClause.Features["feature_columns"][0].(*ir.NumericColumn)
 	a.True(ok)
 	a.Equal("sepal_length", nc.FieldMeta.Name)
 }


### PR DESCRIPTION
Rename the `TrainIR` members to `TrainClause` to be consistent with the renaming of `TrainIR` struct to `TrainClause`