### PR TITLE
add PAI e2e test for internal env

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -195,9 +195,9 @@ func prepareTestData(dbStr string) error {
 			datasets = []string{
 				testdata.ODPSFeatureMapSQL,
 				testdata.ODPSSparseColumnSQL,
-				fmt.Sprintf(testdata.IrisMaxComputeSQL, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB)}
+				fmt.Sprintf(testdata.IrisMaxComputeSQL, caseDB)}
 		} else {
-			datasets = []string{fmt.Sprintf(testdata.IrisMaxComputeSQL, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB)}
+			datasets = []string{fmt.Sprintf(testdata.IrisMaxComputeSQL, caseDB)}
 		}
 	default:
 		return fmt.Errorf("unrecognized SQLFLOW_TEST_DB %s", db)

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -45,6 +45,9 @@ var caseTrainTable = "train"
 var caseTestTable = "test"
 var casePredictTable = "predict"
 
+// caseInto used by CaseTrainSQL
+var caseInto = "sqlflow_models.my_dnn_model"
+
 const unitestPort = 50051
 
 func serverIsReady(addr string, timeout time.Duration) bool {
@@ -73,7 +76,7 @@ func connectAndRunSQL(sql string) ([]string, [][]*any.Any, error) {
 	}
 	defer conn.Close()
 	cli := pb.NewSQLFlowClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()
 	stream, err := cli.Run(ctx, sqlRequest(sql))
 	if err != nil {
@@ -192,9 +195,9 @@ func prepareTestData(dbStr string) error {
 			datasets = []string{
 				testdata.ODPSFeatureMapSQL,
 				testdata.ODPSSparseColumnSQL,
-				testdata.IrisMaxComputeSQL}
+				fmt.Sprintf(testdata.IrisMaxComputeSQL, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB)}
 		} else {
-			datasets = []string{testdata.IrisMaxComputeSQL}
+			datasets = []string{fmt.Sprintf(testdata.IrisMaxComputeSQL, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB, caseDB)}
 		}
 	default:
 		return fmt.Errorf("unrecognized SQLFLOW_TEST_DB %s", db)
@@ -391,14 +394,16 @@ func TestEnd2EndMaxCompute(t *testing.T) {
 	dbConnStr = fmt.Sprintf("maxcompute://%s:%s@%s", AK, SK, endpoint)
 	go start(modelDir, caCrt, caKey, unitestPort, false)
 	waitPortReady(fmt.Sprintf("localhost:%d", unitestPort), 0)
-	err = prepareTestData(dbConnStr)
-	if err != nil {
-		t.Fatalf("prepare test dataset failed: %v", err)
-	}
+
 	caseDB = os.Getenv("MAXCOMPUTE_PROJECT")
 	caseTrainTable = "sqlflow_test_iris_train"
 	caseTestTable = "sqlflow_test_iris_test"
 	casePredictTable = "sqlflow_test_iris_predict"
+	err = prepareTestData(dbConnStr)
+	if err != nil {
+		t.Fatalf("prepare test dataset failed: %v", err)
+	}
+
 	t.Run("TestTrainSQL", CaseTrainSQL)
 }
 
@@ -561,8 +566,8 @@ func CaseTrainSQL(t *testing.T) {
 		validation.select = "SELECT * FROM %s.%s LIMIT 30"
 	COLUMN sepal_length, sepal_width, petal_length, petal_width
 	LABEL class
-	INTO sqlflow_models.my_dnn_model;
-	`, caseDB, caseTrainTable, caseDB, caseTrainTable)
+	INTO %s;
+	`, caseDB, caseTrainTable, caseDB, caseTrainTable, caseInto)
 	_, _, err := connectAndRunSQL(trainSQL)
 	if err != nil {
 		a.Fail("Run trainSQL error: %v", err)
@@ -571,7 +576,7 @@ func CaseTrainSQL(t *testing.T) {
 	predSQL := fmt.Sprintf(`SELECT *
 FROM %s.%s
 TO PREDICT %s.%s.class
-USING sqlflow_models.my_dnn_model;`, caseDB, caseTestTable, caseDB, casePredictTable)
+USING %s;`, caseDB, caseTestTable, caseDB, casePredictTable, caseInto)
 	_, _, err = connectAndRunSQL(predSQL)
 	if err != nil {
 		a.Fail("Run predSQL error: %v", err)
@@ -1065,4 +1070,45 @@ FROM housing.xgb_predict LIMIT 5;`)
 		}
 		a.False(nilCount == 13)
 	}
+}
+
+func TestEnd2EndMaxComputePAI(t *testing.T) {
+	testDBDriver := os.Getenv("SQLFLOW_TEST_DB")
+	if testDBDriver != "maxcompute" {
+		t.Skip("Skipping non maxcompute tests")
+	}
+	if os.Getenv("SQLFLOW_submitter") != "pai" {
+		t.Skip("Skip non PAI tests")
+	}
+	AK := os.Getenv("MAXCOMPUTE_AK")
+	SK := os.Getenv("MAXCOMPUTE_SK")
+	endpoint := os.Getenv("MAXCOMPUTE_ENDPOINT")
+	dbConnStr = fmt.Sprintf("maxcompute://%s:%s@%s", AK, SK, endpoint)
+	modelDir := ""
+
+	tmpDir, caCrt, caKey, err := generateTempCA()
+	defer os.RemoveAll(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to generate CA pair %v", err)
+	}
+
+	caseDB = os.Getenv("MAXCOMPUTE_PROJECT")
+	if caseDB == "" {
+		t.Fatalf("Must set env MAXCOMPUTE_PROJECT")
+	}
+	fmt.Println(caseDB)
+	caseTrainTable = "sqlflow_test_iris_train"
+	caseTestTable = "sqlflow_test_iris_test"
+	casePredictTable = "sqlflow_test_iris_predict"
+	// write model to current MaxCompute project
+	caseInto = "my_dnn_model"
+
+	go start(modelDir, caCrt, caKey, unitestPort, false)
+	waitPortReady(fmt.Sprintf("localhost:%d", unitestPort), 0)
+	err = prepareTestData(dbConnStr)
+	if err != nil {
+		t.Fatalf("prepare test dataset failed: %v", err)
+	}
+
+	t.Run("TestTrainSQL", CaseTrainSQL)
 }

--- a/pkg/sql/codegen/pai/template_tf.go
+++ b/pkg/sql/codegen/pai/template_tf.go
@@ -53,8 +53,9 @@ driver, dsn = "{{.DataSource}}".split("://")
 assert driver == "maxcompute"
 user, passwd, address, database = sqlflow_submitter.db.parseMaxComputeDSN(dsn)
 
+jobname = '_'.join(['sqlflow', '{{.ModelName}}'.replace('.', '_')])
 pai_cmd = 'pai -name %s -DjobName=%s -Dtags=%s -Dscript=file://%s -DentryFile=%s' % (
-	'tensorflow1120', 'sqlflow_' + '{{.ModelName}}', 'dnn', tarball, '{{.EntryFile}}')
+	'tensorflow1120', jobname, 'dnn', tarball, '{{.EntryFile}}')
 
 # Submit the tarball to PAI
 subprocess.run(["odpscmd", "-u", user,

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -26,6 +26,7 @@ func (s *paiSubmitter) ExecuteTrain(cl *ir.TrainClause) (e error) {
 	}
 	return e
 }
+
 func (s *paiSubmitter) ExecutePredict(cl *ir.PredictClause) error {
 	// TODO(typhoonzero): remove below twice parse when all submitters moved to IR.
 	pr, e := newExtendedSyntaxParser().Parse(cl.OriginalSQL)
@@ -41,5 +42,6 @@ func (s *paiSubmitter) ExecutePredict(cl *ir.PredictClause) error {
 	}
 	return s.runCommand(code)
 }
+
 func (s *paiSubmitter) GetTrainIRFromModel() bool { return false }
 func init()                                       { submitterRegistry["pai"] = &paiSubmitter{&defaultSubmitter{}} }

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -205,7 +205,7 @@ func (s *defaultSubmitter) ExecuteAnalyze(cl *ir.AnalyzeClause) error {
 	s.Writer.Write(img2html)
 	return nil
 }
-func (s *defaultSubmitter) Teardown()                 { os.RemoveAll(s.Cwd) }
+func (s *defaultSubmitter) Teardown()                 {} //os.RemoveAll(s.Cwd) }
 func (s *defaultSubmitter) GetTrainIRFromModel() bool { return true }
 
 func (s *elasticdlSubmitter) ExecuteTrain(cl *ir.TrainClause) error {

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -205,7 +205,7 @@ func (s *defaultSubmitter) ExecuteAnalyze(cl *ir.AnalyzeClause) error {
 	s.Writer.Write(img2html)
 	return nil
 }
-func (s *defaultSubmitter) Teardown()                 {} //os.RemoveAll(s.Cwd) }
+func (s *defaultSubmitter) Teardown()                 { os.RemoveAll(s.Cwd) }
 func (s *defaultSubmitter) GetTrainIRFromModel() bool { return true }
 
 func (s *elasticdlSubmitter) ExecuteTrain(cl *ir.TrainClause) error {

--- a/pkg/sql/testdata/iris_sql.go
+++ b/pkg/sql/testdata/iris_sql.go
@@ -325,15 +325,15 @@ CREATE TABLE iris.iris_empty (
 
 // IrisMaxComputeSQL is .sql format data sample of iris dataset in MaxCompute SQL.
 var IrisMaxComputeSQL = `
-DROP TABLE IF EXISTS gomaxcompute_driver_w7u.sqlflow_test_iris_train;
-CREATE TABLE gomaxcompute_driver_w7u.sqlflow_test_iris_train (
+DROP TABLE IF EXISTS %s.sqlflow_test_iris_train;
+CREATE TABLE %s.sqlflow_test_iris_train (
        sepal_length DOUBLE,
        sepal_width  DOUBLE,
        petal_length DOUBLE,
        petal_width  DOUBLE,
        class BIGINT);
 
-INSERT INTO gomaxcompute_driver_w7u.sqlflow_test_iris_train VALUES
+INSERT INTO %s.sqlflow_test_iris_train VALUES
 (6.4,2.8,5.6,2.2,2),
 (5.0,2.3,3.3,1.0,1),
 (4.9,2.5,4.5,1.7,2),
@@ -445,15 +445,15 @@ INSERT INTO gomaxcompute_driver_w7u.sqlflow_test_iris_train VALUES
 (5.6,2.9,3.6,1.3,1),
 (4.8,3.1,1.6,0.2,0);
 
-DROP TABLE IF EXISTS gomaxcompute_driver_w7u.sqlflow_test_iris_test;
-CREATE TABLE gomaxcompute_driver_w7u.sqlflow_test_iris_test(
+DROP TABLE IF EXISTS %s.sqlflow_test_iris_test;
+CREATE TABLE %s.sqlflow_test_iris_test(
        sepal_length DOUBLE,
        sepal_width  DOUBLE,
        petal_length DOUBLE,
        petal_width  DOUBLE,
        class BIGINT);
 
-INSERT INTO gomaxcompute_driver_w7u.sqlflow_test_iris_test VALUES
+INSERT INTO %s.sqlflow_test_iris_test VALUES
 (6.3,2.7,4.9,1.8,2),
 (5.7,2.8,4.1,1.3,1),
 (5.0,3.0,1.6,0.2,0),
@@ -465,8 +465,8 @@ INSERT INTO gomaxcompute_driver_w7u.sqlflow_test_iris_test VALUES
 (4.8,3.0,1.4,0.1,0),
 (5.5,2.4,3.7,1.0,1);
 
-DROP TABLE IF EXISTS gomaxcompute_driver_w7u.sqlflow_test_iris_empty;
-CREATE TABLE gomaxcompute_driver_w7u.sqlflow_test_iris_empty (
+DROP TABLE IF EXISTS %s.sqlflow_test_iris_empty;
+CREATE TABLE %s.sqlflow_test_iris_empty (
        sepal_length DOUBLE,
        sepal_width  DOUBLE,
        petal_length DOUBLE,

--- a/pkg/sql/testdata/iris_sql.go
+++ b/pkg/sql/testdata/iris_sql.go
@@ -325,15 +325,15 @@ CREATE TABLE iris.iris_empty (
 
 // IrisMaxComputeSQL is .sql format data sample of iris dataset in MaxCompute SQL.
 var IrisMaxComputeSQL = `
-DROP TABLE IF EXISTS %s.sqlflow_test_iris_train;
-CREATE TABLE %s.sqlflow_test_iris_train (
+DROP TABLE IF EXISTS %[1]s.sqlflow_test_iris_train;
+CREATE TABLE %[1]s.sqlflow_test_iris_train (
        sepal_length DOUBLE,
        sepal_width  DOUBLE,
        petal_length DOUBLE,
        petal_width  DOUBLE,
        class BIGINT);
 
-INSERT INTO %s.sqlflow_test_iris_train VALUES
+INSERT INTO %[1]s.sqlflow_test_iris_train VALUES
 (6.4,2.8,5.6,2.2,2),
 (5.0,2.3,3.3,1.0,1),
 (4.9,2.5,4.5,1.7,2),
@@ -445,15 +445,15 @@ INSERT INTO %s.sqlflow_test_iris_train VALUES
 (5.6,2.9,3.6,1.3,1),
 (4.8,3.1,1.6,0.2,0);
 
-DROP TABLE IF EXISTS %s.sqlflow_test_iris_test;
-CREATE TABLE %s.sqlflow_test_iris_test(
+DROP TABLE IF EXISTS %[1]s.sqlflow_test_iris_test;
+CREATE TABLE %[1]s.sqlflow_test_iris_test(
        sepal_length DOUBLE,
        sepal_width  DOUBLE,
        petal_length DOUBLE,
        petal_width  DOUBLE,
        class BIGINT);
 
-INSERT INTO %s.sqlflow_test_iris_test VALUES
+INSERT INTO %[1]s.sqlflow_test_iris_test VALUES
 (6.3,2.7,4.9,1.8,2),
 (5.7,2.8,4.1,1.3,1),
 (5.0,3.0,1.6,0.2,0),
@@ -465,8 +465,8 @@ INSERT INTO %s.sqlflow_test_iris_test VALUES
 (4.8,3.0,1.4,0.1,0),
 (5.5,2.4,3.7,1.0,1);
 
-DROP TABLE IF EXISTS %s.sqlflow_test_iris_empty;
-CREATE TABLE %s.sqlflow_test_iris_empty (
+DROP TABLE IF EXISTS %[1]s.sqlflow_test_iris_empty;
+CREATE TABLE %[1]s.sqlflow_test_iris_empty (
        sepal_length DOUBLE,
        sepal_width  DOUBLE,
        petal_length DOUBLE,


### PR DESCRIPTION
Add one end to end test for submitting jobs in the internal environment. To run the test:

```bash
export SQLFLOW_submitter=pai
export SQLFLOW_TEST_DB=maxcompute
export MAXCOMPUTE_PROJECT="xxx"
export MAXCOMPUTE_ENDPOINT="xxx"
export MAXCOMPUTE_AK="xxx"
export MAXCOMPUTE_SK="xxx"
cd cmd/sqlflowserver && go test -v -run TestEnd2EndMaxComputePAI
```