### PR TITLE
Fix random sorted suggestions

### DIFF
--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -496,6 +496,7 @@ func TestComplete(t *testing.T) {
 	p.InsertText(`RAIN `, false, true)
 	c = s.completer(*p.Document())
 	a.Equal(18, len(c))
+	a.Equal("BoostedTreesClassifier", c[0].Text)
 
 	p.InsertText(`DNN`, false, true)
 	c = s.completer(*p.Document())
@@ -543,6 +544,7 @@ func TestComplete(t *testing.T) {
 	p.InsertText(`model.optimizer=`, false, true)
 	c = s.completer(*p.Document())
 	a.Equal(8, len(c))
+	a.Equal("Adadelta", c[0].Text)
 
 	p.InsertText(`R`, false, true)
 	c = s.completer(*p.Document())


### PR DESCRIPTION
In Go 1, the order in which elements are visited when iterating over a map using a for range statement is random, which is strange for SQLFlow REPL users, this change fixed the problem.
See https://stackoverflow.com/questions/55925822/in-golang-why-are-iterations-over-maps-random and https://nathanleclaire.com/blog/2014/04/27/a-surprising-feature-of-golang-that-colored-me-impressed/