### PR TITLE
Speed up KernelExplainer via kmeans

### DIFF
--- a/python/sqlflow_submitter/tensorflow/explain.py
+++ b/python/sqlflow_submitter/tensorflow/explain.py
@@ -128,13 +128,14 @@ def explain_dnns(datasource, estimator, shap_dataset, plot_type, result_table,
     def predict(d):
         def input_fn():
             return tf.data.Dataset.from_tensor_slices(
-                dict(pd.DataFrame(d, columns=shap_dataset.columns))).batch(1000)
+                dict(pd.DataFrame(d,
+                                  columns=shap_dataset.columns))).batch(1000)
 
         return np.array(
             [p['probabilities'][-1] for p in estimator.predict(input_fn)])
 
     if len(shap_dataset) > 100:
-        # Reduce to 16 weighted samples to speed up 
+        # Reduce to 16 weighted samples to speed up
         shap_dataset_summary = shap.kmeans(shap_dataset, 16)
     else:
         shap_dataset_summary = shap_dataset

--- a/python/sqlflow_submitter/tensorflow/explain.py
+++ b/python/sqlflow_submitter/tensorflow/explain.py
@@ -130,7 +130,6 @@ def explain_dnns(datasource, estimator, shap_dataset, plot_type, result_table,
             return tf.data.Dataset.from_tensor_slices(
                 dict(pd.DataFrame(d, columns=shap_dataset.columns))).batch(1000)
 
-        print(end="\r") 
         return np.array(
             [p['probabilities'][-1] for p in estimator.predict(input_fn)])
 

--- a/python/sqlflow_submitter/tensorflow/explain.py
+++ b/python/sqlflow_submitter/tensorflow/explain.py
@@ -128,13 +128,19 @@ def explain_dnns(datasource, estimator, shap_dataset, plot_type, result_table,
     def predict(d):
         def input_fn():
             return tf.data.Dataset.from_tensor_slices(
-                dict(pd.DataFrame(d, columns=shap_dataset.columns))).batch(1)
+                dict(pd.DataFrame(d, columns=shap_dataset.columns))).batch(1000)
 
+        print(end="\r") 
         return np.array(
-            [p['probabilities'][0] for p in estimator.predict(input_fn)])
+            [p['probabilities'][-1] for p in estimator.predict(input_fn)])
 
-    shap_values = shap.KernelExplainer(predict,
-                                       shap_dataset).shap_values(shap_dataset)
+    if len(shap_dataset) > 100:
+        # Reduce to 16 weighted samples to speed up 
+        shap_dataset_summary = shap.kmeans(shap_dataset, 16)
+    else:
+        shap_dataset_summary = shap_dataset
+    shap_values = shap.KernelExplainer(
+        predict, shap_dataset_summary).shap_values(shap_dataset, l1_reg="aic")
     if result_table != "":
         if is_pai:
             write_shap_values(shap_values, "pai_maxcompute", None,


### PR DESCRIPTION
1. Enlarge batch size
2. Call `shap.kmeans` to reduce sample amount as recommended by SHAP official, see https://github.com/slundberg/shap/blob/master/notebooks/kernel_explainer/Diabetes%20regression.ipynb
The result looks like:
![titanic_dot](https://user-images.githubusercontent.com/4180295/74084134-ca765280-4aa6-11ea-8336-3cbb4a81a100.png)
It seems the binary features are clustered together，which seems ok without loss of generality