### PR TITLE
Repl split stmt

### DIFF
--- a/cmd/repl/prompt.go
+++ b/cmd/repl/prompt.go
@@ -172,7 +172,7 @@ func (p *promptState) lookaheadKeyword(words []string) (string, string, string) 
 
 func (p *promptState) clauseUnderCursor(in prompt.Document) (string, string, string) {
 	// TODO(shendiaomo): use SQLFlow lexer to replace strings.Fields
-	words := strings.Fields(strings.Join(p.statements, " ") + in.TextBeforeCursor())
+	words := strings.Fields(strings.Join(p.statements, " ") + " " + in.TextBeforeCursor())
 	return p.lookaheadKeyword(words)
 }
 

--- a/cmd/repl/prompt.go
+++ b/cmd/repl/prompt.go
@@ -138,8 +138,8 @@ func (p *promptState) initHistory() {
 }
 
 func (p *promptState) updateHistory() {
-	input := strings.Join(p.statements, "; ")
-	lastInput := strings.Join(p.lastStatements, "; ")
+	input := strings.Join(p.statements, " ")
+	lastInput := strings.Join(p.lastStatements, " ")
 	if len(p.statements) != 0 && input != lastInput {
 		f, err := os.OpenFile(p.historyFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if err != nil {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -41,36 +41,91 @@ import (
 
 const tablePageSize = 1000
 
-func lineIsComment(line string) bool {
-	line = strings.TrimSpace(line)
-	if line == "--" || strings.HasPrefix(line, "-- ") {
-		return true
+func isSpace(c byte) bool {
+	return len(bytes.TrimSpace([]byte{c})) == 0
+}
+
+// addLineToStmt scans lines into statements, the last four parameters are both input/output.
+// A user must initialize `inQuotedString` and `isSingleQuoted` to false and `statements` to []
+// at the first call
+func addLineToStmt(line string, inQuotedString, isSingleQuoted *bool, statements *[]string) bool {
+	if len(*statements) == 0 { // First line of the statements
+		*statements = append(*statements, "")
+		line = strings.TrimLeft(line, "\t ")
+	} else {
+		(*statements)[len(*statements)-1] += "\n"
 	}
+	var isEscape bool // Escaping in quoted string cannot cross lines
+	var start, i int
+	for i = 0; i < len(line); i++ {
+		if isEscape {
+			isEscape = false
+			continue
+		}
+		switch line[i] {
+		case '\\':
+			if *inQuotedString {
+				isEscape = true
+			}
+		case '"', '\'':
+			if *inQuotedString {
+				if *isSingleQuoted == (line[i] == '\'') {
+					*inQuotedString = false // We found the end of a quoted string
+				}
+			} else { // The start of a quoted string
+				*inQuotedString = true
+				*isSingleQuoted = (line[i] == '\'')
+			}
+		case ';':
+			if !*inQuotedString { // We found a statement
+				if i-start != 1 { // Ignore empty statement that has only a ';'
+					(*statements)[len(*statements)-1] += line[start:i]
+					*statements = append(*statements, "")
+				}
+				for i+1 < len(line) && isSpace(line[i+1]) {
+					i++ // Ignore leading whitespaces of the next statement
+				}
+				start = i + 1
+			}
+		case '-':
+			if !*inQuotedString {
+				if i+1 < len(line) && line[i+1] == '-' {
+					if i+2 == len(line) || isSpace(line[i+2]) { // We found a line comment
+						// Note: `--` comment doens't interfere with quoted-string and `;`
+						(*statements)[len(*statements)-1] += strings.TrimSpace(line[start:i])
+						if len(*statements) == 1 && (*statements)[0] == "" {
+							*statements = []string{} // The whole line is a comment
+							return true
+						}
+						return false
+					}
+				}
+			}
+		}
+	}
+	if start == i {
+		fmt.Println(*statements)
+		return true // All done, the last character in the line is the end of a statement
+	}
+	(*statements) = append(*statements, line[start:]) // Prepare for searching the next statement
 	return false
 }
 
 // readStmt reads a SQL statement from the scanner.  A statement could have
 // multiple lines and ends at a semicolon at the end of the last line.
-func readStmt(scn *bufio.Scanner) (string, error) {
-	stmt := ""
+func readStmt(scn *bufio.Scanner) ([]string, error) {
+	stmt := []string{}
+	var inQuotedString, isSingleQuoted bool
 	for scn.Scan() {
-		if stmt == "" && lineIsComment(scn.Text()) {
-			continue
+		if addLineToStmt(scn.Text(), &inQuotedString, &isSingleQuoted, &stmt) {
+			return stmt, nil
 		}
-		stmt += scn.Text()
-		// FIXME(tonyyang-svail): It is hacky and buggy to assume that
-		// SQL statements are separated by substrings ";\n".  We need
-		// to call the SQLFlow parser to retrieve statements and run
-		// them one-by-one in a REPL.
-		if strings.HasSuffix(strings.TrimSpace(scn.Text()), ";") {
-			return strings.TrimSpace(stmt), nil
-		}
-		stmt += "\n"
 	}
+	// If the the file doen't ends with ';', we consider the remaining content as a statement
 	if scn.Err() == nil {
 		return stmt, io.EOF
 	}
-	return "", scn.Err()
+	return stmt, scn.Err()
 }
 
 func header(head map[string]interface{}) ([]string, error) {
@@ -190,28 +245,21 @@ func runStmt(stmt string, isTerminal bool, modelDir string, ds string) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	sess := makeSessionFromEnv()
 	sess.DbConnStr = getDataSource(ds, currentDB)
-	statements := strings.Split(stmt, ";")
-	for _, stmt := range statements {
-		if stmt == "" {
-			continue
-		}
-		parts := strings.Fields(stmt)
-		if len(parts) == 2 && strings.ToUpper(parts[0]) == "USE" {
-			switchDatabase(parts[1], sess)
-			continue
-		}
-		stream := sql.RunSQLProgram(stmt+";", modelDir, sess)
-		for rsp := range stream.ReadAll() {
-			// pagination. avoid exceed memory
-			if render(rsp, table, isTerminal) && table.NumLines() == tablePageSize {
-				table.Render()
-				tableRendered = true
-				table.ClearRows()
-			}
-		}
-		if table.NumLines() > 0 || !tableRendered {
+	parts := strings.Fields(strings.ReplaceAll(stmt, ";", ""))
+	if len(parts) == 2 && strings.ToUpper(parts[0]) == "USE" {
+		return switchDatabase(parts[1], sess)
+	}
+	stream := sql.RunSQLProgram(stmt+";", modelDir, sess)
+	for rsp := range stream.ReadAll() {
+		// pagination. avoid exceed memory
+		if render(rsp, table, isTerminal) && table.NumLines() == tablePageSize {
 			table.Render()
+			tableRendered = true
+			table.ClearRows()
 		}
+	}
+	if table.NumLines() > 0 || !tableRendered {
+		table.Render()
 	}
 	return nil
 }
@@ -226,13 +274,15 @@ func assertConnectable(ds string) {
 
 func repl(scanner *bufio.Scanner, modelDir string, ds string) {
 	for {
-		stmt, err := readStmt(scanner)
+		statements, err := readStmt(scanner)
 		fmt.Println()
-		if err == io.EOF && stmt == "" {
+		if err == io.EOF && len(statements) == 0 {
 			return
 		}
-		if err := runStmt(stmt, false, modelDir, ds); err != nil {
-			log.Fatalf("run SQL statement failed: %v", err)
+		for _, stmt := range statements {
+			if err := runStmt(stmt, false, modelDir, ds); err != nil {
+				log.Fatalf("run SQL statement failed: %v", err)
+			}
 		}
 	}
 }
@@ -250,7 +300,7 @@ func makeSessionFromEnv() *pb.Session {
 		Submitter:        os.Getenv("SQLFLOW_submitter")}
 }
 
-func switchDatabase(db string, session *pb.Session) {
+func switchDatabase(db string, session *pb.Session) error {
 	stream := sql.RunSQLProgram("USE "+db, "", session)
 	r := <-stream.ReadAll()
 	switch r.(type) {
@@ -258,7 +308,10 @@ func switchDatabase(db string, session *pb.Session) {
 		session.DbConnStr = getDataSource(session.DbConnStr, db)
 		fmt.Println("Database changed to", db)
 		currentDB = db
+	case error:
+		fmt.Println(r)
 	}
+	return nil
 }
 
 func getDatabaseName(datasource string) string {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -249,7 +249,7 @@ func runStmt(stmt string, isTerminal bool, modelDir string, ds string) error {
 	if len(parts) == 2 && strings.ToUpper(parts[0]) == "USE" {
 		return switchDatabase(parts[1], sess)
 	}
-	stream := sql.RunSQLProgram(stmt+";", modelDir, sess)
+	stream := sql.RunSQLProgram(stmt, modelDir, sess)
 	for rsp := range stream.ReadAll() {
 		// pagination. avoid exceed memory
 		if render(rsp, table, isTerminal) && table.NumLines() == tablePageSize {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -79,13 +79,17 @@ func addLineToStmt(line string, inQuotedString, isSingleQuoted *bool, statements
 		case ';':
 			if !*inQuotedString { // We found a statement
 				if i-start != 1 { // Ignore empty statement that has only a ';'
-					(*statements)[len(*statements)-1] += line[start:i]
-					*statements = append(*statements, "")
+					(*statements)[len(*statements)-1] += line[start : i+1]
 				}
 				for i+1 < len(line) && isSpace(line[i+1]) {
 					i++ // Ignore leading whitespaces of the next statement
 				}
 				start = i + 1
+				if start == len(line) {
+					return true // All done, the last character in the line is the end of a statement
+				}
+				*statements = append(*statements, "") // Prepare for searching the next statement
+
 			}
 		case '-':
 			if !*inQuotedString {
@@ -94,8 +98,8 @@ func addLineToStmt(line string, inQuotedString, isSingleQuoted *bool, statements
 						// Note: `--` comment doens't interfere with quoted-string and `;`
 						(*statements)[len(*statements)-1] += strings.TrimSpace(line[start:i])
 						if len(*statements) == 1 && (*statements)[0] == "" {
-							*statements = []string{} // The whole line is a comment
-							return true
+							*statements = []string{}
+							return true // The whole line is an empty statement that has only a `-- comment`,
 						}
 						return false
 					}
@@ -103,11 +107,7 @@ func addLineToStmt(line string, inQuotedString, isSingleQuoted *bool, statements
 			}
 		}
 	}
-	if start == i {
-		fmt.Println(*statements)
-		return true // All done, the last character in the line is the end of a statement
-	}
-	(*statements) = append(*statements, line[start:]) // Prepare for searching the next statement
+	(*statements)[len(*statements)-1] += line[start:]
 	return false
 }
 

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -127,6 +127,18 @@ func TestReadStmt(t *testing.T) {
 	a.Equal(space.ReplaceAllString(stmt, " "), space.ReplaceAllString(sql, " "))
 }
 
+func TestReadStmt(t *testing.T) {
+	a := assert.New(t)
+	sql := `SELECT * FROM iris.train TO TRAIN DNNClassifier WITH
+				model.hidden_units=[10,20],
+				model.n_classes=3
+			LABEL class INTO sqlflow_models.my_model;`
+	scanner := bufio.NewScanner(strings.NewReader(sql))
+	stmt, err := readStmt(scanner)
+	a.Nil(err)
+	a.Equal(space.ReplaceAllString(stmt, " "), space.ReplaceAllString(sql, " "))
+}
+
 func TestPromptState(t *testing.T) {
 	a := assert.New(t)
 	s := newPromptState()

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -262,6 +262,27 @@ func TestReadStmt(t *testing.T) {
 	a.Equal(io.EOF, err)
 	a.Equal(1, len(stmt))
 	a.Equal(space.ReplaceAllString(stmt[0], " "), `SELECT * FROM tbl WHERE a== '";`)
+
+	sql3 = `--
+            -- 1. test
+            use iris; show
+            tables; --
+			select * from tbl where a not like '-- %'
+	        ;` // Test multiple statements
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(0, len(stmt))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(0, len(stmt))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(3, len(stmt))
+	a.Equal("use iris;", stmt[0])
+	a.Equal("show tables;", space.ReplaceAllString(stmt[1], " "))
+	a.Equal(" select * from tbl where a not like '-- %' ;", space.ReplaceAllString(stmt[2], " "))
+
 }
 
 func TestPromptState(t *testing.T) {

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -252,7 +252,6 @@ func TestReadStmt(t *testing.T) {
 	stmt, err = readStmt(scanner)
 	a.Nil(err)
 	a.Equal(1, len(stmt))
-	fmt.Println(stmt)
 	a.Equal(stmt[0], sql3)
 
 	sql3 = `SELECT * FROM tbl WHERE a==-- " \";
@@ -268,7 +267,7 @@ func TestReadStmt(t *testing.T) {
             use iris; show
             tables; --
 			select * from tbl where a not like '-- %'
-	        ;` // Test multiple statements
+	        ;` // Test multiple statements in multiple lines
 	scanner = bufio.NewScanner(strings.NewReader(sql3))
 	stmt, err = readStmt(scanner)
 	a.Nil(err)
@@ -283,6 +282,13 @@ func TestReadStmt(t *testing.T) {
 	a.Equal("show tables;", space.ReplaceAllString(stmt[1], " "))
 	a.Equal(" select * from tbl where a not like '-- %' ;", space.ReplaceAllString(stmt[2], " "))
 
+	sql3 = `use iris; show tables;` // Test multiple statements in single line
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(2, len(stmt))
+	a.Equal("use iris;", stmt[0])
+	a.Equal("show tables;", space.ReplaceAllString(stmt[1], " "))
 }
 
 func TestPromptState(t *testing.T) {

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -95,16 +96,6 @@ func TestMainFastFail(t *testing.T) {
 	testMainFastFail(t, false)
 }
 
-func TestLineIsComment(t *testing.T) {
-	a := assert.New(t)
-	sql := `-- 1. test`
-	a.True(lineIsComment(sql))
-	sql = `--`
-	a.True(lineIsComment(sql))
-	sql = `SHOW databases`
-	a.False(lineIsComment(sql))
-}
-
 func TestReadStmt(t *testing.T) {
 	a := assert.New(t)
 	sql := `SELECT * FROM iris.train TO TRAIN DNNClassifier WITH
@@ -114,7 +105,8 @@ func TestReadStmt(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(sql))
 	stmt, err := readStmt(scanner)
 	a.Nil(err)
-	a.Equal(space.ReplaceAllString(stmt, " "), space.ReplaceAllString(sql, " "))
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), space.ReplaceAllString(sql, " "))
 
 	sql2 := `-- 1. test
              SELECT * FROM iris.train TO TRAIN DNNClassifier WITH
@@ -124,19 +116,152 @@ func TestReadStmt(t *testing.T) {
 	scanner = bufio.NewScanner(strings.NewReader(sql2))
 	stmt, err = readStmt(scanner)
 	a.Nil(err)
-	a.Equal(space.ReplaceAllString(stmt, " "), space.ReplaceAllString(sql, " "))
-}
-
-func TestReadStmt(t *testing.T) {
-	a := assert.New(t)
-	sql := `SELECT * FROM iris.train TO TRAIN DNNClassifier WITH
-				model.hidden_units=[10,20],
-				model.n_classes=3
-			LABEL class INTO sqlflow_models.my_model;`
-	scanner := bufio.NewScanner(strings.NewReader(sql))
-	stmt, err := readStmt(scanner)
+	a.Equal(0, len(stmt)) // The leading one-line comment is considered an empty statement
+	stmt, err = readStmt(scanner)
 	a.Nil(err)
-	a.Equal(space.ReplaceAllString(stmt, " "), space.ReplaceAllString(sql, " "))
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), space.ReplaceAllString(sql, " "))
+
+	sql2 = `-- 1. test`
+	scanner = bufio.NewScanner(strings.NewReader(sql2))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(0, len(stmt))
+
+	sql2 = `--`
+	scanner = bufio.NewScanner(strings.NewReader(sql2))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(0, len(stmt))
+
+	sql2 = `--1. test`
+	scanner = bufio.NewScanner(strings.NewReader(sql2))
+	stmt, err = readStmt(scanner)
+	a.Equal(io.EOF, err) // Don't support standard comment
+	a.Equal(1, len(stmt))
+	a.Equal(sql2, stmt[0])
+
+	sql2 = `SHOW databases;`
+	scanner = bufio.NewScanner(strings.NewReader(sql2))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+
+	sql2 = `SHOW databases`
+	scanner = bufio.NewScanner(strings.NewReader(sql2))
+	stmt, err = readStmt(scanner)
+	a.Equal(err, io.EOF) // EOF is considered the same as ';'
+	a.Equal(1, len(stmt))
+
+	sql3 := `SELECT
+           *
+		   FROM
+		   iris.train
+		   TO
+		   TRAIN
+		   DNNClassifier
+		   WITH
+		   model.hidden_units=[10,20],
+		   model.n_classes=3
+		   LABEL
+		   class
+		   INTO
+		   sqlflow_models.my_model;`
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), space.ReplaceAllString(sql, " "))
+
+	sql3 = `SELECT --
+           * -- comment
+		   FROM -- comment;
+		   iris.train -- comment ;
+		   TO -- comment         ;      TRAIN
+		   TRAIN
+		   DNNClassifier
+		   WITH
+		   model.hidden_units=[10,20],
+		   model.n_classes=3
+		   LABEL
+		   class
+		   INTO
+		   sqlflow_models.my_model;`
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), space.ReplaceAllString(sql, " "))
+
+	sql3 = `SELECT * FROM tbl WHERE a==";";`
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a==";\"';` // Test unclosed quote
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Equal(io.EOF, err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a==";
+	        ";` // Test cross-line quoted string
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a=="\";
+	        ";` // Test Escaping
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a=="';
+	        ";` // Test single quote in double-quoted string
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a=='";
+	        ';` // Test double quote in single-quoted string
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a=="-- \";
+	        ";` // Test double dash in quoted string
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a==--" \";
+	        '";` // Test quoted string in standard comment (not comment actually )
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Nil(err)
+	a.Equal(1, len(stmt))
+	fmt.Println(stmt)
+	a.Equal(stmt[0], sql3)
+
+	sql3 = `SELECT * FROM tbl WHERE a==-- " \";
+	        '";` // Test quoted string in comment, note that the quoted string is unclosed
+	scanner = bufio.NewScanner(strings.NewReader(sql3))
+	stmt, err = readStmt(scanner)
+	a.Equal(io.EOF, err)
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), `SELECT * FROM tbl WHERE a== '";`)
 }
 
 func TestPromptState(t *testing.T) {
@@ -168,14 +293,17 @@ func TestPromptState(t *testing.T) {
 	a.Equal("DNNClassifier", ahead)
 	a.Equal("model.n_classes=3", last)
 
-	var stmt string
+	var stmt []string
+	a.Equal(0, len(s.statements))
 	scanner := bufio.NewScanner(strings.NewReader(sql))
 	for scanner.Scan() {
-		s.execute(scanner.Text(), func(s string) { stmt = s })
+		s.execute(scanner.Text(), func(s string) { stmt = append(stmt, s) })
 	}
-	a.Equal(space.ReplaceAllString(stmt, " "), space.ReplaceAllString(sql, " "))
-	a.Equal("", s.statement)
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), space.ReplaceAllString(sql, " "))
+	a.Equal(0, len(s.statements))
 
+	stmt = []string{}
 	sql2 := `-- 1. test
              SELECT * FROM iris.train TO TRAIN DNNClassifier WITH
 				model.hidden_units=[10,20],
@@ -183,10 +311,10 @@ func TestPromptState(t *testing.T) {
              LABEL class INTO sqlflow_models.my_model;`
 	scanner = bufio.NewScanner(strings.NewReader(sql2))
 	for scanner.Scan() {
-		s.execute(scanner.Text(), func(s string) { stmt = s })
+		s.execute(scanner.Text(), func(s string) { stmt = append(stmt, s) })
 	}
-	a.Equal(strings.TrimSpace(space.ReplaceAllString(stmt, " ")), strings.TrimSpace(space.ReplaceAllString(sql, " ")))
-
+	a.Equal(1, len(stmt))
+	a.Equal(space.ReplaceAllString(stmt[0], " "), space.ReplaceAllString(sql, " "))
 }
 
 func TestComplete(t *testing.T) {
@@ -268,6 +396,15 @@ func TestComplete(t *testing.T) {
 	p.InsertText(`nto sqlflow_models.my_awesome_model;`, false, true)
 	c = s.completer(*p.Document())
 	a.Equal(0, len(c))
+
+	// Test cross line completion
+	s = newPromptState()
+	s.statements = []string{"TO"}
+	p = prompt.NewBuffer()
+	p.InsertText("t", false, true)
+	c = s.completer(*p.Document())
+	a.Equal(1, len(c))
+	a.Equal("TRAIN", c[0].Text)
 }
 
 func TestTerminalCheck(t *testing.T) {


### PR DESCRIPTION
This is a follow-up of #1756 and #1758 
1. This PR split the input into several statements properly via taking single-line comments and quoted-strings into consideration. The new function `AddLineToStmt` do this job.
2. The multiple statements are sent to `RunSQLProgram` respectively, hence make the `use db_name` statements work well.
3. The single-line comments are not constrained to the first line of a statement as #1758 did.
4. Add lots of unit tests to make sure the above works as expected.