### PR TITLE
Add explain tests

### DIFF
--- a/pkg/parser/extended_syntax_parser_test.go
+++ b/pkg/parser/extended_syntax_parser_test.go
@@ -235,6 +235,35 @@ USING TreeExplainer;`
 	a.Equal("TreeExplainer", r.Explainer)
 }
 
+func TestExtendedSyntaxParseToExplainInto(t *testing.T) {
+	a := assert.New(t)
+	s := `TO EXPLAIN my_model
+WITH plots = force
+USING TreeExplainer
+INTO db.table;`
+	r, idx, e := parseSQLFlowStmt(s)
+	a.Equal(len(s), idx) // right before ; due to the end_of_stmt syntax rule.
+	a.NoError(e)
+	a.True(r.Extended)
+	a.True(r.Explain)
+	a.Equal("db.table", r.ExplainInto)
+	a.Equal("TreeExplainer", r.Explainer)
+}
+
+func TestExtendedSyntaxParseToExplainIntoNoWith(t *testing.T) {
+	a := assert.New(t)
+	s := `TO EXPLAIN my_model
+USING TreeExplainer
+INTO db.table;`
+	r, idx, e := parseSQLFlowStmt(s)
+	a.Equal(len(s), idx) // right before ; due to the end_of_stmt syntax rule.
+	a.NoError(e)
+	a.True(r.Extended)
+	a.True(r.Explain)
+	a.Equal("db.table", r.ExplainInto)
+	a.Equal("TreeExplainer", r.Explainer)
+}
+
 func TestExtendedSyntaxParseSelectStarAndPrint(t *testing.T) {
 	a := assert.New(t)
 	s := `SELECT *, b FROM a LIMIT 10  ;  `

--- a/python/sqlflow_submitter/tensorflow/explain_example.py
+++ b/python/sqlflow_submitter/tensorflow/explain_example.py
@@ -1,0 +1,46 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sqlflow_submitter
+from sqlflow_submitter.tensorflow.train import train
+from sqlflow_submitter.tensorflow.predict import pred
+from sqlflow_submitter.tensorflow.explain import explain
+from estimator_example import datasource, select_binary, validate_select_binary, feature_column_names, feature_columns, feature_metas, label_meta
+import tensorflow as tf
+
+if __name__ == "__main__":
+    train(is_keras_model=False,
+        datasource=datasource,
+        estimator=tf.estimator.BoostedTreesClassifier,
+        select="SELECT * FROM iris.train where class!=2",
+        validate_select="SELECT * FROM iris.test where class!=2",
+        feature_columns=feature_columns,
+        feature_column_names=feature_column_names,
+        feature_metas=feature_metas,
+        label_meta=label_meta,
+        model_params={"n_batches_per_layer": 8, "n_classes": 2, "n_trees": 50, "center_bias": True},
+        save="btmodel",
+        batch_size=8,
+        epochs=20,
+        verbose=0)
+    explain(datasource=datasource,
+        estimator_cls=tf.estimator.BoostedTreesClassifier,
+        select="SELECT * FROM iris.test where class!=2",
+        feature_columns=feature_columns,
+        feature_column_names=feature_column_names,
+        feature_metas=feature_metas,
+        label_meta=label_meta,
+        model_params={"n_batches_per_layer": 8, "n_classes": 2, "n_trees": 50, "center_bias": True},
+        save="btmodel",
+        is_pai=False,
+        plot_type='bar')

--- a/python/sqlflow_submitter/tensorflow/train_predict_test.py
+++ b/python/sqlflow_submitter/tensorflow/train_predict_test.py
@@ -27,6 +27,15 @@ class TestEstimatorModels(TestCase):
         except:
             self.fail("%s" % ret.stderr)
     
+    def test_explain(self):
+        try:
+            # should run this test under directory $GOPATH/sqlflow.org/sqlflow
+            ret = subprocess.run(["/miniconda/envs/sqlflow-dev/bin/python", "python/sqlflow_submitter/tensorflow/explain_example.py"],
+                env={"PYTHONPATH": "python"})
+            self.assertEqual(ret.returncode, 0)
+        except:
+            self.fail("%s" % ret.stderr)
+    
     def test_keras(self):
         try:
             # should run this test under directory $GOPATH/sqlflow.org/sqlflow

--- a/python/sqlflow_submitter/tensorflow/train_predict_test.py
+++ b/python/sqlflow_submitter/tensorflow/train_predict_test.py
@@ -35,7 +35,7 @@ class TestEstimatorModels(TestCase):
     def test_explain(self):
         try:
             # should run this test under directory $GOPATH/sqlflow.org/sqlflow
-            ret = subprocess.run(["/miniconda/envs/sqlflow-dev/bin/python", 
+            ret = subprocess.run(["/usr/local/bin/python", 
                                   "python/sqlflow_submitter/tensorflow/explain_example.py"],
                                  env={"PYTHONPATH": "python"},
                                  check=True)


### PR DESCRIPTION
Part of https://github.com/sql-machine-learning/sqlflow/issues/1612

- add `to explain ... using ...  into` parser tests
- add  `to explain ... using ...  into` ir_generator tests
- add Tensorflow BoostedTrees python tests