### PR TITLE
Fix duplicated history

### DIFF
--- a/cmd/repl/prompt.go
+++ b/cmd/repl/prompt.go
@@ -70,6 +70,7 @@ type promptState struct {
 	livePrefix       string
 	enableLivePrefix bool
 	statement        string
+	lastStatement    string
 	keywords         []string
 	history          []string
 	historyFileName  string
@@ -90,6 +91,7 @@ func (p *promptState) execute(in string, cb func(string)) {
 			p.enableLivePrefix = false
 			fmt.Println()
 			cb(p.statement)
+			p.lastStatement = p.statement
 			p.statement = ""
 			return
 		}
@@ -137,7 +139,7 @@ func (p *promptState) initHistory() {
 }
 
 func (p *promptState) updateHistory() {
-	if p.statement != "" {
+	if p.statement != "" && p.statement != p.lastStatement {
 		f, err := os.OpenFile(p.historyFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if err != nil {
 			return


### PR DESCRIPTION
The current implementation of REPL saves history statements multiple times even they are the same, this commit fixes the behavior.
For example, if we input several empty statements (`;`s):
Before this commit, the history file looks like:
```bash
# tail ~/.sqlflow_history
;
;
;
;
;
;
;
;
;
;
```
After this commit, the history file looks like:
```bash
# tail ~/.sqlflow_history
;
```
Obviously, the latter is consistent with shells.