### PR TITLE
Commented out the argument as Pods crashing due to argument  ["--enab…

### DIFF
--- a/doc/k8s/sqlflow-server.yaml
+++ b/doc/k8s/sqlflow-server.yaml
@@ -19,7 +19,6 @@ spec:
         name: sqlflow-server
         imagePullPolicy: Always
         command: ["sqlflowserver"]
-        #args: ["--enable-session"]
         ports:
         - containerPort: 50051
           name: sqlflow-server

--- a/doc/k8s/sqlflow-server.yaml
+++ b/doc/k8s/sqlflow-server.yaml
@@ -19,7 +19,7 @@ spec:
         name: sqlflow-server
         imagePullPolicy: Always
         command: ["sqlflowserver"]
-        args: ["--enable-session"]
+        #args: ["--enable-session"]
         ports:
         - containerPort: 50051
           name: sqlflow-server


### PR DESCRIPTION
…le-session"]

Commented out the argument in the yaml as pods are creashing due to the below argument:
args: ["--enable-session"] this argument is not valid causing the ppod to crashback