### PR TITLE
Support the training of XGBoost models on PAI

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1370,7 +1370,9 @@ func CaseTrainXGBoostOnPAI(t *testing.T) {
 	TO TRAIN xgboost.gbtree
 	WITH
 		objective="multi:softprob",
-		train.num_boost_round = 30
+		train.num_boost_round = 30,
+		eta = 0.4,
+		num_class = 3
 	LABEL class
 	INTO my_xgb_classi_model;`, caseTrainTable)
 	_, _, err := connectAndRunSQL(trainSQL)

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1380,17 +1380,21 @@ func CaseTrainXGBoostOnPAI(t *testing.T) {
 		a.Fail("Run trainSQL error: %v", err)
 	}
 
-	// 	predSQL := fmt.Sprintf(`SELECT * FROM %s
-	// TO EXPLAIN %s
-	// WITH label_col=class
-	// USING TreeExplainer
-	// INTO %s.explain_result;`, caseTestTable, caseInto, caseDB)
-	// 	_, _, err = connectAndRunSQL(predSQL)
-	// 	if err != nil {
-	// 		a.Fail("Run predSQL error: %v", err)
-	// 	}
+	// TODO(typhoonzero): add predict and explain test
 }
 
+// TestEnd2EndMaxComputePAI test cases that runs on PAI. Need to set below
+// environment variables to run the test:
+// SQLFLOW_submitter=pai
+// SQLFLOW_TEST_DB=maxcompute
+// SQLFLOW_TEST_DB_MAXCOMPUTE_PROJECT="xxx"
+// SQLFLOW_TEST_DB_MAXCOMPUTE_ENDPOINT="xxx"
+// SQLFLOW_TEST_DB_MAXCOMPUTE_AK="xxx"
+// SQLFLOW_TEST_DB_MAXCOMPUTE_SK="xxx"
+// SQLFLOW_OSS_CHECKPOINT_DIR="xxx"
+// SQLFLOW_OSS_ENDPOINT="xxx"
+// SQLFLOW_OSS_AK="xxx"
+// SQLFLOW_OSS_SK="xxx"
 func TestEnd2EndMaxComputePAI(t *testing.T) {
 	testDBDriver := os.Getenv("SQLFLOW_TEST_DB")
 	if testDBDriver != "maxcompute" {

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1364,6 +1364,31 @@ INTO %s.explain_result;`, caseTestTable, caseInto, caseDB)
 	}
 }
 
+func CaseTrainXGBoostOnPAI(t *testing.T) {
+	a := assert.New(t)
+	trainSQL := fmt.Sprintf(`SELECT * FROM %s
+	TO TRAIN xgboost.gbtree
+	WITH
+		objective="multi:softprob",
+		train.num_boost_round = 30
+	LABEL class
+	INTO my_xgb_classi_model;`, caseTrainTable)
+	_, _, err := connectAndRunSQL(trainSQL)
+	if err != nil {
+		a.Fail("Run trainSQL error: %v", err)
+	}
+
+	// 	predSQL := fmt.Sprintf(`SELECT * FROM %s
+	// TO EXPLAIN %s
+	// WITH label_col=class
+	// USING TreeExplainer
+	// INTO %s.explain_result;`, caseTestTable, caseInto, caseDB)
+	// 	_, _, err = connectAndRunSQL(predSQL)
+	// 	if err != nil {
+	// 		a.Fail("Run predSQL error: %v", err)
+	// 	}
+}
+
 func TestEnd2EndMaxComputePAI(t *testing.T) {
 	testDBDriver := os.Getenv("SQLFLOW_TEST_DB")
 	if testDBDriver != "maxcompute" {
@@ -1404,6 +1429,7 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 	t.Run("CaseTrainSQL", CaseTrainSQL)
 	t.Run("CaseTrainDNNAndExplain", CaseTrainDNNAndExplain)
 	t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
+	t.Run("CaseTrainXGBoostOnPAI", CaseTrainXGBoostOnPAI)
 	t.Run("CaseTrainDistributedPAI", CaseTrainDistributedPAI)
 }
 

--- a/pkg/sql/codegen/pai/codegen_test.go
+++ b/pkg/sql/codegen/pai/codegen_test.go
@@ -124,7 +124,7 @@ func TestWrapperCodegen(t *testing.T) {
 	os.Setenv("SQLFLOW_OSS_CHECKPOINT_DIR", "oss://bucket/?role_arn=xxx&host=xxx")
 	defer os.Unsetenv("SQLFLOW_OSS_CHECKPOINT_DIR")
 	// code, dataSource, modelName, cwd, tmpTrainTable, tmpValTable string, numPS, numWrokers int
-	code, err := wrapper("", dataSource, "my_dnn_model", cwd, "tmpTrainTable", "tmpValTable", "", mockClusterConfig())
+	code, err := wrapper("", dataSource, "my_dnn_model", cwd, "tmpTrainTable", "tmpValTable", "", mockClusterConfig(), false)
 	a.NoError(err)
 	a.True(strings.Contains(code, `assert driver == "maxcompute"`))
 

--- a/pkg/sql/codegen/pai/codegen_test.go
+++ b/pkg/sql/codegen/pai/codegen_test.go
@@ -124,7 +124,7 @@ func TestWrapperCodegen(t *testing.T) {
 	os.Setenv("SQLFLOW_OSS_CHECKPOINT_DIR", "oss://bucket/?role_arn=xxx&host=xxx")
 	defer os.Unsetenv("SQLFLOW_OSS_CHECKPOINT_DIR")
 	// code, dataSource, modelName, cwd, tmpTrainTable, tmpValTable string, numPS, numWrokers int
-	code, err := wrapper("", dataSource, "my_dnn_model", cwd, "tmpTrainTable", "tmpValTable", "", mockClusterConfig(), false)
+	code, err := genSubmitter("", dataSource, "my_dnn_model", cwd, "tmpTrainTable", "tmpValTable", "", mockClusterConfig(), false)
 	a.NoError(err)
 	a.True(strings.Contains(code, `assert driver == "maxcompute"`))
 

--- a/pkg/sql/codegen/pai/template_tf.go
+++ b/pkg/sql/codegen/pai/template_tf.go
@@ -23,6 +23,7 @@ type wrapperFiller struct {
 	PAIValidateTable  string
 	ResultTable       string
 	OSSCheckpointDir  string // uri for PAI to save checkpoints on OSS, e.g. oss://bucket/dir/?role_arn=xxx&host=xxx
+	IsXgboost         bool
 }
 
 type saveModelFiller struct {
@@ -62,6 +63,9 @@ archive = tarfile.open(tarball, "w|gz")
 with open("requirements.txt", "w") as req_fn:
     req_fn.write("shap==0.28.5\n")
     req_fn.write("seaborn==0.9.0\n")
+{{if .IsXgboost}}
+    req_fn.write("xgboost==0.90\n")
+{{end}}
 
 # '.' is always in sys.path
 archive.add(sqlflow_submitter.__path__[0], arcname='sqlflow_submitter')

--- a/pkg/sql/codegen/pai/template_tf.go
+++ b/pkg/sql/codegen/pai/template_tf.go
@@ -64,7 +64,7 @@ with open("requirements.txt", "w") as req_fn:
     req_fn.write("shap==0.28.5\n")
     req_fn.write("seaborn==0.9.0\n")
 {{if .IsXgboost}}
-    req_fn.write("xgboost==0.90\n")
+    req_fn.write("xgboost==0.82\n")
 {{end}}
 
 # '.' is always in sys.path

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -135,7 +135,6 @@ func (s *defaultSubmitter) runCommand(program string) error {
 	if e := cmd.Run(); e != nil {
 		return fmt.Errorf("failed: %v\n%sProgram%[2]s\n%s\n%[2]sOutput%[2]s\n%[4]v", e, "==========", program, output.String())
 	}
-	fmt.Println(output.String())
 	return nil
 }
 

--- a/pkg/sql/submitter.go
+++ b/pkg/sql/submitter.go
@@ -135,6 +135,7 @@ func (s *defaultSubmitter) runCommand(program string) error {
 	if e := cmd.Run(); e != nil {
 		return fmt.Errorf("failed: %v\n%sProgram%[2]s\n%s\n%[2]sOutput%[2]s\n%[4]v", e, "==========", program, output.String())
 	}
+	fmt.Println(output.String())
 	return nil
 }
 

--- a/python/sqlflow_submitter/xgboost/train.py
+++ b/python/sqlflow_submitter/xgboost/train.py
@@ -54,6 +54,7 @@ def train(datasource, select, model_params, train_params, feature_field_meta,
     bst = xgb.train(model_params,
                     dtrain,
                     evals=watchlist,
-                    evals_result=re**train_params)
+                    evals_result=re,
+                    **train_params)
     bst.save_model("my_model")
     print("Evaluation result: %s" % re)

--- a/python/sqlflow_submitter/xgboost/train.py
+++ b/python/sqlflow_submitter/xgboost/train.py
@@ -53,8 +53,7 @@ def train(datasource, select, model_params, train_params, feature_field_meta,
     re = dict()
     bst = xgb.train(model_params,
                     dtrain,
-                    **train_params,
                     evals=watchlist,
-                    evals_result=re)
+                    evals_result=re**train_params)
     bst.save_model("my_model")
     print("Evaluation result: %s" % re)


### PR DESCRIPTION
Currently, SQLFlow can generate Python submitters to run TensorFlow jobs on PAI.  This PR adds the feature of generating Python submitters for XGBoost jobs on PAI.

Fix #1771 