### PR TITLE
Rename ir.SQLStatement into ir.SQLFlowStmt

### DIFF
--- a/pkg/ir/ir.go
+++ b/pkg/ir/ir.go
@@ -14,11 +14,7 @@
 // Package ir is the Intermediate Representation of parsed SQL statements
 package ir
 
-// SQLProgram represents a parsed SQL program.
-// TODO(typhoonzero): Can generate a DAG workflow from a SQL program.
-type SQLProgram []SQLStatement
-
-// Executor is a visitor that generates and executes code for SQLStatement
+// Executor is a visitor that generates and executes code for SQLFlowStmt
 type Executor interface {
 	ExecuteQuery(*StandardSQL) error
 	ExecuteTrain(*TrainStmt) error
@@ -26,8 +22,8 @@ type Executor interface {
 	ExecuteExplain(*ExplainStmt) error
 }
 
-// SQLStatement represent all kind of IRs including: TrainStmt, PredictStmt, ExplainStmt and standard SQL.
-type SQLStatement interface {
+// SQLFlowStmt has multiple implementations: TrainStmt, PredictStmt, ExplainStmt and standard SQL.
+type SQLFlowStmt interface {
 	SetOriginalSQL(string)
 	Execute(Executor) error
 	IsExtended() bool
@@ -78,7 +74,7 @@ func (cl *TrainStmt) Execute(s Executor) error { return s.ExecuteTrain(cl) }
 // SetOriginalSQL sets the original sql string
 func (cl *TrainStmt) SetOriginalSQL(sql string) { cl.OriginalSQL = sql }
 
-// IsExtended returns whether a SQLStatement is an extended SQL statement
+// IsExtended returns whether a SQLFlowStmt is an extended SQL statement
 func (cl *TrainStmt) IsExtended() bool { return true }
 
 // GetOriginalSQL returns the original SQL statement used to get current IR result
@@ -117,7 +113,7 @@ func (cl *PredictStmt) Execute(s Executor) error { return s.ExecutePredict(cl) }
 // SetOriginalSQL sets the original sql string
 func (cl *PredictStmt) SetOriginalSQL(sql string) { cl.OriginalSQL = sql }
 
-// IsExtended returns whether a SQLStatement is an extended SQL statement
+// IsExtended returns whether a SQLFlowStmt is an extended SQL statement
 func (cl *PredictStmt) IsExtended() bool { return true }
 
 // GetOriginalSQL returns the original SQL statement used to get current IR result
@@ -153,7 +149,7 @@ func (cl *ExplainStmt) Execute(s Executor) error { return s.ExecuteExplain(cl) }
 // SetOriginalSQL sets the original sql string
 func (cl *ExplainStmt) SetOriginalSQL(sql string) { cl.OriginalSQL = sql }
 
-// IsExtended returns whether a SQLStatement is an extended SQL statement
+// IsExtended returns whether a SQLFlowStmt is an extended SQL statement
 func (cl *ExplainStmt) IsExtended() bool { return true }
 
 // GetOriginalSQL returns the original SQL statement used to get current IR result
@@ -168,7 +164,7 @@ func (sql *StandardSQL) Execute(s Executor) error { return s.ExecuteQuery(sql) }
 // SetOriginalSQL sets the original sql string
 func (sql *StandardSQL) SetOriginalSQL(s string) {}
 
-// IsExtended returns whether a SQLStatement is an extended SQL statement
+// IsExtended returns whether a SQLFlowStmt is an extended SQL statement
 func (sql *StandardSQL) IsExtended() bool { return false }
 
 // GetOriginalSQL returns the original SQL statement used to get current IR result

--- a/pkg/sql/codegen/couler/codegen.go
+++ b/pkg/sql/codegen/couler/codegen.go
@@ -63,7 +63,7 @@ func getStepEnvs(session *pb.Session) (map[string]string, error) {
 }
 
 // GenCode generates Couler program
-func GenCode(programIR ir.SQLProgram, session *pb.Session) (string, error) {
+func GenCode(programIR []ir.SQLFlowStmt, session *pb.Session) (string, error) {
 	stepEnvs, err := getStepEnvs(session)
 	if err != nil {
 		return "", err

--- a/pkg/sql/codegen/couler/codegen_test.go
+++ b/pkg/sql/codegen/couler/codegen_test.go
@@ -40,10 +40,10 @@ func TestCoulerCodegen(t *testing.T) {
 	a.True(strings.Contains(code, `step_envs["SQLFLOW_OSS_AK"] = "oss_key"`))
 }
 
-func mockSQLProgramIR() ir.SQLProgram {
+func mockSQLProgramIR() []ir.SQLFlowStmt {
 	standardSQL := ir.StandardSQL("SELECT * FROM iris.train limit 10;")
 	trainStmt := ir.MockTrainStmt(false)
-	return []ir.SQLStatement{&standardSQL, trainStmt}
+	return []ir.SQLFlowStmt{&standardSQL, trainStmt}
 }
 
 var testCoulerClusterConfig = `
@@ -124,7 +124,7 @@ func TestKatibCodegen(t *testing.T) {
 	standardSQL := ir.StandardSQL("SELECT * FROM iris.train limit 10;")
 	sqlIR := MockKatibTrainStmt(fmt.Sprintf("mysql://%s", cfg.FormatDSN()))
 
-	program := []ir.SQLStatement{&standardSQL, &sqlIR}
+	program := []ir.SQLFlowStmt{&standardSQL, &sqlIR}
 
 	_, err := GenCode(program, &pb.Session{})
 

--- a/pkg/sql/executor_ir.go
+++ b/pkg/sql/executor_ir.go
@@ -108,9 +108,9 @@ func submitWorkflow(wr *pipe.Writer, sqlProgram string, modelDir string, session
 	// 		SELECT ... TO TRAIN ...
 	// the multiple ir generator steps pipeline can be:
 	// sql -> parsed result -> infer columns -> load train ir from saved model ..
-	spIRs := []ir.SQLStatement{}
+	spIRs := []ir.SQLFlowStmt{}
 	for _, sql := range sqls {
-		var r ir.SQLStatement
+		var r ir.SQLFlowStmt
 		if parser.IsExtendedSyntax(sql) {
 			if sql.Train {
 				r, err = generateTrainStmt(sql.SQLFlowSelectStmt)
@@ -174,7 +174,7 @@ func runSQLProgram(wr *pipe.Writer, sqlProgram string, db *database.DB, modelDir
 		cleanCwd := func(cwd string) error {
 			return os.RemoveAll(cwd)
 		}
-		var r ir.SQLStatement
+		var r ir.SQLFlowStmt
 		if parser.IsExtendedSyntax(sql) {
 			if sql.Train {
 				r, err = generateTrainStmtWithInferredColumns(sql.SQLFlowSelectStmt, session.DbConnStr, true)
@@ -208,7 +208,7 @@ func runSQLProgram(wr *pipe.Writer, sqlProgram string, db *database.DB, modelDir
 	return nil
 }
 
-func runSingleSQLIR(wr *pipe.Writer, sqlIR ir.SQLStatement, db *database.DB, modelDir string, cwd string, session *pb.Session) (e error) {
+func runSingleSQLIR(wr *pipe.Writer, sqlIR ir.SQLFlowStmt, db *database.DB, modelDir string, cwd string, session *pb.Session) (e error) {
 	startTime := time.Now().UnixNano()
 	var originalSQL string
 	defer func() {

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -196,7 +196,7 @@ func verifyTrainStmt(trainStmt *ir.TrainStmt, db *database.DB, verifyLabel bool)
 	return nil
 }
 
-func verifyIRWithTrainStmt(sqlir ir.SQLStatement, db *database.DB) error {
+func verifyIRWithTrainStmt(sqlir ir.SQLFlowStmt, db *database.DB) error {
 	var selectStmt string
 	var trainStmt *ir.TrainStmt
 	switch s := sqlir.(type) {


### PR DESCRIPTION
While @typhoonzero and I were discussing https://github.com/sql-machine-learning/sqlflow/issues/1434#issuecomment-575966175, we agree that we should rename `ir.SQLStatement` into `ir.SQLFlowStmt` so to make the name consistent with `parser.SQLFlowStmt`.

In this PR, I also deleted the type `ir.SQLProgram`, because (1) there is only one place (the Couler codegen) that uses this type, (2) there is no `parser.SQLProgram` but `[]*parser.SQLFlowStmt` instead, and (3) it is hard to decide if we should name it `ir.SQLFlowPrgm` or `ir.SQLFlowProgram`.