### PR TITLE
Cleanup pkg/parser API

### DIFF
--- a/pkg/parser/sqlflow_parser.go
+++ b/pkg/parser/sqlflow_parser.go
@@ -44,7 +44,7 @@ func ParseStatement(dialect, program string) (*SQLFlowStmt, error) {
 		return nil, err
 	}
 	if len(stmts) != 1 {
-		return nil, fmt.Errorf("expecting one statement, got %s", len(stmts))
+		return nil, fmt.Errorf("expecting one statement, got %d", len(stmts))
 	}
 
 	return stmts[0], nil

--- a/pkg/parser/sqlflow_parser.go
+++ b/pkg/parser/sqlflow_parser.go
@@ -32,22 +32,22 @@ type SQLFlowStmt struct {
 
 // IsExtendedSyntax returns true if a parsed statement uses any
 // SQLFlow syntax extensions.
-func IsExtendedSyntax(stmt *SQLFlowStmt) bool {
+func (stmt *SQLFlowStmt) IsExtendedSyntax() bool {
 	return stmt.SQLFlowSelectStmt != nil
 }
 
-// ParseOneStatement parses a SQL program by calling Parse, and
+// ParseStatement parses a SQL program by calling Parse, and
 // asserts that this program contains one and only one statement.
-func ParseOneStatement(dialect, sql string) (*SQLFlowStmt, error) {
-	sqls, err := Parse(dialect, sql)
+func ParseStatement(dialect, program string) (*SQLFlowStmt, error) {
+	stmts, err := Parse(dialect, program)
 	if err != nil {
 		return nil, err
 	}
-	if len(sqls) != 1 {
-		return nil, fmt.Errorf("unexpected number of statements 1(expected) != %v(received)", len(sqls))
+	if len(stmts) != 1 {
+		return nil, fmt.Errorf("expecting one statement, got %s", len(stmts))
 	}
 
-	return sqls[0], nil
+	return stmts[0], nil
 }
 
 // Parse a SQL program in the given dialect into a list of SQL statements.

--- a/pkg/parser/sqlflow_parser_test.go
+++ b/pkg/parser/sqlflow_parser_test.go
@@ -46,7 +46,7 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		s, err := Parse(dbms, sql+";")
 		a.NoError(err)
 		a.Equal(1, len(s))
-		a.False(IsExtendedSyntax(s[0]))
+		a.False(s[0].IsExtendedSyntax())
 		if isJavaParser(dbms) {
 			a.Equal(sql, s[0].Original)
 		} else {
@@ -60,7 +60,7 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.NoError(err)
 		a.Equal(len(external.SelectCases), len(s))
 		for i := range s {
-			a.False(IsExtendedSyntax(s[i]))
+			a.False(s[i].IsExtendedSyntax())
 			if isJavaParser(dbms) {
 				a.Equal(external.SelectCases[i], s[i].Original)
 			} else {
@@ -76,11 +76,11 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.NoError(err)
 		a.Equal(2, len(s))
 
-		a.True(IsExtendedSyntax(s[0]))
+		a.True(s[0].IsExtendedSyntax())
 		a.Equal(sql+` `, s[0].StandardSelect.String())
 		a.Equal(fmt.Sprintf(`%s %s;`, sql, extendedSQL), s[0].Original)
 
-		a.False(IsExtendedSyntax(s[1]))
+		a.False(s[1].IsExtendedSyntax())
 		if isJavaParser(dbms) {
 			a.Equal(sql, s[1].Original)
 		} else {
@@ -94,8 +94,8 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		s, err := Parse(dbms, sqls)
 		a.NoError(err)
 		a.Equal(2, len(s))
-		a.False(IsExtendedSyntax(s[0]))
-		a.True(IsExtendedSyntax(s[1]))
+		a.False(s[0].IsExtendedSyntax())
+		a.True(s[1].IsExtendedSyntax())
 		if isJavaParser(dbms) {
 			a.Equal(sql, s[0].Original)
 		} else {
@@ -112,13 +112,9 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.NoError(err)
 		a.Equal(3, len(s))
 
-		// a.False(IsExtendedSyntax(s[0]))
-		// a.True(IsExtendedSyntax(s[1]))
-		// a.False(IsExtendedSyntax(s[2]))
-
-		a.False(IsExtendedSyntax(s[0]))
-		a.True(IsExtendedSyntax(s[1]))
-		a.False(IsExtendedSyntax(s[2]))
+		a.False(s[0].IsExtendedSyntax())
+		a.True(s[1].IsExtendedSyntax())
+		a.False(s[2].IsExtendedSyntax())
 
 		if isJavaParser(dbms) {
 			a.Equal(sql, s[0].Original)

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -137,7 +137,7 @@ func loadModelMeta(pr *parser.SQLFlowSelectStmt, db *database.DB, cwd, modelDir,
 	}
 	// Parse the training SELECT statement used to train
 	// the model for the prediction.
-	tr, e := parser.ParseOneStatement(db.DriverName, m.TrainSelect)
+	tr, e := parser.ParseStatement(db.DriverName, m.TrainSelect)
 	if e != nil {
 		return nil, fmt.Errorf("parse: TrainSelect %v raise %v", m.TrainSelect, e)
 	}

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -51,7 +51,7 @@ func TestGenerateTrainStmt(t *testing.T) {
 	INTO mymodel;
 	`
 
-	r, e := parser.ParseOneStatement("mysql", normal)
+	r, e := parser.ParseStatement("mysql", normal)
 	a.NoError(e)
 
 	trainStmt, err := generateTrainStmt(r.SQLFlowSelectStmt)
@@ -176,7 +176,7 @@ func TestGenerateTrainStmtModelZoo(t *testing.T) {
 	INTO mymodel;
 	`
 
-	r, e := parser.ParseOneStatement("mysql", normal)
+	r, e := parser.ParseStatement("mysql", normal)
 	a.NoError(e)
 
 	trainStmt, err := generateTrainStmt(r.SQLFlowSelectStmt)
@@ -194,7 +194,7 @@ func TestGeneratePredictStmt(t *testing.T) {
 	predSQL := `SELECT * FROM iris.test
 TO PREDICT iris.predict.class
 USING sqlflow_models.mymodel;`
-	r, e := parser.ParseOneStatement("mysql", predSQL)
+	r, e := parser.ParseStatement("mysql", predSQL)
 	a.NoError(e)
 
 	// need to save a model first because predict SQL will read the train SQL
@@ -248,7 +248,7 @@ INTO sqlflow_models.my_xgboost_model;
 	a.NoError(e)
 	a.True(goodStream(stream.ReadAll()))
 
-	pr, e := parser.ParseOneStatement("mysql", `
+	pr, e := parser.ParseStatement("mysql", `
 	SELECT *
 	FROM iris.train
 	TO EXPLAIN sqlflow_models.my_xgboost_model
@@ -272,7 +272,7 @@ INTO sqlflow_models.my_xgboost_model;
 	a.True(ok)
 	a.Equal("sepal_length", nc.FieldDesc.Name)
 
-	pr, e = parser.ParseOneStatement("mysql", `
+	pr, e = parser.ParseStatement("mysql", `
 	SELECT *
 	FROM iris.train
 	TO EXPLAIN sqlflow_models.my_xgboost_model
@@ -291,7 +291,7 @@ INTO sqlflow_models.my_xgboost_model;
 	a.Equal(len(ExplainIntoStmt.Attributes), 3)
 	a.Equal("db.explain_result", ExplainIntoStmt.Into)
 
-	pr, e = parser.ParseOneStatement("mysql", `SELECT * FROM iris.train TO EXPLAIN sqlflow_models.my_xgboost_model;`)
+	pr, e = parser.ParseStatement("mysql", `SELECT * FROM iris.train TO EXPLAIN sqlflow_models.my_xgboost_model;`)
 	a.NoError(e)
 	shortExplainStmt, e := generateExplainStmt(pr.SQLFlowSelectStmt, connStr, modelDir, cwd, true)
 	a.NoError(e)

--- a/pkg/verifier/verifier_test.go
+++ b/pkg/verifier/verifier_test.go
@@ -15,8 +15,9 @@ package verifier
 
 import (
 	"os"
-	"sqlflow.org/sqlflow/pkg/parser"
 	"testing"
+
+	"sqlflow.org/sqlflow/pkg/parser"
 
 	"github.com/stretchr/testify/assert"
 	"sqlflow.org/sqlflow/pkg/database"
@@ -56,7 +57,7 @@ func TestVerify(t *testing.T) {
 
 func TestVerifyColumnNameAndType(t *testing.T) {
 	a := assert.New(t)
-	trainParse, e := parser.ParseOneStatement("mysql", `SELECT gender, tenure, TotalCharges
+	trainParse, e := parser.ParseStatement("mysql", `SELECT gender, tenure, TotalCharges
 FROM churn.train LIMIT 10
 TO TRAIN DNNClassifier
 WITH
@@ -67,14 +68,14 @@ LABEL class
 INTO sqlflow_models.my_dnn_model;`)
 	a.NoError(e)
 
-	predParse, e := parser.ParseOneStatement("mysql", `SELECT gender, tenure, TotalCharges
+	predParse, e := parser.ParseStatement("mysql", `SELECT gender, tenure, TotalCharges
 FROM churn.train LIMIT 10
 TO PREDICT iris.predict.class
 USING sqlflow_models.my_dnn_model;`)
 	a.NoError(e)
 	a.NoError(VerifyColumnNameAndType(trainParse.SQLFlowSelectStmt, predParse.SQLFlowSelectStmt, database.GetTestingDBSingleton()))
 
-	predParse, e = parser.ParseOneStatement("mysql", `SELECT gender, tenure
+	predParse, e = parser.ParseStatement("mysql", `SELECT gender, tenure
 FROM churn.train LIMIT 10
 TO PREDICT iris.predict.class
 USING sqlflow_models.my_dnn_model;`)


### PR DESCRIPTION
Minimize the API of pkg/parser and make it like the one in https://github.com/sql-machine-learning/sqlflow/issues/1434#issuecomment-575966175

After the merge of this PR, the exported types include:

1. `type SQLFlowStmt struct`, and
1. AST node-like types defined in goyacc file.

The exported functions include:

1. `func ParseStatement(dialect, program string) (*SQLFlowStmt, error)`
1. `func Parse(dialect, program string) ([]*SQLFlowStmt, error) `

The following commands help me understand the API.

```bash
git grep 'type *[A-Z]'
git grep 'func *[A-Z]'
```