### PR TITLE
Optimize ASCII figure for decision plot

### DIFF
--- a/python/plotille_text_backend.py
+++ b/python/plotille_text_backend.py
@@ -81,7 +81,7 @@ class FigureCanvasPlotille(FigureCanvasAgg):
 
         w, h = i.size
 
-        can = Canvas(128, 64, color_mode='byte')
+        can = Canvas(128, int(80 / w * h), color_mode='byte')
 
         for y in range(h):
             for x in range(w):


### PR DESCRIPTION
Make the ASCII figures proportional to the original figures, or the decision plot cannot be displayed properly because it's too long.