### PR TITLE
Improve ascii for small size figure

### DIFF
--- a/python/plotille_text_backend.py
+++ b/python/plotille_text_backend.py
@@ -121,8 +121,8 @@ class FigureCanvasPlotille(FigureCanvasAgg):
         def set_text(canvas, x, y, text):
             x_idx = canvas._transform_x(x)
             y_idx = canvas._transform_y(y)
-            x_c = x_idx // 2
-            y_c = y_idx // 4
+            x_c = max(x_idx // 2, 0)
+            y_c = max(y_idx // 4, 0)
 
             for i, c in enumerate(text):
                 canvas._canvas[y_c][x_c + i] = c


### PR DESCRIPTION
Fix #1778 , the result of the same command now looks like:
![image](https://user-images.githubusercontent.com/4180295/73058876-82183b80-3ecf-11ea-8fb2-4d5b6ebf2cbb.png)
