### PR TITLE
Remove  train.shuffle attribute to avoid CRON job failed on CI

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -952,7 +952,6 @@ WITH
 			model.eval_metrics_fn = "eval_metrics_fn",
 			model.num_classes = 3,
 			model.dataset_fn = "dataset_fn",
-			train.shuffle = 120,
 			train.epoch = 2,
 			train.grads_to_wait = 2,
 			train.tensorboard_log_dir = "",

--- a/python/test_magic_elasticdl.py
+++ b/python/test_magic_elasticdl.py
@@ -25,7 +25,6 @@ class TestSQLFlowMagic(unittest.TestCase):
 		TO TRAIN ElasticDLKerasClassifier 
 		WITH
 			model.num_classes = 10,
-			train.shuffle = 120,
 			train.epoch = 2,
 			train.grads_to_wait = 2,
 			train.tensorboard_log_dir = "",


### PR DESCRIPTION
temporary fix #1502 