### PR TITLE
Remove the redundant check and warning message

### DIFF
--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -265,7 +265,7 @@ func main() {
 	scanner := bufio.NewScanner(reader)
 	if isTerminal {
 		if !it2Check {
-			fmt.Println("Mode: non-sixel")
+			fmt.Println("The terminal doesn't support sixel, explanation statements will show ASCII figures.")
 		}
 		runPrompt(func(stmt string) { runStmt(stmt, true, *modelDir, *ds) })
 	} else {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -230,11 +230,6 @@ func makeSessionFromEnv() *pb.Session {
 	}
 }
 
-func commandExists(cmd string) bool {
-	_, err := exec.LookPath(cmd)
-	return err == nil
-}
-
 func main() {
 	ds := flag.String("datasource", "", "database connect string")
 	modelDir := flag.String("model_dir", "", "model would be saved on the local dir, otherwise upload to the table.")
@@ -269,8 +264,8 @@ func main() {
 	}
 	scanner := bufio.NewScanner(reader)
 	if isTerminal {
-		if !commandExists("it2check") {
-			fmt.Println("Warning: defaults to non-sixel mode")
+		if !it2Check {
+			fmt.Println("Mode: non-sixel")
 		}
 		runPrompt(func(stmt string) { runStmt(stmt, true, *modelDir, *ds) })
 	} else {

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -203,11 +203,12 @@ func TestComplete(t *testing.T) {
 
 func TestTerminalCheck(t *testing.T) {
 	a := assert.New(t)
-	a.True(commandExists("it2check"))
+	_, err := exec.LookPath("it2check")
+	a.Nil(err)
 	a.False(it2Check)
 
 	a.True(isHTMLSnippet("<div></div>"))
-	_, err := getBase64EncodedImage("")
+	_, err = getBase64EncodedImage("")
 	a.Error(err)
 	image, err := getBase64EncodedImage(testImageHTML)
 	a.Nil(err)


### PR DESCRIPTION
1. `it2check` is certainly present in the Docker image. The checking seems to be redundant. 
2. Now that REPL works well in ASCII mode. We don't need a warning anymore.