### PR TITLE
Support switching database in REPL with the  statement

### DIFF
--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -255,9 +255,15 @@ func getDatabaseName(datasource string) string {
 	if e != nil {
 		log.Fatalf("unrecognized data source '%s'", datasource)
 	}
-	re := regexp.MustCompile(`[^/]*/(\w*).*`) // mysql and hive
+	// The data source string of MySQL and Hive have similar patterns
+	// with the database name as a pathname under root. For example:
+	// mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0
+	// hive://root:root@127.0.0.1:10000/iris?auth=NOSASL
+	re := regexp.MustCompile(`[^/]*/(\w*).*`) // Extract the database name of MySQL and Hive
 	switch driver {
 	case "maxcompute":
+		// The database name in data source string of MaxCompute is the argument to parameter
+		// `curr_project`
 		re = regexp.MustCompile(`[^/].*/api[?].*curr_project=(\w*).*`)
 	case "mysql":
 	case "hive":
@@ -270,6 +276,7 @@ func getDatabaseName(datasource string) string {
 	return ""
 }
 
+// getDataSource generates a data source string that is using database `db` from the original dataSource
 func getDataSource(dataSource, db string) string {
 	driver, other, e := database.ParseURL(dataSource)
 	if e != nil {

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -32,6 +32,31 @@ import (
 
 var space = regexp.MustCompile(`\s+`)
 
+func testGetDataSource(t *testing.T, dataSource, databaseName string) {
+	a := assert.New(t)
+	a.Equal(dataSource, getDataSource(dataSource, databaseName))
+	a.Equal(databaseName, getDatabaseName(dataSource))
+	a.NotEqual(dataSource, getDataSource(dataSource, databaseName+"test"))
+	a.Equal(databaseName+"test", getDatabaseName(getDataSource(dataSource, databaseName+"test")))
+}
+func TestGetDataSource(t *testing.T) {
+	a := assert.New(t)
+	a.Equal("", getDatabaseName("maxcompute://test:test@service.cn.maxcompute.aliyun.com/api"))
+	testGetDataSource(t, "maxcompute://test:test@service.cn.maxcompute.aliyun.com/api?curr_project=iris&scheme=https", "iris")
+	testGetDataSource(t, "maxcompute://test:test@service.cn.maxcompute.aliyun.com/api?curr_project=&scheme=https", "")
+
+	testGetDataSource(t, "mysql://root:root@tcp(127.0.0.1:3306)/", "")
+	testGetDataSource(t, "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0", "")
+	testGetDataSource(t, "mysql://root:root@tcp(127.0.0.1:3306)/iris", "iris")
+	testGetDataSource(t, "mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0", "iris")
+
+	testGetDataSource(t, "hive://root:root@localhost:10000/", "")
+	testGetDataSource(t, "hive://root:root@127.0.0.1:10000/?auth=NOSASL", "")
+	testGetDataSource(t, "hive://root:root@localhost:10000/churn", "churn")
+	testGetDataSource(t, "hive://root:root@127.0.0.1:10000/iris?auth=NOSASL", "iris")
+
+}
+
 func testMainFastFail(t *testing.T, interactive bool) {
 	a := assert.New(t)
 	// Run the crashing code when FLAG is set


### PR DESCRIPTION
Fix #1562 
It's a little more complicated than estimated. Fortunately, REPL calls RunSQLProgram that reconnects the DBMS every time when called.
I kept the user-provided `ds` and replace the database into it when there's a `USE db_name` statement. The mechanism is not perfect but seems to work well.
![image](https://user-images.githubusercontent.com/4180295/72682606-c095ab00-3b09-11ea-85de-59006c3b42ba.png)
p. s. Because both`SubmitWorkflow` and `RunSQLProgram` in sqlflowserver use session, we may try to support `use db_name` in sqlflowserver after this is merged.