### PR TITLE
Updated Docker File to Get rid of Jupyter Hub Login Problem to sqlflo…

### DIFF
--- a/doc/k8s/sqlflowhub/Dockerfile
+++ b/doc/k8s/sqlflowhub/Dockerfile
@@ -1,5 +1,13 @@
 FROM sqlflow/sqlflow
 
+RUN echo "root:root" | chpasswd
+RUN sudo -s
+
+RUN mkdir /home/sqlflow
+RUN chown root:root /home/sqlflow
+RUN chmod -R 755 /home/sqlflow
+RUN chmod -R 755 /root
+
 RUN mkdir -p /etc/jhub && \
     bash -c "pip install jupyterhub && \
     pip install notebook"


### PR DESCRIPTION
…w due to insufficient priviledgesin go path

Error due to Privilege issue in /home/mysql:


``` python
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/traitlets/traitlets.py", line 528, in get
    value = obj._trait_values[self.name]
KeyError: 'runtime_dir'
```

During handling of the above exception, another exception occurred:

``` python
Traceback (most recent call last):
  File "/usr/local/bin/jupyterhub-singleuser", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/singleuser.py", line 660, in main
    return SingleUserNotebookApp.launch_instance(argv)
  File "/usr/local/lib/python3.6/dist-packages/jupyter_core/application.py", line 268, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/traitlets/config/application.py", line 663, in launch_instance
    app.initialize(argv)
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/singleuser.py", line 558, in initialize
    return super().initialize(argv)
  File "</usr/local/lib/python3.6/dist-packages/decorator.py:decorator-gen-7>", line 2, in initialize
  File "/usr/local/lib/python3.6/dist-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/notebook/notebookapp.py", line 1676, in initialize
    self.init_configurables()
  File "/usr/local/lib/python3.6/dist-packages/notebook/notebookapp.py", line 1349, in init_configurables
    connection_dir=self.runtime_dir,
  File "/usr/local/lib/python3.6/dist-packages/traitlets/traitlets.py", line 556, in __get__
    return self.get(obj, cls)
  File "/usr/local/lib/python3.6/dist-packages/traitlets/traitlets.py", line 535, in get
    value = self._validate(obj, dynamic_default())
  File "/usr/local/lib/python3.6/dist-packages/jupyter_core/application.py", line 99, in _runtime_dir_default
    ensure_dir_exists(rd, mode=0o700)
  File "/usr/local/lib/python3.6/dist-packages/jupyter_core/utils/__init__.py", line 13, in ensure_dir_exists
    os.makedirs(path, mode=mode)
  File "/usr/lib/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/home/sqlflow/.local'
[I 2020-01-07 23:44:25.021 JupyterHub log:174] 302 GET /hub/spawn -> /hub/spawn-pending/sqlflow (sqlflow@::ffff:127.0.0.1) 1024.97ms
[I 2020-01-07 23:44:25.214 JupyterHub pages:303] sqlflow is pending spawn
[I 2020-01-07 23:44:25.220 JupyterHub log:174] 200 GET /hub/spawn-pending/sqlflow (sqlflow@::ffff:127.0.0.1) 24.21ms
ERROR:asyncio:Task exception was never retrieved
future: <Task finished coro=<BaseHandler.spawn_single_user() done, defined at /usr/local/lib/python3.6/dist-packages/jupyterhub/handlers/base.py:697> exception=HTTPError()>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/handlers/base.py", line 889, in spawn_single_user
    timedelta(seconds=self.slow_spawn_timeout), finish_spawn_future
tornado.util.TimeoutError: Timeout
```

ERROR DUE TO PRIVILEGE ISSUE IN ROOT AS THE BASE INSTALLATION OF THE go IS INSIDE ROOT:

Error Due to Privilege Issue In Root folder as the base installation of go is Inside It and Sqlflow user not able to access it.

``` python
Traceback (most recent call last):
  File "/usr/local/bin/jupyterhub-singleuser", line 5, in <module>
    from jupyterhub.singleuser import main
  File "/usr/local/lib/python3.6/dist-packages/jupyterhub/singleuser.py", line 41, in <module>
    from notebook.notebookapp import (
  File "/usr/local/lib/python3.6/dist-packages/notebook/notebookapp.py", line 83, in <module>
    from .services.contents.manager import ContentsManager
  File "/usr/local/lib/python3.6/dist-packages/notebook/services/contents/manager.py", line 17, in <module>
    from nbformat import sign, validate as validate_nb, ValidationError
  File "/usr/local/lib/python3.6/dist-packages/nbformat/__init__.py", line 33, in <module>
    from .validator import validate, ValidationError
  File "/usr/local/lib/python3.6/dist-packages/nbformat/validator.py", line 12, in <module>
    from jsonschema import ValidationError
  File "/usr/local/lib/python3.6/dist-packages/jsonschema/__init__.py", line 33, in <module>
    import importlib_metadata as metadata
  File "/usr/local/lib/python3.6/dist-packages/importlib_metadata/__init__.py", line 554, in <module>
    __version__ = version(__name__)
  File "/usr/local/lib/python3.6/dist-packages/importlib_metadata/__init__.py", line 516, in version
    return distribution(distribution_name).version
  File "/usr/local/lib/python3.6/dist-packages/importlib_metadata/__init__.py", line 489, in distribution
    return Distribution.from_name(distribution_name)
  File "/usr/local/lib/python3.6/dist-packages/importlib_metadata/__init__.py", line 190, in from_name
    dist = next(dists, None)
  File "/usr/local/lib/python3.6/dist-packages/importlib_metadata/__init__.py", line 432, in <genexpr>
    for path in map(cls._switch_path, paths)
  File "/usr/local/lib/python3.6/dist-packages/importlib_metadata/__init__.py", line 456, in _search_path
    if not root.is_dir():
  File "/usr/lib/python3.6/pathlib.py", line 1348, in is_dir
    return S_ISDIR(self.stat().st_mode)
  File "/usr/lib/python3.6/pathlib.py", line 1158, in stat
    return self._accessor.stat(self)
  File "/usr/lib/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
PermissionError: [Errno 13] Permission denied: '/root/go/src/sqlflow.org/sqlflow/python'
```