### PR TITLE
Enable text highlighting in magic cells

### DIFF
--- a/scripts/docker/install-jupyter.bash
+++ b/scripts/docker/install-jupyter.bash
@@ -23,3 +23,15 @@ mkdir -p /workspace
 echo 'get_ipython().magic(u"%reload_ext sqlflow.magic")' >> $IPYTHON_STARTUP/00-first.py
 echo 'get_ipython().magic(u"%reload_ext autoreload")' >> $IPYTHON_STARTUP/00-first.py
 echo 'get_ipython().magic(u"%autoreload 2")' >> $IPYTHON_STARTUP/00-first.py
+
+# Enable highlighting, see https://stackoverflow.com/questions/43641362
+mkdir -p $HOME/.jupyter/custom/
+echo '
+require(['notebook/js/codecell'], function(codecell) {
+  codecell.CodeCell.options_default.highlight_modes['magic_text/x-mysql'] = {'reg':[/^%%sqlflow/]} ;
+  Jupyter.notebook.events.one('kernel_ready.Kernel', function(){
+  Jupyter.notebook.get_cells().map(function(cell){
+      if (cell.cell_type == 'code'){ cell.auto_highlight(); } }) ;
+  });
+});
+' > $HOME/.jupyter/custom/custom.js


### PR DESCRIPTION
Fix #1381 .
The result on my MacBook looks like:
![image](https://user-images.githubusercontent.com/4180295/70895406-dce58a00-2029-11ea-946b-c17f19617659.png)
Most of the keywords show color correctly. I'll later try to find a way to highlight the extended keyword correctly. (Probably in a different color.)