### PR TITLE
Refactor executor_ir.go using the visitor pattern

### DIFF
--- a/pkg/sql/executor_ir.go
+++ b/pkg/sql/executor_ir.go
@@ -15,21 +15,11 @@ package sql
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path"
 	"strings"
-	"sync"
 	"time"
 
 	pb "sqlflow.org/sqlflow/pkg/proto"
-	"sqlflow.org/sqlflow/pkg/sql/codegen/pai"
-	"sqlflow.org/sqlflow/pkg/sql/codegen/tensorflow"
-	"sqlflow.org/sqlflow/pkg/sql/codegen/xgboost"
 	"sqlflow.org/sqlflow/pkg/sql/ir"
 )
 
@@ -43,35 +33,6 @@ type EndOfExecution struct {
 // WorkflowJob indicates the Argo Workflow ID
 type WorkflowJob struct {
 	JobID string
-}
-
-var envSubmitter = os.Getenv("SQLFLOW_submitter")
-
-// SubmitterType is the type of SQLFlow submitter
-type SubmitterType int
-
-const (
-	// SubmitterPAI indicates that SQLFlow uses the PAI platform as submitter
-	SubmitterPAI = iota
-	// SubmitterEDL indicates that SQLFlow uses ElasticDL as submitter
-	SubmitterEDL
-	// SubmitterALPS indicates that SQLFlow uses ALPS as submitter
-	SubmitterALPS
-	// SubmitterDefault indicates that SQLFlow uses the default submitter
-	SubmitterDefault
-)
-
-func submitter() SubmitterType {
-	switch envSubmitter {
-	case "pai":
-		return SubmitterPAI
-	case "elasticdl":
-		return SubmitterEDL
-	case "alps":
-		return SubmitterALPS
-	default:
-		return SubmitterDefault
-	}
 }
 
 // RunSQLProgram run a SQL program.
@@ -155,9 +116,9 @@ func runSQLProgram(wr *PipeWriter, sqlProgram string, db *DB, modelDir string, s
 			if parsed.train {
 				r, err = generateTrainIRWithInferredColumns(parsed, connStr)
 			} else if parsed.analyze {
-				r, err = generateAnalyzeIR(parsed, connStr, modelDir, submitter() != SubmitterPAI)
+				r, err = generateAnalyzeIR(parsed, connStr, modelDir, submitter().GetTrainIRFromModel())
 			} else {
-				r, err = generatePredictIR(parsed, connStr, modelDir, submitter() != SubmitterPAI)
+				r, err = generatePredictIR(parsed, connStr, modelDir, submitter().GetTrainIRFromModel())
 			}
 		} else {
 			standardSQL := ir.StandardSQL(sql.standard)
@@ -171,7 +132,6 @@ func runSQLProgram(wr *PipeWriter, sqlProgram string, db *DB, modelDir string, s
 			return e
 		}
 	}
-
 	return nil
 }
 
@@ -187,242 +147,11 @@ func runSingleSQLIR(wr *PipeWriter, sqlIR ir.SQLStatement, db *DB, modelDir stri
 			})
 		}
 	}()
-
-	switch sqlIR.(type) {
-	case *ir.StandardSQL:
-		originalSQL = string(*sqlIR.(*ir.StandardSQL))
-		if e = runStandardSQL(wr, originalSQL, db); e != nil {
-			return e
-		}
-	case *ir.TrainClause:
-		originalSQL = sqlIR.(*ir.TrainClause).OriginalSQL
-		if e = runTrainIR(sqlIR.(*ir.TrainClause), wr, db, modelDir, session); e != nil {
-			return e
-		}
-	case *ir.PredictClause:
-		originalSQL = sqlIR.(*ir.PredictClause).OriginalSQL
-		if e = runPredictIR(sqlIR.(*ir.PredictClause), wr, db, modelDir, session); e != nil {
-			return e
-		}
-	case *ir.AnalyzeClause:
-		originalSQL = sqlIR.(*ir.AnalyzeClause).OriginalSQL
-		if e = runAnalyzeIR(sqlIR.(*ir.AnalyzeClause), wr, db, modelDir, session); e != nil {
-			return e
-		}
-	default:
-		return fmt.Errorf("got error ir type: %T", sqlIR)
-	}
-
-	return nil
-}
-
-// TODO(tony): remove the following function after all submitter has been moved to IR
-func runThirdPartySubmitterTrain(wr *PipeWriter, sql string, db *DB, cwd string, session *pb.Session) error {
-	pr, e := newExtendedSyntaxParser().Parse(sql)
-	if e != nil {
+	if e := submitter().Setup(wr, db, modelDir, session); e != nil {
 		return e
 	}
-
-	switch submitter() {
-	case SubmitterEDL:
-		return elasticDLTrain(wr, pr, db, cwd, session)
-	case SubmitterALPS:
-		return alpsTrain(wr, pr, db, cwd, session)
-	default:
-		return fmt.Errorf("unrecognized SQLFLOW_submitter %s", os.Getenv("SQLFLOW_submitter"))
-	}
-}
-
-func runTrainIR(trainIR *ir.TrainClause, wr *PipeWriter, db *DB, modelDir string, session *pb.Session) error {
-	// cwd is used to store train scripts and save output models.
-	cwd, err := ioutil.TempDir("/tmp", "sqlflow")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(cwd)
-
-	if submitter() != SubmitterDefault && submitter() != SubmitterPAI {
-		return runThirdPartySubmitterTrain(wr, trainIR.OriginalSQL, db, cwd, session)
-	}
-
-	// ---------------------- run the IR ---------------------------
-	var program bytes.Buffer
-	if trainIR.ValidationSelect == "" {
-		trainIR.ValidationSelect = trainIR.Select
-	}
-	if isXGBoostModel(trainIR.Estimator) {
-		code, err := xgboost.Train(trainIR)
-		if err != nil {
-			return err
-		}
-		program.WriteString(code)
-	} else {
-		if submitter() != SubmitterPAI {
-			code, err := tensorflow.Train(trainIR)
-			if err != nil {
-				return err
-			}
-			program.WriteString(code)
-		} else {
-			code, err := pai.Train(trainIR, trainIR.Into, cwd)
-			if err != nil {
-				return err
-			}
-			program.WriteString(code)
-		}
-	}
-	cw := &logChanWriter{wr: wr}
-	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("\n==========Program======\n%s\n=======Program Output===========\n", program.String()))
-
-	w := io.MultiWriter(cw, &buf)
-	defer cw.Close()
-	cmd := sqlflowCmd(cwd, db.driverName)
-	cmd.Stdin = &program
-	cmd.Stdout = w
-	cmd.Stderr = w
-	if e := cmd.Run(); e != nil {
-		return fmt.Errorf("predict failed: %v\n %s", e, buf.String())
-	}
-	if submitter() != SubmitterPAI {
-		m := model{workDir: cwd, TrainSelect: trainIR.OriginalSQL}
-		if modelDir != "" {
-			return m.saveTar(modelDir, trainIR.Into)
-		}
-		return m.save(db, trainIR.Into, session)
-	}
-	return nil
-}
-
-// TODO(tony): remove the following function after all submitter has been moved to IR
-func runThirdPartySubmitterPred(wr *PipeWriter, sql string, db *DB, cwd string, session *pb.Session) error {
-	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
-	pr, e := newExtendedSyntaxParser().Parse(sql)
-	if e != nil {
-		return e
-	}
-	if submitter() == SubmitterALPS {
-		return alpsPred(wr, pr, db, cwd, session)
-	} else if submitter() == SubmitterEDL {
-		return elasticDLPredict(wr, pr, db, cwd, session)
-	}
-
-	return nil
-}
-
-func runPredictIR(predIR *ir.PredictClause, wr *PipeWriter, db *DB, modelDir string, session *pb.Session) error {
-	// cwd is used to load the saved model for prediction.
-	cwd, err := ioutil.TempDir("/tmp", "sqlflow")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(cwd)
-
-	if submitter() != SubmitterDefault && submitter() != SubmitterPAI {
-		return runThirdPartySubmitterPred(wr, predIR.OriginalSQL, db, cwd, session)
-	}
-
-	// ------------------- run pred IR -----------------------
-	var program bytes.Buffer
-	if submitter() == SubmitterPAI {
-		code, err := pai.Predict(predIR, predIR.TrainIR.Into, cwd)
-		if err != nil {
-			return err
-		}
-		err = createPredictionTableFromIR(predIR, db, session)
-		if err != nil {
-			return err
-		}
-
-		program.WriteString(code)
-	} else {
-		if err := recoverModelDir(db, cwd, modelDir, predIR.TrainIR.Into); err != nil {
-			return err
-		}
-		if isXGBoostModel(predIR.TrainIR.Estimator) {
-			code, err := xgboost.Pred(predIR, session)
-			if err != nil {
-				return err
-			}
-			err = createPredictionTableFromIR(predIR, db, session)
-			if err != nil {
-				return err
-			}
-			program.WriteString(code)
-		} else {
-			err = createPredictionTableFromIR(predIR, db, session)
-			if err != nil {
-				return err
-			}
-			code, err := tensorflow.Pred(predIR, session)
-			if err != nil {
-				return err
-			}
-			program.WriteString(code)
-		}
-	}
-
-	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("\n==========Program======\n%s\n=======Program Output===========\n", program.String()))
-
-	cw := &logChanWriter{wr: wr}
-	w := io.MultiWriter(cw, &buf)
-	defer cw.Close()
-	cmd := sqlflowCmd(cwd, db.driverName)
-	cmd.Env = append(os.Environ())
-	cmd.Stdin = &program
-	cmd.Stdout = w
-	cmd.Stderr = w
-	if e := cmd.Run(); e != nil {
-		return fmt.Errorf("predict failed: %v\n %s", e, buf.String())
-	}
-	return nil
-}
-
-func runAnalyzeIR(analyzeIR *ir.AnalyzeClause, wr *PipeWriter, db *DB, modelDir string, session *pb.Session) error {
-	// cwd is used to load the saved model for prediction.
-	cwd, err := ioutil.TempDir("/tmp", "sqlflow")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(cwd)
-
-	// load the model for analyze
-	if err := recoverModelDir(db, cwd, modelDir, analyzeIR.TrainIR.Into); err != nil {
-		return err
-	}
-
-	cmd := exec.Command("python", "-u")
-	cmd.Dir = cwd
-
-	if !strings.HasPrefix(strings.ToUpper(analyzeIR.TrainIR.Estimator), `XGBOOST.`) {
-		return fmt.Errorf("unsupported model %s", analyzeIR.TrainIR.Estimator)
-	}
-	code, err := xgboost.Analyze(analyzeIR)
-	if err != nil {
-		return err
-	}
-	var program bytes.Buffer
-	program.WriteString(code)
-	cmd.Stdin = &program
-	if _, err := cmd.CombinedOutput(); err != nil {
-		return err
-	}
-
-	imgFile, err := os.Open(path.Join(cwd, "summary.png"))
-	if err != nil {
-		return err
-	}
-	defer imgFile.Close()
-
-	imgBytes, err := ioutil.ReadAll(imgFile)
-	if err != nil {
-		return err
-	}
-	imgBase64Str := base64.StdEncoding.EncodeToString(imgBytes)
-	img2html := fmt.Sprintf("<div align='center'><img src='data:image/png;base64,%s' /></div>", imgBase64Str)
-	wr.Write(img2html)
-	return nil
+	defer submitter().Teardown()
+	return sqlIR.Execute(submitter())
 }
 
 // Create prediction table with appropriate column type.
@@ -442,7 +171,6 @@ func createPredictionTable(predParsed *extendedSelect, db *DB, session *pb.Sessi
 	if e != nil {
 		return e
 	}
-
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "create table %s (", tableName)
 	for _, c := range predParsed.columns["feature_columns"] {
@@ -546,16 +274,6 @@ func createPredictionTableFromIR(predIR *ir.PredictClause, db *DB, session *pb.S
 	return nil
 }
 
-func recoverModelDir(db *DB, cwd, modelDir, modelName string) error {
-	if modelDir != "" {
-		_, err := loadTar(modelDir, cwd, modelName)
-		return err
-	}
-
-	_, err := load(db, modelName, cwd)
-	return err
-}
-
 func loadModelMeta(pr *extendedSelect, db *DB, cwd, modelDir, modelName string) (*extendedSelect, error) {
 	var m *model
 	var e error
@@ -567,7 +285,6 @@ func loadModelMeta(pr *extendedSelect, db *DB, cwd, modelDir, modelName string) 
 	if e != nil {
 		return nil, fmt.Errorf("load %v", e)
 	}
-
 	// Parse the training SELECT statement used to train
 	// the model for the prediction.
 	tr, e := parseOneStatement(db.driverName, m.TrainSelect)
@@ -584,50 +301,4 @@ func loadModelMeta(pr *extendedSelect, db *DB, cwd, modelDir, modelName string) 
 	return pr, nil
 }
 
-type logChanWriter struct {
-	wr *PipeWriter
-
-	m    sync.Mutex
-	buf  bytes.Buffer
-	prev string
-}
-
-func (cw *logChanWriter) Write(p []byte) (n int, err error) {
-	// Both cmd.Stdout and cmd.Stderr are writing to cw
-	cw.m.Lock()
-	defer cw.m.Unlock()
-
-	n, err = cw.buf.Write(p)
-	if err != nil {
-		return n, err
-	}
-
-	for {
-		line, err := cw.buf.ReadString('\n')
-		cw.prev = cw.prev + line
-		// ReadString returns err != nil if and only if the returned Data
-		// does not end in delim.
-		if err != nil {
-			break
-		}
-
-		if err := cw.wr.Write(cw.prev); err != nil {
-			return len(cw.prev), err
-		}
-		cw.prev = ""
-	}
-	return n, nil
-}
-
-func (cw *logChanWriter) Close() {
-	if len(cw.prev) > 0 {
-		cw.wr.Write(cw.prev)
-		cw.prev = ""
-	}
-}
-
-// ----------------------- useful for testing --------------------------
-
-func getDefaultSession() *pb.Session {
-	return &pb.Session{}
-}
+func getDefaultSession() *pb.Session { return &pb.Session{} } // for testing

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -80,6 +80,9 @@ func generateTrainIR(slct *extendedSelect, connStr string) (*ir.TrainClause, err
 		}}
 
 	vslct, _ := parseValidationSelect(attrList)
+	if vslct == "" {
+		vslct = slct.standardSelect.String()
+	}
 	return &ir.TrainClause{
 		DataSource: connStr,
 		Select:     slct.standardSelect.String(),
@@ -126,6 +129,9 @@ func verifyIRWithTrainIR(sqlir ir.SQLStatement, db *DB) error {
 	trainFields, e := verify(selectStmt, db)
 	if e != nil {
 		return e
+	}
+	if trainIR == nil { // Implies we dont' need to load model
+		return nil
 	}
 
 	predFields, e := verify(trainIR.Select, db)

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"sqlflow.org/sqlflow/pkg/sql/codegen/pai"
+	"sqlflow.org/sqlflow/pkg/sql/ir"
+)
+
+type paiSubmitter struct{ *defaultSubmitter }
+
+func (s *paiSubmitter) ExecuteTrain(cl *ir.TrainClause) (e error) {
+	if code, e := pai.Train(cl, cl.Into, s.Cwd); e == nil {
+		return s.runCommand(code)
+	}
+	return e
+}
+func (s *paiSubmitter) ExecutePredict(cl *ir.PredictClause) error {
+	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
+	pr, e := newExtendedSyntaxParser().Parse(cl.OriginalSQL)
+	if e != nil {
+		return e
+	}
+	if e = createPredictionTableFromIR(cl, s.Db, s.Session); e != nil {
+		return e
+	}
+	code, e := pai.Predict(cl, pr.model, s.Cwd)
+	if e != nil {
+		return e
+	}
+	return s.runCommand(code)
+}
+func (s *paiSubmitter) GetTrainIRFromModel() bool { return false }
+func init()                                       { submitterRegistry["pai"] = &paiSubmitter{&defaultSubmitter{}} }

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -115,7 +115,7 @@ func (s *defaultSubmitter) SaveModel(cl *ir.TrainClause) error {
 	if s.ModelDir != "" {
 		return m.saveTar(s.ModelDir, cl.Into)
 	}
-	return m.save(s.Db, cl.Into)
+	return m.save(s.Db, cl.Into, s.Session)
 }
 
 func (s *defaultSubmitter) LoadModel(cl *ir.TrainClause) error {

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -1,0 +1,240 @@
+// Copyright 2019 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+
+	pb "sqlflow.org/sqlflow/pkg/proto"
+	"sqlflow.org/sqlflow/pkg/sql/codegen/tensorflow"
+	"sqlflow.org/sqlflow/pkg/sql/codegen/xgboost"
+	"sqlflow.org/sqlflow/pkg/sql/ir"
+)
+
+var envSubmitter = os.Getenv("SQLFLOW_submitter")
+
+var submitterRegistry = map[string](Submitter){
+	"default":   &defaultSubmitter{},
+	"alps":      &alpsSubmitter{&defaultSubmitter{}},
+	"elasticdl": &elasticdlSubmitter{&defaultSubmitter{}},
+}
+
+func submitter() Submitter {
+	s := submitterRegistry[envSubmitter]
+	if s == nil {
+		s = submitterRegistry["default"]
+	}
+	return s
+}
+
+// Submitter extends ir.Executor
+type Submitter interface {
+	ir.Executor
+	Setup(*PipeWriter, *DB, string, *pb.Session) error
+	Teardown()
+	GetTrainIRFromModel() bool
+}
+
+type logChanWriter struct {
+	wr   *PipeWriter
+	m    sync.Mutex
+	buf  bytes.Buffer
+	prev string
+}
+
+func (cw *logChanWriter) Write(p []byte) (n int, err error) {
+	// Both cmd.Stdout and cmd.Stderr are writing to cw
+	cw.m.Lock()
+	defer cw.m.Unlock()
+
+	n, err = cw.buf.Write(p)
+	if err != nil {
+		return n, err
+	}
+	for {
+		line, err := cw.buf.ReadString('\n')
+		cw.prev = cw.prev + line
+		// ReadString returns err != nil if and only if the returned Data
+		// does not end in delim.
+		if err != nil {
+			break
+		}
+		if err := cw.wr.Write(cw.prev); err != nil {
+			return len(cw.prev), err
+		}
+		cw.prev = ""
+	}
+	return n, nil
+}
+
+func (cw *logChanWriter) Close() {
+	if len(cw.prev) > 0 {
+		cw.wr.Write(cw.prev)
+		cw.prev = ""
+	}
+}
+
+type defaultSubmitter struct {
+	Writer   *PipeWriter
+	Db       *DB
+	ModelDir string
+	Cwd      string
+	Session  *pb.Session
+}
+
+type elasticdlSubmitter struct{ *defaultSubmitter }
+type alpsSubmitter struct{ *defaultSubmitter }
+
+func (s *defaultSubmitter) Setup(w *PipeWriter, db *DB, modelDir string, session *pb.Session) error {
+	// cwd is used to store train scripts and save output models.
+	cwd, err := ioutil.TempDir("/tmp", "sqlflow")
+	s.Writer, s.Db, s.ModelDir, s.Cwd, s.Session = w, db, modelDir, cwd, session
+	return err
+}
+
+func (s *defaultSubmitter) SaveModel(cl *ir.TrainClause) error {
+	m := model{workDir: s.Cwd, TrainSelect: cl.OriginalSQL}
+	if s.ModelDir != "" {
+		return m.saveTar(s.ModelDir, cl.Into)
+	}
+	return m.save(s.Db, cl.Into)
+}
+
+func (s *defaultSubmitter) LoadModel(cl *ir.TrainClause) error {
+	if s.ModelDir != "" {
+		_, err := loadTar(s.ModelDir, s.Cwd, cl.Into)
+		return err
+	}
+	_, err := load(s.Db, cl.Into, s.Cwd)
+	return err
+}
+
+func (s *defaultSubmitter) runCommand(program string) error {
+	cw := &logChanWriter{wr: s.Writer}
+	var output bytes.Buffer
+	w := io.MultiWriter(cw, &output)
+	defer cw.Close()
+	cmd := sqlflowCmd(s.Cwd, s.Db.driverName)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = bytes.NewBufferString(program), w, w
+	if e := cmd.Run(); e != nil {
+		return fmt.Errorf("failed: %v\n%sProgram%[2]s\n%s\n%[2]sOutput%[2]s\n%[4]v", e, "==========", program, output.String())
+	}
+	return nil
+}
+
+func (s *defaultSubmitter) ExecuteQuery(sql *ir.StandardSQL) error {
+	return runStandardSQL(s.Writer, string(*sql), s.Db)
+}
+
+func (s *defaultSubmitter) ExecuteTrain(cl *ir.TrainClause) (e error) {
+	var code string
+	if isXGBoostModel(cl.Estimator) {
+		code, e = xgboost.Train(cl)
+	} else {
+		code, e = tensorflow.Train(cl)
+	}
+	if e == nil {
+		if e = s.runCommand(code); e == nil {
+			e = s.SaveModel(cl)
+		}
+	}
+	return e
+}
+
+func (s *defaultSubmitter) ExecutePredict(cl *ir.PredictClause) (e error) {
+	if e = s.LoadModel(cl.TrainIR); e == nil {
+		if e = createPredictionTableFromIR(cl, s.Db, s.Session); e == nil {
+			var code string
+			if isXGBoostModel(cl.TrainIR.Estimator) {
+				code, e = xgboost.Pred(cl, s.Session)
+			} else {
+				code, e = tensorflow.Pred(cl, s.Session)
+			}
+			if e == nil {
+				e = s.runCommand(code)
+			}
+		}
+	}
+	return e
+}
+func (s *defaultSubmitter) ExecuteAnalyze(cl *ir.AnalyzeClause) error {
+	if err := s.LoadModel(cl.TrainIR); err != nil {
+		return err
+	}
+	if !isXGBoostModel(cl.TrainIR.Estimator) {
+		return fmt.Errorf("unsupported model %s", cl.TrainIR.Estimator)
+	}
+
+	code, err := xgboost.Analyze(cl)
+	if err != nil {
+		return err
+	}
+	if err = s.runCommand(code); err != nil {
+		return err
+	}
+	imgFile, err := os.Open(path.Join(s.Cwd, "summary.png"))
+	if err != nil {
+		return err
+	}
+	defer imgFile.Close()
+	imgBytes, err := ioutil.ReadAll(imgFile)
+	if err != nil {
+		return err
+	}
+	imgBase64Str := base64.StdEncoding.EncodeToString(imgBytes)
+	img2html := fmt.Sprintf("<div align='center'><img src='data:image/png;base64,%s' /></div>", imgBase64Str)
+	s.Writer.Write(img2html)
+	return nil
+}
+func (s *defaultSubmitter) Teardown()                 { os.RemoveAll(s.Cwd) }
+func (s *defaultSubmitter) GetTrainIRFromModel() bool { return true }
+
+func (s *elasticdlSubmitter) ExecuteTrain(cl *ir.TrainClause) (e error) {
+	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
+	if pr, e := newExtendedSyntaxParser().Parse(cl.OriginalSQL); e == nil {
+		e = elasticDLTrain(s.Writer, pr, s.Db, s.Cwd, s.Session)
+	}
+	return e
+}
+
+func (s *elasticdlSubmitter) ExecutePredict(cl *ir.PredictClause) (e error) {
+	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
+	if pr, e := newExtendedSyntaxParser().Parse(cl.OriginalSQL); e == nil {
+		e = elasticDLPredict(s.Writer, pr, s.Db, s.Cwd, s.Session)
+	}
+	return e
+}
+
+func (s *alpsSubmitter) ExecuteTrain(cl *ir.TrainClause) (e error) {
+	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
+	if pr, e := newExtendedSyntaxParser().Parse(cl.OriginalSQL); e == nil {
+		e = alpsTrain(s.Writer, pr, s.Db, s.Cwd, s.Session)
+	}
+	return e
+}
+
+func (s *alpsSubmitter) ExecutePredict(cl *ir.PredictClause) (e error) {
+	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
+	if pr, e := newExtendedSyntaxParser().Parse(cl.OriginalSQL); e == nil {
+		e = alpsPred(s.Writer, pr, s.Db, s.Cwd, s.Session)
+	}
+	return e
+}

--- a/pkg/sql/submitter_test.go
+++ b/pkg/sql/submitter_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubmitterRegistry(t *testing.T) {
+	a := assert.New(t)
+	a.Equal(4, len(submitterRegistry))
+	a.NotNil(submitterRegistry["pai"])
+	a.NotNil(submitterRegistry["default"])
+	a.NotNil(submitterRegistry["elasticdl"])
+	a.NotNil(submitterRegistry["alps"])
+	a.Equal(submitter(), submitterRegistry["default"])
+}


### PR DESCRIPTION
Wikipedia:
> The visitor design pattern is a way of separating an algorithm from an object structure on which it operates. A practical result of this separation is the ability to add new operations to _existing object structures_ without modifying the structures

In our scenario, the above _existing object structure_ is the `ir.SQLStatement` interface and the four types implemented that interface, because there're always requirements to add new operations to the object structure(i.e. add a new submitter), but the structure itself is relatively stable.
This pull request extracts two new concepts: an `Executor` is a visitor to `SQLStatement`, a `Submitter` extends `Executor` and represents a submitter platform such as _"pai"_, _"alps"_ or _"elasticdl"_. 

`defaultSubmitter` encapsulates the core functionality of the former `TrainIR`, `PredictIR` and `AnalyzeIR` functions and exposes several utility methods. As a result, it is a piece of cake to implement `alpsSubmitter` and `elasticdlSubmitter`.

The pull request uses a `map[string]Submmiter` as a type registry.

`paiSubmitter` demos how a new submitter can be implemented as a new file without touching any other existing source files

This also fixes #1239 

**TODO**
1. Move `submitter.go` and all its dependencies into a new package `submitter`
1. A better design to replace the `if` checking `xgboost` or `tensorflow`