### PR TITLE
Speicify namenode addr in session or hdfs cli configuration file

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -91,7 +91,11 @@ func connectAndRunSQL(sql string) ([]string, [][]*any.Any, error) {
 }
 
 func sqlRequest(sql string) *pb.Request {
-	se := &pb.Session{Token: "user-unittest", DbConnStr: dbConnStr}
+	se := &pb.Session{
+		Token:            "user-unittest",
+		DbConnStr:        dbConnStr,
+		HdfsNamenodeAddr: os.Getenv("SQLFLOW_TEST_NAMENODE_ADDR"),
+	}
 	return &pb.Request{Sql: sql, Session: se}
 }
 

--- a/pkg/sqlfs/hive_writer_test.go
+++ b/pkg/sqlfs/hive_writer_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -46,7 +47,7 @@ func TestSQLFSNewHiveWriter(t *testing.T) {
 	t.Logf("Confirm executed with %s", db.DriverName)
 
 	tbl := fmt.Sprintf("%s%d", testDatabaseName, rand.Int())
-	w, e := newHiveWriter(db.DB, "/hivepath", tbl, "", "", bufSize)
+	w, e := newHiveWriter(db.DB, "/hivepath", tbl, "", "", os.Getenv("SQLFLOW_TEST_HDFS_NAMENODE_ADDR"), bufSize)
 	a.NoError(e)
 	a.NotNil(w)
 
@@ -70,7 +71,7 @@ func TestSQLFSHiveWriterWriteAndRead(t *testing.T) {
 	t.Logf("Confirm executed with %s", db.DriverName)
 
 	tbl := fmt.Sprintf("%s%d", testDatabaseName, rand.Int())
-	w, e := newHiveWriter(db.DB, "/hivepath", tbl, "", "", bufSize)
+	w, e := newHiveWriter(db.DB, "/hivepath", tbl, "", "", os.Getenv("SQLFLOW_TEST_HDFS_NAMENODE_ADDR"), bufSize)
 	a.NoError(e)
 	a.NotNil(w)
 

--- a/pkg/sqlfs/writer.go
+++ b/pkg/sqlfs/writer.go
@@ -26,7 +26,7 @@ const bufSize = 32 * 1024
 // returns a writer.
 func Create(db *sql.DB, dbms, table string, session *pb.Session) (io.WriteCloser, error) {
 	if dbms == "hive" {
-		return newHiveWriter(db, session.HiveLocation, table, session.HdfsUser, session.HdfsPass, bufSize)
+		return newHiveWriter(db, session.HiveLocation, table, session.HdfsUser, session.HdfsPass, session.HdfsNamenodeAddr, bufSize)
 	}
 	return newSQLWriter(db, dbms, table, bufSize)
 }

--- a/python/sqlflow_submitter/db_writer/hive.py
+++ b/python/sqlflow_submitter/db_writer/hive.py
@@ -86,10 +86,7 @@ class HiveDBWriter(BufferedDBWriter):
             hdfs_path = os.getenv("SQLFLOW_HIVE_LOCATION_ROOT_PATH", "/sqlflow")
         else:
             hdfs_path = self.hive_location
-        if self.hdfs_namenode_addr == "":
-            namenode_addr = os.getenv("SQLFLOW_HDFS_NAMENODE_ADDR", "127.0.0.1:8020")
-        else:
-            namenode_addr = self.hdfs_namenode_addr
+        
         # upload CSV to HDFS
         hdfs_envs = os.environ.copy()
         if self.hdfs_user != "":
@@ -97,8 +94,8 @@ class HiveDBWriter(BufferedDBWriter):
         if self.hdfs_pass != "":
             hdfs_envs.update({"HADOOP_USER_PASSWORD": self.hdfs_pass})
         # if namenode_addr is not set, use local hdfs command's configuration.
-        if namenode_addr != "":
-            cmd_namenode_str = "-fs hdfs://%s" % (namenode_addr)
+        if self.hdfs_namenode_addr != "":
+            cmd_namenode_str = "-fs hdfs://%s" % (self.hdfs_namenode_addr)
         else:
             cmd_namenode_str = ""
         cmd_str = "hdfs dfs %s -mkdir -p %s/%s/" % (cmd_namenode_str, hdfs_path, self.table_name)

--- a/scripts/test/hive.sh
+++ b/scripts/test/hive.sh
@@ -30,6 +30,7 @@ set -e
 hdfs dfs -rm -r -f hdfs://localhost:8020/sqlflow
 hdfs dfs -mkdir -p hdfs://localhost:8020/sqlflow
 export SQLFLOW_HIVE_LOCATION_ROOT_PATH=/sqlflow
+export SQLFLOW_TEST_NAMENODE_ADDR="127.0.0.1:8020"
 
 export SQLFLOW_TEST_DB=hive
 # NOTE: we have already installed sqlflow_submitter under python installation path


### PR DESCRIPTION
HDFS namenode addr has two ways to configure:
1. set env `SQLFLOW_HDFS_NAMENODE_ADDR` with `repl`.
2. Specify it in the HDFS cli configuration file.
