### PR TITLE
Refactor to diminish duplicated code

### DIFF
--- a/python/sqlflow_submitter/explainer.py
+++ b/python/sqlflow_submitter/explainer.py
@@ -1,0 +1,42 @@
+# Copyright 2019 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+# TODO(shendiaomo): extract common code from tensorflow/explain.py and xgboost/explain.py
+# TODO(shendiaomo): add a unit test for this file later
+
+def plot_and_save(plotfunc, filename='summary'):
+    '''
+    plot_and_save plots and saves matplotlib figures using different backends
+    Args:
+        plotfunc: A callable that plot the figures
+        filename: The prefix of the figure files to be saved
+    Return:
+        None
+    '''
+
+    # The default backend 
+    plotfunc()
+    plt.savefig(filename, bbox_inches='tight')
+
+    # The plotille text backend 
+    matplotlib.use('module://plotille_text_backend')
+    import matplotlib.pyplot as plt_text_backend
+    sys.stdout.isatty = lambda:True
+    plotfunc()
+    plt_text_backend.savefig(filename, bbox_inches='tight')
+

--- a/python/sqlflow_submitter/xgboost/explain.py
+++ b/python/sqlflow_submitter/xgboost/explain.py
@@ -21,6 +21,7 @@ import pandas as pd
 import sys
 
 from sqlflow_submitter.db import connect_with_data_source, db_generator
+from sqlflow_submitter import explainer
 
 def xgb_shap_dataset(datasource, select, feature_column_names, label_name, feature_specs):
     conn = connect_with_data_source(datasource)
@@ -40,14 +41,6 @@ def xgb_shap_values(x):
     explainer = shap.TreeExplainer(bst)
     return explainer.shap_values(x)
 
-def plot_with_text_backend(fn, shap_values, features, summary_params):
-    # save {fn}.txt using the plotille text backend 
-    matplotlib.use('module://plotille_text_backend')
-    import matplotlib.pyplot as plt_text_backend
-    shap.summary_plot(shap_values, features, show=False, **summary_params)
-    sys.stdout.isatty = lambda:True
-    plt_text_backend.savefig(fn, bbox_inches='tight')
-
 def explain(datasource,
             select,
             feature_field_meta,
@@ -60,8 +53,4 @@ def explain(datasource,
     shap_values = xgb_shap_values(x)
 
     # save summary.png using the default backend
-    shap.summary_plot(shap_values, x, show=False, **summary_params)
-    plt.savefig('summary', bbox_inches='tight')
-
-    # save summary.txt using the plotille text backend 
-    plot_with_text_backend('summary', shap_values, x, summary_params)
+    explainer.plot_and_save(lambda: shap.summary_plot(shap_values, x, show=False, **summary_params))


### PR DESCRIPTION
Encapsulate text-based and image-based `savefig` into a single function in a standalone module. Other framework-independent code would be moved to `explainer.py` later.