### PR TITLE
Update Java formatter in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,10 @@
     rev: v4.3.21
     hooks:
     -   id: isort
+- repo: local
+  hooks:
+      - id: google_style_java
+        name: google_style_java
+        entry: bash ./scripts/pre-commit/google_java_format.sh
+        language: system
+        files: \.(java)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,6 @@
     - id: go-lint
     - id: validate-toml
     - id: no-go-testing
-- repo: https://github.com/wangkuiyi/google-style-precommit-hook
-  rev: v0.1.1
-  hooks:
-    - id: google-style-java
-      pass_filenames: false # https://github.com/sql-machine-learning/sqlflow/issues/1152#issuecomment-551325589
 - repo: local
   hooks:
     - id: copyright_checker

--- a/scripts/docker/install-java.bash
+++ b/scripts/docker/install-java.bash
@@ -37,4 +37,4 @@ echo '<settings>
   </mirrors>
 </settings>' > /root/.m2/settings.xml
 
-curl -sLJ "https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-1.6-all-deps.jar" -o /usr/loca/bin/google-java-format-1.6-all-deps.jar
+curl -sLJ "https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-1.6-all-deps.jar" -o /usr/local/bin/google-java-format-1.6-all-deps.jar

--- a/scripts/docker/install-java.bash
+++ b/scripts/docker/install-java.bash
@@ -36,3 +36,5 @@ echo '<settings>
     </mirror>
   </mirrors>
 </settings>' > /root/.m2/settings.xml
+
+curl -sLJ "https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-1.6-all-deps.jar" -o /usr/loca/bin/google-java-format-1.6-all-deps.jar

--- a/scripts/pre-commit/google_java_format.sh
+++ b/scripts/pre-commit/google_java_format.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
+echo $changed_java_files
+java -jar /usr/local/bin/google-java-format-1.6-all-deps.jar --replace $changed_java_files


### PR DESCRIPTION
Currently, we configure pre-commit to use this https://github.com/wangkuiyi/google-style-precommit-hook Java format hook script, which downloads the formatter, if not yet, when users run the git commit command, into `./cahce/`.

This PR changes the behavior to download the formatter when building the Docker image.  Also, it assumes that the formatter is in /usr/local/bin, which is the common case as users try to install the tool before using it.