### PR TITLE
Make extended syntax parser return correct idx on errored statement

### DIFF
--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -378,6 +378,7 @@ func parseSQLFlowStmt(s string) (r *SQLFlowSelectStmt, idx int, e error) {
 	extendedSyntaxParse(lex) // extendedSyntaxParse is auto generated.
 	idx = lex.pos
 	if lex.err != nil {
+		parseResult = nil
 		idx = lex.previous
 	}
 	return parseResult, idx, lex.err

--- a/pkg/parser/extended_syntax_parser_test.go
+++ b/pkg/parser/extended_syntax_parser_test.go
@@ -170,9 +170,17 @@ func TestExtendedSyntaxParseNonSelectStmt(t *testing.T) {
 func TestExtendedSyntaxParseUnmatchedQuotation(t *testing.T) {
 	a := assert.New(t)
 	{
+		// unmatched quotation within a statement
 		r, idx, e := parseSQLFlowStmt(`TO TRAIN "some_thing`)
 		a.Error(e)
 		a.Equal(9, idx)
+		a.Nil(r)
+	}
+	{
+		// unmatched quotation right after the statement
+		r, idx, e := parseSQLFlowStmt(`to train a with b = c label d into e;"`)
+		a.Error(e)
+		a.Equal(len(`to train a with b = c label d into e;`), idx)
 		a.Nil(r)
 	}
 }

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -187,7 +187,7 @@ func (l *lexer) lexString(lval *extendedSyntaxSymType) int {
 	for r := l.next(); r != '"' && r != '\''; r = l.next() {
 		if r == eof {
 			l.previous = l.start
-			// return error position
+			l.err = fmt.Errorf("unmatched quotation")
 			return -l.start
 		}
 		if r == '\\' {

--- a/pkg/parser/sqlflow_parser_test.go
+++ b/pkg/parser/sqlflow_parser_test.go
@@ -166,6 +166,21 @@ func TestParseFirstSQLStatement(t *testing.T) {
 	}
 
 	{
+		// corner case: no space between two statements
+		pr, idx, e := parseFirstSQLFlowStmt(`to train a with b = c label d into e;select a from b;`)
+		a.NotNil(pr)
+		a.Equal(len(`to train a with b = c label d into e;`), idx)
+		a.NoError(e)
+	}
+
+	{
+		pr, idx, e := parseFirstSQLFlowStmt(`to train a with b = c label d into e;"`)
+		a.NotNil(pr)
+		a.Equal(len(`to train a with b = c label d into e;`), idx)
+		a.NoError(e)
+	}
+
+	{
 		pr, idx, e := parseFirstSQLFlowStmt(`to train a with b =?? c label d into e ...`)
 		a.Nil(pr)
 		a.Equal(-1, idx)


### PR DESCRIPTION
Fix #1755.