### PR TITLE
Support pai random forests predict and explain

### DIFF
--- a/pkg/sql/ir/ir.go
+++ b/pkg/sql/ir/ir.go
@@ -182,8 +182,13 @@ type ExplainStmt struct {
 	Attributes map[string]interface{}
 	// Explainer types. For example TreeExplainer.
 	Explainer string
+	// ModelName is the model to be explained, e.g. TO EXPLAIN model_name
+	ModelName string
 	// Into stores the model explain result. Note that this field is optional.
 	Into string
+	// When SQLFLOW_submitter == "pai", tmp tables will be created for predicting task
+	// see: pai_submitter.go
+	TmpExplainTable string
 	// TrainStmt is the TrainStmt used for generating the training job of the corresponding model
 	TrainStmt *TrainStmt
 }

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -305,6 +305,7 @@ func generateExplainStmt(slct *parser.SQLFlowSelectStmt, connStr, modelDir strin
 		Attributes: attrs,
 		Explainer:  slct.Explainer,
 		TrainStmt:  trainStmt,
+		ModelName:  slct.TrainedModel,
 		Into:       slct.ExplainInto,
 	}
 


### PR DESCRIPTION
Support train, predict, explain using PAI random forests.

NOTE:

1. We can not load the saved random forests model and determine the model type when predicting, a workaround is to test if the model is a PAI Tensorflow model, so need to set `SQLFLOW_OSS_ENDPOINT`, `SQLFLOW_OSS_AK`, `SQLFLOW_OSS_SK` envs to access OSS to find out if the model is a Tensorflow model. Should find a way to determine PAI model type.
2. The predict result does not contain samples, this should be fixed in the next PR.

To run the test:

```bash
export SQLFLOW_submitter=pai
export SQLFLOW_TEST_DB=maxcompute
export SQLFLOW_TEST_DB_MAXCOMPUTE_PROJECT="xxx"
export SQLFLOW_TEST_DB_MAXCOMPUTE_ENDPOINT="xxx"
export SQLFLOW_TEST_DB_MAXCOMPUTE_AK="xxx"
export SQLFLOW_TEST_DB_MAXCOMPUTE_SK="xxx"
export SQLFLOW_OSS_CHECKPOINT_DIR="oss://xxx"

# used for testing random forests
export SQLFLOW_OSS_ENDPOINT="oss-cn-zhangjiakou.aliyuncs.com"
export SQLFLOW_OSS_AK="LTAI4Fhq4abko7MMSeBm8Ebt"
export SQLFLOW_OSS_SK="vBEd4W5G6zbtxbvlZmp5szYyh7jb3E"

cd cmd/sqlflowserver && go test -v -run TestEnd2EndMaxComputePAI/CaseTrainPAIRandomForests
```
