### PR TITLE
Retry upgrade Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ deb http://us.archive.ubuntu.com/ubuntu/ xenial-proposed main restricted univers
 deb http://us.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse \n\
 ' > /etc/apt/sources.list
 
+RUN apt-get update && apt-get upgrade -y
+
 # Install wget, curl, unzip, bzip2, git
 COPY scripts/docker/install-download-tools.bash /
 RUN /install-download-tools.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # The default source archive.ubuntu.com is busy and slow. We use the following source makes docker build running faster.
 RUN echo '\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM ubuntu:18.04
 
 # The default source archive.ubuntu.com is busy and slow. We use the following source makes docker build running faster.
 RUN echo '\n\
-deb http://us.archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse \n\
-deb http://us.archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse \n\
-deb http://us.archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse \n\
-deb http://us.archive.ubuntu.com/ubuntu/ xenial-proposed main restricted universe multiverse \n\
-deb http://us.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse \n\
+deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse \n\
+deb http://us.archive.ubuntu.com/ubuntu/ bionic-security main restricted universe multiverse \n\
+deb http://us.archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse \n\
+deb http://us.archive.ubuntu.com/ubuntu/ bionic-proposed main restricted universe multiverse \n\
+deb http://us.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse \n\
 ' > /etc/apt/sources.list
 
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update
 
 # Install wget, curl, unzip, bzip2, git
 COPY scripts/docker/install-download-tools.bash /

--- a/scripts/docker/install-download-tools.bash
+++ b/scripts/docker/install-download-tools.bash
@@ -15,5 +15,4 @@
 
 set -e
 
-apt-get update
-apt-get install -y curl wget bzip2 unzip git
+apt-get install -y curl wget unzip git

--- a/scripts/tensorflow_step_image/Dockerfile
+++ b/scripts/tensorflow_step_image/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:16.04
 
 # The default source archive.ubuntu.com is busy and slow. We use the following source makes docker build running faster.
 RUN echo '\n\
-deb http://cn.archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse \n\
-deb http://cn.archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse \n\
-deb http://cn.archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse \n\
-deb http://cn.archive.ubuntu.com/ubuntu/ xenial-proposed main restricted universe multiverse \n\
-deb http://cn.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse \n\
+deb http://cn.archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse \n\
+deb http://cn.archive.ubuntu.com/ubuntu/ bionic-security main restricted universe multiverse \n\
+deb http://cn.archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse \n\
+deb http://cn.archive.ubuntu.com/ubuntu/ bionic-proposed main restricted universe multiverse \n\
+deb http://cn.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse \n\
 ' > /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y openjdk-8-jdk maven


### PR DESCRIPTION
This follows up https://github.com/sql-machine-learning/sqlflow/pull/1598

A direct necessity of upgrading Ubuntu is to use modern Python. Applications like SHAP requires Python >=3.6, which is not officially supported on Ubuntu 16.04.  Miniconda could build from source code with patches, but Miniconda is not a reasonable dependency when we are using Docker.