### PR TITLE
Use a case insensitive regexp to make feature derivation robust to typos

### DIFF
--- a/pkg/sql/executor_ir_test.go
+++ b/pkg/sql/executor_ir_test.go
@@ -26,7 +26,7 @@ import (
 const (
 	testTrainSelectWithLimit = `
 SELECT * FROM iris.train
-limit 10
+liMIT 10
 TO TRAIN xgboost.gbtree
 WITH
     objective="multi:softprob",

--- a/pkg/sql/feature_derivation.go
+++ b/pkg/sql/feature_derivation.go
@@ -232,7 +232,7 @@ func InferFeatureColumns(trainIR *ir.TrainClause) error {
 
 	// TODO(typhoonzero): find a way to using subqueries like select * from (%s) AS a LIMIT 100
 	q := trainIR.Select
-	re, err := regexp.Compile("(LIMIT [0-9]+|limit [0-9]+)")
+	re, err := regexp.Compile("(?i)LIMIT [0-9]+")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A slight improvement for #1269.