### PR TITLE
Add Alisa submitter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.17.0 // indirect
+	sqlflow.org/goalisa v0.0.0-20200102084343-1d6bdf1016f5
 	sqlflow.org/gohive v0.0.0-20191009030413-2b2325ce8b38
 	sqlflow.org/gomaxcompute v0.0.0-20191028113124-e214922c510c
 )

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -489,6 +490,8 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:w
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:L5q+DGLGOQFpo1snNEkLOJT2d1YTW66rWNzatr3He1k=
+sqlflow.org/goalisa v0.0.0-20200102084343-1d6bdf1016f5 h1:O2LQOgzRYWTg5zeWEBQxJDJttYz1pw6l85Pd+BkzTs4=
+sqlflow.org/goalisa v0.0.0-20200102084343-1d6bdf1016f5/go.mod h1:LV+g0REt+Th85EutzxbJa1W2GAH0IhNcXT9VLco7eVo=
 sqlflow.org/gohive v0.0.0-20191009030413-2b2325ce8b38 h1:AIJwoPuFBMLtiivuvZdqvdvFQ+xTo22WJAymcG6FX50=
 sqlflow.org/gohive v0.0.0-20191009030413-2b2325ce8b38/go.mod h1:IudT38uGbK5q+Ztx2AsZDzjc04yBsIOUtIDMh/WSJkk=
 sqlflow.org/gomaxcompute v0.0.0-20191028113124-e214922c510c h1:rbxu1RC8cU8zkEr5CE8Oc6kmvMyXcGoaMr0J5gOARMw=

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -20,6 +20,7 @@ import (
 
 	// import drivers for heterogenous DB support
 	_ "github.com/go-sql-driver/mysql"
+	_ "sqlflow.org/goalisa"
 	_ "sqlflow.org/gohive"
 	_ "sqlflow.org/gomaxcompute"
 )

--- a/pkg/sql/alisa_submitter.go
+++ b/pkg/sql/alisa_submitter.go
@@ -1,0 +1,55 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"fmt"
+
+	"sqlflow.org/sqlflow/pkg/database"
+	"sqlflow.org/sqlflow/pkg/pipe"
+	pb "sqlflow.org/sqlflow/pkg/proto"
+	"sqlflow.org/sqlflow/pkg/sql/ir"
+)
+
+type alisaSubmitter struct {
+}
+
+func (s *alisaSubmitter) ExecuteQuery(cl *ir.StandardSQL) error {
+	return nil
+}
+
+func (s *alisaSubmitter) ExecuteTrain(cl *ir.TrainStmt) error {
+	// TODO: implement submit train task:
+	//
+	// code := pai.Train(cl, cl.Into, pai.s.Cwd)
+	// cmd.Execute("tar", "czf", "train.tar.gz", pai.s.Cwd)
+	// cmd.Execute("osscmd", "cp", "train.tar.gz", "oss://sqlflow-bucket/...")
+	// goalisa.createTask("pai -name tensorflow1120 -Dscript=@@train.tar.gz",
+	// 	res_download_url={downloadUrl:"http://oss-endpoint/train.tar.gz", "resourceName":"train.tar.gz"})
+	return nil
+}
+
+func (s *alisaSubmitter) ExecutePredict(cl *ir.PredictStmt) error {
+	return nil
+}
+
+func (s *alisaSubmitter) ExecuteExplain(cl *ir.ExplainStmt) error {
+	return fmt.Errorf("Alisa submitter does not support EXPLAIN clause")
+}
+
+func (s *alisaSubmitter) Setup(w *pipe.Writer, db *database.DB, modelDir string, cwd string, session *pb.Session) {
+}
+
+func (s *alisaSubmitter) GetTrainStmtFromModel() bool { return false }
+func init()                                           { SubmitterRegister("alisa", &alisaSubmitter{}) }

--- a/pkg/sql/alisa_submitter_test.go
+++ b/pkg/sql/alisa_submitter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The SQLFlow Authors. All rights reserved.
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,25 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package database
+package sql
 
 import (
-	"database/sql"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDatabaseParseURL(t *testing.T) {
+func TestAlisaSubmitter(t *testing.T) {
 	a := assert.New(t)
-	driver, dataSource, e := ParseURL(testingMySQLURL())
-	a.EqualValues(driver, "mysql")
-	a.EqualValues(dataSource, "root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0")
-	a.NoError(e)
-}
-
-func TestDriverList(t *testing.T) {
-	a := assert.New(t)
-	expected := []string{"alisa", "hive", "maxcompute", "mysql"}
-	a.EqualValues(expected, sql.Drivers())
+	os.Setenv("SQLFLOW_submitter", "alisa")
+	defer os.Setenv("SQLFLOW_submitter", "")
+	_, ok := GetSubmitter().(*alisaSubmitter)
+	a.True(ok)
 }

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -140,4 +140,4 @@ func (s *paiSubmitter) ExecutePredict(cl *ir.PredictStmt) error {
 }
 
 func (s *paiSubmitter) GetTrainStmtFromModel() bool { return false }
-func init()                                         { submitterRegistry["pai"] = &paiSubmitter{&defaultSubmitter{}} }
+func init()                                         { SubmitterRegister("pai", &paiSubmitter{}) }

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -31,15 +31,25 @@ import (
 	"sqlflow.org/sqlflow/pkg/sql/ir"
 )
 
-var envSubmitter = os.Getenv("SQLFLOW_submitter")
-
 var submitterRegistry = map[string](Submitter){
 	"default": &defaultSubmitter{},
 	// TODO(typhoonzero): add submitters like alps, elasticdl
 }
 
+// SubmitterRegister registes a submitter
+func SubmitterRegister(name string, submitter Submitter) {
+	if submitter == nil {
+		panic("submitter: Register submitter twice")
+	}
+	if _, dup := submitterRegistry[name]; dup {
+		panic("submitter: Register called twice")
+	}
+	submitterRegistry[name] = submitter
+}
+
 // GetSubmitter returns a proper Submitter from configuations in environment variables.
 func GetSubmitter() Submitter {
+	envSubmitter := os.Getenv("SQLFLOW_submitter")
 	s := submitterRegistry[envSubmitter]
 	if s == nil {
 		s = submitterRegistry["default"]

--- a/pkg/sql/submitter_test.go
+++ b/pkg/sql/submitter_test.go
@@ -21,8 +21,9 @@ import (
 
 func TestSubmitterRegistry(t *testing.T) {
 	a := assert.New(t)
-	a.Equal(2, len(submitterRegistry))
+	a.Equal(3, len(submitterRegistry))
 	a.NotNil(submitterRegistry["pai"])
 	a.NotNil(submitterRegistry["default"])
+	a.NotNil(submitterRegistry["alisa"])
 	a.Equal(GetSubmitter(), submitterRegistry["default"])
 }


### PR DESCRIPTION
part of #1321 

This PR import `goalisa` and add `alisaSubmitter` struct.

Before I continue to implement `alisaSubmitter`, I would like to clean up `submitter` code,  move the existing submitter code to `pkg/submitter`.
 