### PR TITLE
Fix the 'Cannot infer num from shape <unknown>' error

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -274,6 +274,7 @@ func TestEnd2EndMySQL(t *testing.T) {
 	t.Run("TestShowDatabases", CaseShowDatabases)
 	t.Run("TestSelect", CaseSelect)
 	t.Run("TestTrainSQL", CaseTrainSQL)
+	t.Run("TestTrainBoostedTreesEstimator", CaseTrainBoostedTreesEstimator)
 	t.Run("CaseTrainSQLWithMetrics", CaseTrainSQLWithMetrics)
 	t.Run("TestTextClassification", CaseTrainTextClassification)
 	t.Run("CaseTrainTextClassificationCustomLSTM", CaseTrainTextClassificationCustomLSTM)
@@ -663,6 +664,21 @@ FROM %s.%s LIMIT 5;`, caseDB, casePredictTable)
 		for ; nilCount < 4 && row[nilCount] == nil; nilCount++ {
 		}
 		a.False(nilCount == 4)
+	}
+}
+
+func CaseTrainBoostedTreesEstimator(t *testing.T) {
+	a := assert.New(t)
+	trainSQL := fmt.Sprintf(`
+	SELECT * FROM %s.%s TO TRAIN BoostedTreesRegressor
+	WITH
+		model.n_batches_per_layer=300
+	LABEL class
+	INTO %s;
+	`, caseDB, caseTrainTable, caseDB)
+	_, _, err := connectAndRunSQL(trainSQL)
+	if err != nil {
+		a.Fail("Run trainSQL error: %v", err)
 	}
 }
 

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -675,7 +675,7 @@ func CaseTrainBoostedTreesEstimator(t *testing.T) {
 		model.n_batches_per_layer=300
 	LABEL class
 	INTO %s;
-	`, caseDB, caseTrainTable, caseDB)
+	`, caseDB, caseTrainTable, caseInto)
 	_, _, err := connectAndRunSQL(trainSQL)
 	if err != nil {
 		a.Fail("Run trainSQL error: %v", err)

--- a/pkg/sql/codegen/xgboost/template_analyze.go
+++ b/pkg/sql/codegen/xgboost/template_analyze.go
@@ -51,7 +51,7 @@ def analyzer_dataset():
     ys = pd.DataFrame(columns=[label_name])
     i = 0
     for row in stream():
-        xs.loc[i] = row[0]
+        xs.loc[i] = [item[0] for item in row[0]]
         ys.loc[i] = row[1]
         i += 1
     return xs, ys

--- a/python/sqlflow_submitter/db.py
+++ b/python/sqlflow_submitter/db.py
@@ -152,7 +152,7 @@ def db_generator(driver, conn, statement,
                 else:
                     raise ValueError('unrecognize dtype {}'.format(feature_spec[feature_name]["dtype"]))
             else:
-                return raw_val
+                return (raw_val,)
 
     def reader():
         if driver == "hive":
@@ -189,7 +189,7 @@ def db_generator(driver, conn, statement,
                 features = []
                 for name in feature_column_names:
                     feature = read_feature(row[field_names.index(name)], feature_specs[name], name)
-                    features.append([feature])
+                    features.append(feature)
                 yield tuple(features), label
             if len(rows) < fetch_size:
                 break

--- a/python/sqlflow_submitter/db.py
+++ b/python/sqlflow_submitter/db.py
@@ -189,8 +189,8 @@ def db_generator(driver, conn, statement,
                 features = []
                 for name in feature_column_names:
                     feature = read_feature(row[field_names.index(name)], feature_specs[name], name)
-                    features.append(feature)
-                yield (tuple(features), [label])
+                    features.append([feature])
+                yield tuple(features), label
             if len(rows) < fetch_size:
                 break
         cursor.close()

--- a/python/sqlflow_submitter/db_test.py
+++ b/python/sqlflow_submitter/db_test.py
@@ -163,9 +163,9 @@ class TestGenerator(TestCase):
             idx = 0
             for d in gen():
                 if idx == 0:
-                    self.assertEqual(d, ((1.0,), [0]))
+                    self.assertEqual(d, (((1.0,),), 0))
                 elif idx == 1:
-                    self.assertEqual(d, ((2.0,), [1]))
+                    self.assertEqual(d, (((2.0,),), 1))
                 idx += 1
             self.assertEqual(idx, 2)
 

--- a/python/sqlflow_submitter/tensorflow/estimator_example.py
+++ b/python/sqlflow_submitter/tensorflow/estimator_example.py
@@ -65,7 +65,7 @@ label_meta = {
     "feature_name": "class",
     "dtype": "int64",
     "delimiter": "",
-    "shape": [1],
+    "shape": [],
     "is_sparse": "false" == "true"
 }
 

--- a/python/sqlflow_submitter/tensorflow/input_fn.py
+++ b/python/sqlflow_submitter/tensorflow/input_fn.py
@@ -43,9 +43,10 @@ def input_fn(select, conn, feature_column_names, feature_metas, label_meta):
         # NOTE: vector columns like 23,21,3,2,0,0 should use shape None
         if feature_metas[name]["is_sparse"]:
             feature_types.append((tf.int64, tf.int32, tf.int64))
+            shapes.append((None, None, None))
         else:
             feature_types.append(get_dtype(feature_metas[name]["dtype"]))
-        shapes.append(feature_metas[name]["shape"])
+            shapes.append(feature_metas[name]["shape"])
 
     gen = db_generator(conn.driver, conn, select, feature_column_names, label_meta["feature_name"], feature_metas)
     dataset = tf.data.Dataset.from_generator(gen,

--- a/python/sqlflow_submitter/tensorflow/metrics.py
+++ b/python/sqlflow_submitter/tensorflow/metrics.py
@@ -30,11 +30,11 @@ def get_tf_metrics(metrics):
         for mn in metrics:
             metric = eval("tf.keras.metrics.%s()" % mn)
             if mn in metric_names_use_class_id:
-                metric.update_state(y_true=labels, y_pred=predictions["class_ids"])
+                metric.update_state(y_true=[labels], y_pred=predictions["class_ids"])
             elif mn in metric_names_use_probabilities:
-                metric.update_state(y_true=labels, y_pred=predictions["probabilities"])
+                metric.update_state(y_true=[labels], y_pred=predictions["probabilities"])
             elif mn in metric_names_use_predictions:
-                metric.update_state(y_true=labels, y_pred=predictions["predictions"])
+                metric.update_state(y_true=[labels], y_pred=predictions["predictions"])
             metric_dict[mn] = metric
         return metric_dict
     return tf_metrics_func

--- a/python/sqlflow_submitter/tensorflow/predict.py
+++ b/python/sqlflow_submitter/tensorflow/predict.py
@@ -142,7 +142,7 @@ def estimator_predict(estimator, model_params, save, result_table,
             result = fast_predictor.predict(features)
             row = []
             for idx, _ in enumerate(feature_column_names):
-                val = features[0][idx]
+                val = features[0][idx][0]
                 row.append(str(val))
             if "class_ids" in list(result)[0]:
                 row.append(str(list(result)[0]["class_ids"][0]))

--- a/python/sqlflow_submitter/tensorflow/predict.py
+++ b/python/sqlflow_submitter/tensorflow/predict.py
@@ -91,7 +91,7 @@ def keras_predict(estimator, model_params, save, result_table,
             result = classifier_pkg.prepare_prediction_column(result[0])
             row = []
             for idx, name in enumerate(feature_column_names):
-                val = features[0][name].numpy()[0]
+                val = features[0][name].numpy()[0][0]
                 row.append(str(val))
             row.append(str(result))
             w.write(row)

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -74,7 +74,7 @@ def keras_train_and_save(estimator, model_params, save,
         loss=classifier_pkg.loss,
         metrics=keras_metrics)
     if hasattr(classifier, 'sqlflow_train_loop'):
-        def flatten(feature, label):  # TODO(shendiaomo): This is temporary
+        def flatten(feature, label):  # TODO(shendiaomo): Modify the cluster model to adapt the new input structure
             for k in feature:
                 feature[k] = feature[k][0]
             return feature, [label]

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -74,7 +74,11 @@ def keras_train_and_save(estimator, model_params, save,
         loss=classifier_pkg.loss,
         metrics=keras_metrics)
     if hasattr(classifier, 'sqlflow_train_loop'):
-        classifier.sqlflow_train_loop(train_dataset)
+        def flatten(feature, label):  # TODO(shendiaomo): This is temporary
+            for k in feature:
+                feature[k] = feature[k][0]
+            return feature, [label]
+        classifier.sqlflow_train_loop(train_dataset.map(flatten))
     else:
         if label_meta["feature_name"] != "":
             history = classifier.fit(train_dataset,

--- a/python/sqlflow_submitter/xgboost/train.py
+++ b/python/sqlflow_submitter/xgboost/train.py
@@ -19,7 +19,7 @@ def xgb_dataset(conn, fn, dataset_sql, feature_column_name, label_name, feature_
     with open(fn, 'w') as f:
         for item in gen():
             features, label = item
-            row_data = [str(label[0])] + ["%d:%f" % (i, v) for i, v in enumerate(features)]
+            row_data = [str(label)] + ["%d:%f" % (i, v[0]) for i, v in enumerate(features)]
             f.write("\t".join(row_data) + "\n")
     # TODO(yancey1989): generate group and weight text file if necessary
     return xgb.DMatrix(fn)


### PR DESCRIPTION
Fix #1546 
The fix provides an appropriate argument to the `shape` parameter of `from_generator` in `input_fn.py`.
This change affects all that depends on the input dataset, we have to modify every place to stack/flatten the input features.