### PR TITLE
Remove the call to shap.initjs() because it's useless

### DIFF
--- a/python/sqlflow_submitter/xgboost/explain.py
+++ b/python/sqlflow_submitter/xgboost/explain.py
@@ -22,8 +22,6 @@ import sys
 
 from sqlflow_submitter.db import connect_with_data_source, db_generator
 
-shap.initjs()
-
 def xgb_shap_dataset(datasource, select, feature_column_names, label_name, feature_specs):
     conn = connect_with_data_source(datasource)
     stream = db_generator(conn.driver, conn, select, feature_column_names, label_name, feature_specs)


### PR DESCRIPTION
The code
```python
shap.initjs()
```
is not useful for SQLFlow because SQLFlow saves the figures to persistent storage rather than showing the figures in the web page directly. 

Moreover,  the code in https://github.com/slundberg/shap/blob/fb6ca4a54774b9caa666d120f6cad59708adf867/shap/plots/force.py#L217 will print a message like `<IPython.core.display.HTML object>` to console, which is confusing.

