### PR TITLE
add submitter package

### DIFF
--- a/pkg/submitter/submitter.go
+++ b/pkg/submitter/submitter.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submitter
+
+import (
+	"sort"
+
+	"sqlflow.org/sqlflow/pkg/database"
+	"sqlflow.org/sqlflow/pkg/pipe"
+	"sqlflow.org/sqlflow/pkg/sql/ir"
+
+	pb "sqlflow.org/sqlflow/pkg/proto"
+)
+
+var submitterRegistry = make(map[string]Submitter)
+
+// Submitter submites the generated program by code generator
+type Submitter interface {
+	ir.Executor
+	Setup(*pipe.Writer, *database.DB, string, string, *pb.Session)
+	GetTrainStmtFromModel() bool
+}
+
+// Register makes a submitter available by the providing name,
+// if the submitter has already registered or registered twice,
+// it panics.
+func Register(name string, submitter Submitter) {
+	if submitter == nil {
+		panic("submitter: Register submitter twice")
+	}
+	if _, dup := submitterRegistry[name]; dup {
+		panic("submitter: Register called twice")
+	}
+	submitterRegistry[name] = submitter
+}
+
+// Submitters returens a list of the registered submitter name
+func Submitters() []string {
+	list := []string{}
+	for name := range submitterRegistry {
+		list = append(list, name)
+	}
+	sort.Strings(list)
+	return list
+}

--- a/pkg/submitter/submitter_test.go
+++ b/pkg/submitter/submitter_test.go
@@ -30,7 +30,7 @@ func (s *TestSubmitter) ExecuteTrain(cl *ir.TrainStmt) error     { return nil }
 func (s *TestSubmitter) ExecutePredict(cl *ir.PredictStmt) error { return nil }
 func (s *TestSubmitter) ExecuteExplain(cl *ir.ExplainStmt) error { return nil }
 func (s *TestSubmitter) GetTrainStmtFromModel() bool             { return true }
-func (s *TestSubmitter) Setup(w *pipe.Writer, db *database.DB, modelDir string, cwd string, session *pb.Session) {
+func (s *TestSubmitter) setup(w *pipe.Writer, db *database.DB, modelDir string, cwd string, session *pb.Session) {
 }
 
 func TestRegister(t *testing.T) {
@@ -49,4 +49,10 @@ func TestRegister(t *testing.T) {
 
 	expected := []string{"test"}
 	a.Equal(expected, Submitters())
+
+	s, err := New("test", nil, nil, "", "", nil)
+	a.NoError(err)
+
+	_, ok := s.(*TestSubmitter)
+	a.True(ok)
 }

--- a/pkg/submitter/submitter_test.go
+++ b/pkg/submitter/submitter_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submitter
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sqlflow.org/sqlflow/pkg/database"
+	"sqlflow.org/sqlflow/pkg/pipe"
+	pb "sqlflow.org/sqlflow/pkg/proto"
+	"sqlflow.org/sqlflow/pkg/sql/ir"
+
+	"testing"
+)
+
+type TestSubmitter struct{}
+
+func (s *TestSubmitter) ExecuteQuery(cl *ir.StandardSQL) error   { return nil }
+func (s *TestSubmitter) ExecuteTrain(cl *ir.TrainStmt) error     { return nil }
+func (s *TestSubmitter) ExecutePredict(cl *ir.PredictStmt) error { return nil }
+func (s *TestSubmitter) ExecuteExplain(cl *ir.ExplainStmt) error { return nil }
+func (s *TestSubmitter) GetTrainStmtFromModel() bool             { return true }
+func (s *TestSubmitter) Setup(w *pipe.Writer, db *database.DB, modelDir string, cwd string, session *pb.Session) {
+}
+
+func TestRegister(t *testing.T) {
+	a := assert.New(t)
+	a.NotPanics(func() {
+		Register("test", &TestSubmitter{})
+	})
+
+	// panic if register nil or register same submitter twice.
+	a.Panics(func() {
+		Register("test", nil)
+	})
+	a.Panics(func() {
+		Register("test", &TestSubmitter{})
+	})
+
+	expected := []string{"test"}
+	a.Equal(expected, Submitters())
+}


### PR DESCRIPTION
part of #1585 
TODO: move the existing `pai/python` submitter to the `submitter` package.
