### PR TITLE
Print time spent in REPL and remove redundant `+\'

### DIFF
--- a/cmd/repl/prompt.go
+++ b/cmd/repl/prompt.go
@@ -87,7 +87,6 @@ func (p *promptState) execute(in string, cb func(string)) {
 		if addLineToStmt(in, &p.inQuotedString, &p.isSingleQuoted, &p.statements) {
 			p.updateHistory()
 			p.enableLivePrefix = false
-			fmt.Println()
 			for _, stmt := range p.statements {
 				cb(stmt)
 			}


### PR DESCRIPTION
- Print time spent in REPL
- The original code has a tiny bug that prints `"+\n+\n"` at the end of execution, this change fixes the problem.
Before the change:
```bash
sqlflow> show tables;

2020/02/06 11:56:04 runSQLProgram error: runQuery failed: Error 1046: No database selected
+
+
sqlflow> show databases;

+--------------------+
|      DATABASE      |
+--------------------+
| information_schema |
| boston             |
| churn              |
| creditcard         |
| imdb               |
| iris               |
| mysql              |
| performance_schema |
| sqlflow            |
| sqlflow_models     |
| sys                |
| titanic            |
+--------------------+
sqlflow>
```
After the change:
```bash
sqlflow> show tables;
2020/02/06 12:55:46 runSQLProgram error: runQuery failed: Error 1046: No database selected
sqlflow> show databases;
+--------------------+
|      DATABASE      |
+--------------------+
| information_schema |
| boston             |
| churn              |
| creditcard         |
| imdb               |
| iris               |
| mysql              |
| performance_schema |
| sqlflow            |
| sqlflow_models     |
| sys                |
| titanic            |
+--------------------+
12 rows in set (0.00 sec)

sqlflow>
```