### PR TITLE
[parser] Make Calcite parser support create statement

### DIFF
--- a/java/parser/pom.xml
+++ b/java/parser/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-core</artifactId>
+            <artifactId>calcite-server</artifactId>
             <version>1.19.0</version>
         </dependency>
         <dependency>

--- a/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
+++ b/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
@@ -5,6 +5,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl;
 
 public class CalciteParserAdaptor {
 
@@ -28,8 +29,10 @@ public class CalciteParserAdaptor {
 
     int accumulated_position = 0;
     while (true) {
+      SqlParser.Config sqlParserConfig =
+          SqlParser.configBuilder().setParserFactory(SqlDdlParserImpl.FACTORY).build();
       try {
-        SqlParser parser = SqlParser.create(sql);
+        SqlParser parser = SqlParser.create(sql, sqlParserConfig);
         SqlNode sqlnode = parser.parseQuery();
         parse_result.Statements.add(sql);
         return parse_result;
@@ -39,7 +42,7 @@ public class CalciteParserAdaptor {
         int epos = posToIndex(sql, line, column);
 
         try {
-          SqlParser parser = SqlParser.create(sql.substring(0, epos));
+          SqlParser parser = SqlParser.create(sql.substring(0, epos), sqlParserConfig);
           SqlNode sqlnode = parser.parseQuery();
 
           // parseQuery doesn't throw exception

--- a/java/parser/src/test/java/org/sqlflow/parser/CalciteParserAdaptorTest.java
+++ b/java/parser/src/test/java/org/sqlflow/parser/CalciteParserAdaptorTest.java
@@ -30,6 +30,16 @@ public class CalciteParserAdaptorTest {
             + "        HAVING SUM(priceEach * quantityOrdered) > 60000)");
 
     {
+      String sql = "create table ttt as (select * from iris.train)";
+      String sql_program = String.format("%s;", sql);
+      ParseResult parse_result = (new CalciteParserAdaptor()).ParseAndSplit(sql_program);
+      assertEquals(-1, parse_result.Position);
+      assertEquals("", parse_result.Error);
+      assertEquals(1, parse_result.Statements.size());
+      assertEquals(sql, parse_result.Statements.get(0));
+    }
+
+    {
       String sql_program =
           "SELECT *\n"
               + "FROM iris.train\n"


### PR DESCRIPTION
Need to enable DDL extension to support parsing on create statements.

DDL Calcite Doc: https://calcite.apache.org/docs/reference.html#ddl-extensions

StackOverflow Solution: https://stackoverflow.com/questions/53801005/apache-calcite-cant-seem-to-parse-ddl-statements
