### PR TITLE
[CI] Speed up deployment phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,6 @@ jobs:
         - docker run --rm --net=host -e SQLFLOW_WORKFLOW_STEP_IMAGE=sqlflow:submitter -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.kube:/root/.kube -v /home/$USER/.minikube/:/home/$USER/.minikube/ -v $GOPATH:/root/go -w /root/go/src/sqlflow.org/sqlflow sqlflow:latest bash scripts/test/workflow.sh
     - stage: deploy
       script:
-        - set -e
-        - docker pull sqlflow/sqlflow:latest && docker build --cache-from sqlflow/sqlflow:latest -t sqlflow:latest -f Dockerfile .
         - bash scripts/deploy.sh
 
 env:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,6 +30,8 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     exit 0
 fi
 
+docker pull sqlflow/sqlflow:latest && docker build --cache-from sqlflow/sqlflow:latest -t sqlflow:latest -f Dockerfile .
+
 if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
         DOCKER_TAG="nightly"


### PR DESCRIPTION
Check if CI needs to deploy before building the image. This will reduce the CI time of PR by ~12 minutes.