### PR TITLE
Make WITH clause in TRAIN statement optional

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -687,6 +687,16 @@ func CaseTrainBoostedTreesEstimator(t *testing.T) {
 	}
 }
 
+func CaseTrainLinearClassifier(t *testing.T) {
+	a := assert.New(t)
+	trainSQL := fmt.Sprintf(`SELECT * FROM iris.train WHERE class !=2
+TO TRAIN LinearClassifier LABEL class INTO %s;`, caseInto)
+	_, _, err := connectAndRunSQL(trainSQL)
+	if err != nil {
+		a.Fail("Run trainSQL error: %v", err)
+	}
+}
+
 func CaseTrainSQLWithMetrics(t *testing.T) {
 	a := assert.New(t)
 	trainSQL := `SELECT * FROM iris.train WHERE class!=2

--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -252,6 +252,15 @@ train_clause
 	$$.Label = $6
 	$$.Save = $8
 }
+| TO TRAIN IDENT label_clause INTO IDENT {
+	$$.Estimator = $3
+	$$.Label = $4
+	$$.Save = $6
+}
+| TO TRAIN IDENT WITH attrs INTO IDENT {
+	$$.Estimator = $3
+	$$.Save = $5
+}
 ;
 
 predict_clause

--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -259,7 +259,8 @@ train_clause
 }
 | TO TRAIN IDENT WITH attrs INTO IDENT {
 	$$.Estimator = $3
-	$$.Save = $5
+	$$.TrainAttrs = $5
+	$$.Save = $7
 }
 ;
 


### PR DESCRIPTION
The default setting of `LinearClassifier` works well in many cases. Omitting the WITH clause is more friendly for novice users.
For example
```sql
SELECT * FROM iris.train WHERE class != 2
TO TRAIN LinearClassifier LABEL class INTO sqlflow_models.temp;
```
will get a decent result as
```python
{'accuracy': 1.0, 'accuracy_baseline': 0.54285717, 'auc': 1.0, 'auc_precision_recall': 1.0, 'average_loss': 0.23411807, 'label/mean': 0.45714286, 'loss': 0.23411807, 'precision': 1.0, 'prediction/mean': 0.56584316, 'recall': 1.0, 'global_step': 70}
```
while
```sql
SELECT * FROM iris.train WHERE class != 2
TO TRAIN DNNClassifier WITH model.hidden_units=[100, 100] LABEL class INTO sqlflow_models.temp;
```
can only achieve 
```python
{'accuracy': 0.7, 'accuracy_baseline': 0.54285717, 'auc': 1.0, 'auc_precision_recall': 1.0, 'average_loss': 0.56149596, 'label/mean': 0.45714286, 'loss': 0.56149596, 'precision': 1.0, 'prediction/mean': 0.4176486, 'recall': 0.34375, 'global_step': 70}
```

The loss of LinearClassifier with default learning rate and optimizer is less than half of the DNNClassifier with a similar setting.