### PR TITLE
Remove duplicated select field in parsing result

### DIFF
--- a/pkg/parser/sqlflow_parser.go
+++ b/pkg/parser/sqlflow_parser.go
@@ -22,12 +22,11 @@ import (
 
 // SQLFlowStmt represents a parsed SQL statement.  The original
 // statement is in Original.  If it is a standard SQL statement,
-// Standard has the statement as well, and Extended is nil.  Or, if it
-// is a statement with SQLFlow syntax extension, Standard is the
-// prefixed SELECT statement, and Extended is the parsed extension.
+// Original has the statement as well, and Extended is nil.  Or, if it
+// is a statement with SQLFlow syntax extension, Original is the whole
+// statement and Extended is the parsed extension.
 type SQLFlowStmt struct {
 	Original string
-	Standard string
 	*SQLFlowSelectStmt
 }
 
@@ -68,7 +67,7 @@ func Parse(dialect, program string) ([]*SQLFlowStmt, error) {
 		return sqls, nil
 	}
 
-	left := sqls[len(sqls)-1].Standard
+	left := sqls[len(sqls)-1].Original
 	program = program[i:]
 
 	// TO TRAIN dnn LABEL class INTO my_model; SELECT ...
@@ -118,7 +117,7 @@ func thirdPartyParse(dialect, program string) ([]*SQLFlowStmt, int, error) {
 	}
 	var spr []*SQLFlowStmt
 	for _, sql := range sqls {
-		spr = append(spr, &SQLFlowStmt{Original: sql, Standard: sql, SQLFlowSelectStmt: nil})
+		spr = append(spr, &SQLFlowStmt{Original: sql, SQLFlowSelectStmt: nil})
 	}
 	return spr, i, nil
 }

--- a/pkg/parser/sqlflow_parser_test.go
+++ b/pkg/parser/sqlflow_parser_test.go
@@ -48,9 +48,9 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.Equal(1, len(s))
 		a.False(IsExtendedSyntax(s[0]))
 		if isJavaParser(dbms) {
-			a.Equal(sql, s[0].Standard)
+			a.Equal(sql, s[0].Original)
 		} else {
-			a.Equal(sql+`;`, s[0].Standard)
+			a.Equal(sql+`;`, s[0].Original)
 		}
 	}
 
@@ -62,9 +62,9 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		for i := range s {
 			a.False(IsExtendedSyntax(s[i]))
 			if isJavaParser(dbms) {
-				a.Equal(external.SelectCases[i], s[i].Standard)
+				a.Equal(external.SelectCases[i], s[i].Original)
 			} else {
-				a.Equal(external.SelectCases[i]+`;`, s[i].Standard)
+				a.Equal(external.SelectCases[i]+`;`, s[i].Original)
 			}
 		}
 	}
@@ -77,14 +77,14 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.Equal(2, len(s))
 
 		a.True(IsExtendedSyntax(s[0]))
-		a.Equal(sql+` `, s[0].Standard)
+		a.Equal(sql+` `, s[0].StandardSelect.String())
 		a.Equal(fmt.Sprintf(`%s %s;`, sql, extendedSQL), s[0].Original)
 
 		a.False(IsExtendedSyntax(s[1]))
 		if isJavaParser(dbms) {
-			a.Equal(sql, s[1].Standard)
+			a.Equal(sql, s[1].Original)
 		} else {
-			a.Equal(sql+`;`, s[1].Standard)
+			a.Equal(sql+`;`, s[1].Original)
 		}
 	}
 
@@ -97,11 +97,11 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.False(IsExtendedSyntax(s[0]))
 		a.True(IsExtendedSyntax(s[1]))
 		if isJavaParser(dbms) {
-			a.Equal(sql, s[0].Standard)
+			a.Equal(sql, s[0].Original)
 		} else {
-			a.Equal(sql+`;`, s[0].Standard)
+			a.Equal(sql+`;`, s[0].Original)
 		}
-		a.Equal(sql+` `, s[1].Standard)
+		a.Equal(sql+` `, s[1].StandardSelect.String())
 		a.Equal(fmt.Sprintf(`%s %s;`, sql, extendedSQL), s[1].Original)
 	}
 
@@ -121,14 +121,14 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.False(IsExtendedSyntax(s[2]))
 
 		if isJavaParser(dbms) {
-			a.Equal(sql, s[0].Standard)
-			a.Equal(sql, s[2].Standard)
+			a.Equal(sql, s[0].Original)
+			a.Equal(sql, s[2].Original)
 		} else {
-			a.Equal(sql+`;`, s[0].Standard)
-			a.Equal(sql+`;`, s[2].Standard)
+			a.Equal(sql+`;`, s[0].Original)
+			a.Equal(sql+`;`, s[2].Original)
 		}
 
-		a.Equal(sql+` `, s[1].Standard)
+		a.Equal(sql+` `, s[1].StandardSelect.String())
 		a.Equal(fmt.Sprintf(`%s %s;`, sql, extendedSQL), s[1].Original)
 	}
 

--- a/pkg/sql/executor_ir.go
+++ b/pkg/sql/executor_ir.go
@@ -120,7 +120,7 @@ func submitWorkflow(wr *pipe.Writer, sqlProgram string, modelDir string, session
 				r, err = generatePredictStmt(sql.SQLFlowSelectStmt, session.DbConnStr, modelDir, "", false)
 			}
 		} else {
-			standardSQL := ir.StandardSQL(sql.Standard)
+			standardSQL := ir.StandardSQL(sql.Original)
 			r = &standardSQL
 		}
 		if err != nil {
@@ -183,7 +183,7 @@ func runSQLProgram(wr *pipe.Writer, sqlProgram string, db *database.DB, modelDir
 				r, err = generatePredictStmt(sql.SQLFlowSelectStmt, session.DbConnStr, modelDir, cwd, GetSubmitter(session.Submitter).GetTrainStmtFromModel())
 			}
 		} else {
-			standardSQL := ir.StandardSQL(sql.Standard)
+			standardSQL := ir.StandardSQL(sql.Original)
 			r = &standardSQL
 		}
 


### PR DESCRIPTION
There is a duplication between `SQLFlowStmt.Standard` and `SQLFlowStmt.SQLFlowSelectStmt.StandardSelect.origin`. I am removing the `SQLFlowStmt.Standard`.