### PR TITLE
Try upgrade base image from Ubuntu 16.04 to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # The default source archive.ubuntu.com is busy and slow. We use the following source makes docker build running faster.
 RUN echo '\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ deb http://us.archive.ubuntu.com/ubuntu/ xenial-proposed main restricted univers
 deb http://us.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse \n\
 ' > /etc/apt/sources.list
 
+RUN apt-get update
+
 # Install wget, curl, unzip, bzip2, git
 COPY scripts/docker/install-download-tools.bash /
 RUN /install-download-tools.bash

--- a/scripts/docker/install-download-tools.bash
+++ b/scripts/docker/install-download-tools.bash
@@ -15,5 +15,4 @@
 
 set -e
 
-apt-get update
 apt-get install -y curl wget bzip2 unzip git

--- a/scripts/docker/install-elasticdl.bash
+++ b/scripts/docker/install-elasticdl.bash
@@ -16,7 +16,7 @@
 set -e
 
 # Install ElasticDL and kubectl.
-apt-get update && apt-get install -y docker.io sudo
+apt-get install -y docker.io sudo
 curl -sLo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 git clone https://github.com/sql-machine-learning/elasticdl.git
 cd elasticdl

--- a/scripts/docker/install-java.bash
+++ b/scripts/docker/install-java.bash
@@ -15,5 +15,5 @@
 
 set -e
 
-apt-get update && apt-get install -y openjdk-8-jdk maven
+apt-get install -y openjdk-8-jdk maven
 

--- a/scripts/docker/install-mysql.bash
+++ b/scripts/docker/install-mysql.bash
@@ -15,14 +15,10 @@
 
 set -e
 
-apt-get update 
-
-apt-get install -y libmysqlclient-dev
-
 # Install MySQL server without a password prompt
 echo 'mysql-server mysql-server/root_password password root' | debconf-set-selections
 echo 'mysql-server mysql-server/root_password_again password root' | debconf-set-selections
-apt-get update && apt-get install -y mysql-server
+apt-get install -y libmysqlclient-dev mysql-server
 mkdir -p /var/run/mysqld
 mkdir -p /var/lib/mysql
 chown mysql:mysql /var/run/mysqld

--- a/scripts/docker/install-python.bash
+++ b/scripts/docker/install-python.bash
@@ -16,7 +16,7 @@
 set -e
 
 # pip install mysqlclient needs GCC.
-apt-get update && apt-get install -y build-essential
+apt-get install -y build-essential
 
 # We use miniconda to maintain the Python environment so we can install SQLFlow's submitter 
 # template Python files to the canonical path /miniconda/envs/sqlflow-dev/lib/python3.6/site-packages/.


### PR DESCRIPTION
Currently, we use Miniconda to install Python 3.6 in the Docker image.  This seems redundant as containers are virtualenvs. Before I try to remove Miniconda, I want to make sure that apt-get could install Python 3.6. However, the default Python 3 version on Ubuntu 16.04 is 3.5. So, I am trying to upgrade the base image to Ubuntu 18.04, whose default Python 3 version is 3.6.