### PR TITLE
Enable auto type conversion from int to float

### DIFF
--- a/pkg/sql/codegen/attribute/attribute.go
+++ b/pkg/sql/codegen/attribute/attribute.go
@@ -97,7 +97,10 @@ func (d Dictionary) Validate(attrs map[string]interface{}) error {
 		}
 
 		if desc.Type != Unknown && desc.Type != reflect.TypeOf(v) {
-			return fmt.Errorf(errUnexpectedType, k, desc.Type, v)
+			// Allow implicit converstion from int to float to ease typing
+			if !(desc.Type == Float && reflect.TypeOf(v) == Int) {
+				return fmt.Errorf(errUnexpectedType, k, desc.Type, v)
+			}
 		}
 
 		if desc.Checker != nil {


### PR DESCRIPTION
Fix #1356. It seems we only need to support converting from int to float.
Now the following statement can run correctly:
```sql
SELECT * FROM iris.train TO TRAIN xgboost.gbtree WITH subsample=1 LABEL class INTO sqlflow_models.xxx
```