### PR TITLE
Added The Docker Command to install configurable-http-proxy

### DIFF
--- a/doc/k8s/sqlflowhub/Dockerfile
+++ b/doc/k8s/sqlflowhub/Dockerfile
@@ -1,13 +1,13 @@
 FROM sqlflow/sqlflow
 
-##Installed npm
+# Installed npm
 RUN apt-get -y install npm
 
 RUN mkdir -p /etc/jhub && \
     bash -c "pip install jupyterhub && \
     pip install notebook"
     
-##Added to get rid of the of the Proxy Config Folder not founf Errror resulting in POD crash    
+# Added to get rid of the of the Proxy Config Folder not founf Errror resulting in POD crash    
 RUN npm install -g configurable-http-proxy
 
 COPY jupyterhub_config.py /etc/jhub/jupyterhub_config.py

--- a/doc/k8s/sqlflowhub/Dockerfile
+++ b/doc/k8s/sqlflowhub/Dockerfile
@@ -1,8 +1,14 @@
 FROM sqlflow/sqlflow
 
+##Installed npm
+RUN apt-get -y install npm
+
 RUN mkdir -p /etc/jhub && \
     bash -c "pip install jupyterhub && \
     pip install notebook"
+    
+##Added to get rid of the of the Proxy Config Folder not founf Errror resulting in POD crash    
+RUN npm install -g configurable-http-proxy
 
 COPY jupyterhub_config.py /etc/jhub/jupyterhub_config.py
 


### PR DESCRIPTION
Added The Docker Command to install configurable-http-proxy for Jupyter Hub and npm.
Without this the configuarble http proxy is missing and pods for jupyter hub are erroring out at crashback loop.
See the error below:

```
Failed to find proxy ['configurable-http-proxy']
    The proxy can be installed with `npm install -g configurable-http-proxy`.To install `npm`, install nodejs which includes `npm`.If you see an `EACCES` error or permissions error, refer to the `npm` documentation on How To Prevent Permissions Errors.
[C 2020-01-06 21:35:31.938 JupyterHub app:2349] Failed to start proxy
    Traceback (most recent call last):
      File "/usr/local/lib/python3.6/dist-packages/jupyterhub/app.py", line 2347, in start
        await self.proxy.start()
      File "/usr/local/lib/python3.6/dist-packages/jupyterhub/proxy.py", line 650, in start
        cmd, env=env, start_new_session=True, shell=shell
      File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
        restore_signals, start_new_session)
      File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'configurable-http-proxy': 'configurable-http-proxy'
    
ERROR:asyncio:Task exception was never retrieved
future: <Task finished coro=<JupyterHub.launch_instance_async() done, defined at /usr/local/lib/python3.6/dist-packages/jupyterhub/app.py:2477> exception=SystemExit(1,)>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/app.py", line 2347, in start
    await self.proxy.start()
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/proxy.py", line 650, in start
    cmd, env=env, start_new_session=True, shell=shell
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'configurable-http-proxy': 'configurable-http-proxy'
```

During handling of the above exception, another exception occurred:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/app.py", line 2492, in launch_instance
    loop.start()
  File "/usr/local/lib/python3.6/dist-packages/tornado/platform/asyncio.py", line 148, in start
    self.asyncio_loop.run_forever()
  File "/usr/lib/python3.6/asyncio/base_events.py", line 438, in run_forever
    self._run_once()
  File "/usr/lib/python3.6/asyncio/base_events.py", line 1451, in _run_once
    handle._run()
  File "/usr/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/app.py", line 2480, in launch_instance_async
    await self.start()
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/app.py", line 2350, in start
    self.exit(1)
  File "/usr/local/lib/python3.6/dist-packages/traitlets/config/application.py", line 654, in exit
    sys.exit(exit_status)
SystemExit: 1
```