### PR TITLE
Support explaining feature combination via shap interaction value and decision plot

### DIFF
--- a/python/sqlflow_submitter/xgboost/explain.py
+++ b/python/sqlflow_submitter/xgboost/explain.py
@@ -50,7 +50,7 @@ def explain(datasource, select, feature_field_meta, label_name,
 
     shap_values, shap_interaction_values, expected_value = xgb_shap_values(x)
 
-    if summary_params["plot_type"] == "decision":
+    if summary_params.get("plot_type") == "decision":
         explainer.plot_and_save(lambda: shap.decision_plot(
             expected_value,
             shap_interaction_values,

--- a/python/sqlflow_submitter/xgboost/explain.py
+++ b/python/sqlflow_submitter/xgboost/explain.py
@@ -37,7 +37,8 @@ def xgb_shap_values(x):
     bst = xgb.Booster()
     bst.load_model("my_model")
     explainer = shap.TreeExplainer(bst)
-    return explainer.shap_values(x)
+    return explainer.shap_values(x), explainer.shap_interaction_values(
+        x), explainer.expected_value
 
 
 def explain(datasource, select, feature_field_meta, label_name,
@@ -47,8 +48,16 @@ def explain(datasource, select, feature_field_meta, label_name,
     x = xgb_shap_dataset(datasource, select, feature_column_names, label_name,
                          feature_specs)
 
-    shap_values = xgb_shap_values(x)
+    shap_values, shap_interaction_values, expected_value = xgb_shap_values(x)
 
-    # save summary.png using the default backend
-    explainer.plot_and_save(lambda: shap.summary_plot(
-        shap_values, x, show=False, **summary_params))
+    if summary_params["plot_type"] == "decision":
+        explainer.plot_and_save(lambda: shap.decision_plot(
+            expected_value,
+            shap_interaction_values,
+            x,
+            show=False,
+            feature_display_range=slice(None, -40, -1),
+            alpha=1))
+    else:
+        explainer.plot_and_save(lambda: shap.summary_plot(
+            shap_values, x, show=False, **summary_params))

--- a/python/sqlflow_submitter/xgboost/explain_test.py
+++ b/python/sqlflow_submitter/xgboost/explain_test.py
@@ -157,7 +157,7 @@ class ExplainXGBModeTestCase(TestCase):
         x = xgb_shap_dataset(datasource, select, feature_column_names,
                              label_field_meta['name'], feature_specs)
 
-        shap_values = xgb_shap_values(x)
+        shap_values = xgb_shap_values(x)[0]
         expected_features = [
             'chas', 'zn', 'rad', 'indus', 'b', 'tax', 'ptratio', 'age', 'nox',
             'crim', 'dis', 'rm', 'lstat'


### PR DESCRIPTION
Use the following statement to explain the example in the [explain tutorial](https://github.com/sql-machine-learning/sqlflow/blob/develop/doc/tutorial/housing-explain.md)
```sql
SELECT * FROM boston.train 
TO EXPLAIN sqlflow_models.my_xgb_regression_model 
WITH shap_summary.plot_type=decision;
```
The result is ![decision](https://user-images.githubusercontent.com/4180295/72538109-3acef100-38b8-11ea-868d-6bfd4d5598ad.png) thats show the importance of crossed features as well as other features.

If we show only several samples as 
```sql
SELECT * FROM boston.train LIMIT 1
TO EXPLAIN sqlflow_models.my_xgb_regression_model
WITH shap_summary.plot_type=decision;
```
The result ![decision2](https://user-images.githubusercontent.com/4180295/72538333-a4e79600-38b8-11ea-9008-52416a17d124.png) shows the cumulative effect of interactions.

p. s. Maybe we have to refactor the explanation module later to reorganize the explanation methods.
