### PR TITLE
Do not use init to register submitters

### DIFF
--- a/pkg/sql/alisa_submitter.go
+++ b/pkg/sql/alisa_submitter.go
@@ -52,4 +52,3 @@ func (s *alisaSubmitter) Setup(w *pipe.Writer, db *database.DB, modelDir string,
 }
 
 func (s *alisaSubmitter) GetTrainStmtFromModel() bool { return false }
-func init()                                           { SubmitterRegister("alisa", &alisaSubmitter{}) }

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -140,4 +140,3 @@ func (s *paiSubmitter) ExecutePredict(cl *ir.PredictStmt) error {
 }
 
 func (s *paiSubmitter) GetTrainStmtFromModel() bool { return false }
-func init()                                         { SubmitterRegister("pai", &paiSubmitter{}) }

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -38,17 +38,6 @@ var submitterRegistry = map[string](Submitter){
 	// TODO(typhoonzero): add submitters like alps, elasticdl
 }
 
-// SubmitterRegister registes a submitter
-func SubmitterRegister(name string, submitter Submitter) {
-	if submitter == nil {
-		panic("submitter: Register submitter twice")
-	}
-	if _, dup := submitterRegistry[name]; dup {
-		panic("submitter: Register called twice")
-	}
-	submitterRegistry[name] = submitter
-}
-
 // GetSubmitter returns a proper Submitter from configuations in environment variables.
 func GetSubmitter() Submitter {
 	envSubmitter := os.Getenv("SQLFLOW_submitter")

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -33,6 +33,8 @@ import (
 
 var submitterRegistry = map[string](Submitter){
 	"default": &defaultSubmitter{},
+	"pai":     &paiSubmitter{&defaultSubmitter{}},
+	"alisa":   &alisaSubmitter{},
 	// TODO(typhoonzero): add submitters like alps, elasticdl
 }
 


### PR DESCRIPTION
Since `submitterRegistry` is a statically initialized global, init the values in one line is much easier to know which "submitters" we are supporting.