### PR TITLE
Xgboost eval metric

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -336,6 +336,7 @@ func TestEnd2EndMySQL(t *testing.T) {
 	t.Run("CaseTrainTextClassificationIR", CaseTrainTextClassificationIR)
 	t.Run("CaseTrainTextClassificationFeatureDerivation", CaseTrainTextClassificationFeatureDerivation)
 	t.Run("CaseXgboostFeatureDerivation", CaseXgboostFeatureDerivation)
+	t.Run("CaseXgboostEvalMetric", CaseXgboostEvalMetric)
 	t.Run("CaseTrainFeatureDerivation", CaseTrainFeatureDerivation)
 }
 
@@ -371,6 +372,25 @@ INTO sqlflow_models.my_xgb_regression_model;`
 	predSQL := `SELECT * FROM housing.test
 TO PREDICT housing.predict.target
 USING sqlflow_models.my_xgb_regression_model;`
+	_, _, err = connectAndRunSQL(predSQL)
+	if err != nil {
+		a.Fail("run test error: %v", err)
+	}
+}
+
+func CaseXgboostEvalMetric(t *testing.T) {
+	a := assert.New(t)
+	trainSQL := `SELECT * FROM iris.train WHERE class in (0, 1) TO TRAIN xgboost.gbtree
+WITH objective="binary:logistic", eval_metric=auc
+LABEL class
+INTO sqlflow_models.my_xgb_binary_classification_model;`
+	_, _, err := connectAndRunSQL(trainSQL)
+	if err != nil {
+		a.Fail("run test error: %v", err)
+	}
+
+	predSQL := `SELECT * FROM iris.test TO PREDICT iris.predict.class
+USING sqlflow_models.my_xgb_binary_classification_model;`
 	_, _, err = connectAndRunSQL(predSQL)
 	if err != nil {
 		a.Fail("run test error: %v", err)

--- a/doc/model_parameter.md
+++ b/doc/model_parameter.md
@@ -54,6 +54,11 @@ INTO sqlflow_models.my_xgb_regression_model;
 	<td>[default=0.3, alias: learning_rate]<br>Step size shrinkage used in update to prevents overfitting. After each boosting step, we can directly get the weights of new features, and eta shrinks the feature weights to make the boosting process more conservative.<br>range: [0,1]</td>
 </tr>
 <tr>
+	<td>eval_metric</td>
+	<td>string</td>
+	<td>eval metric</td>
+</tr>
+<tr>
 	<td>gamma</td>
 	<td>float32</td>
 	<td>Minimum loss reduction required to make a further partition on a leaf node of the tree.</td>

--- a/pkg/sql/codegen/xgboost/codegen.go
+++ b/pkg/sql/codegen/xgboost/codegen.go
@@ -35,7 +35,8 @@ Step size shrinkage used in update to prevents overfitting. After each boosting 
 range: [0,1]`, attribute.Float32RangeChecker(0, 1, true, true)},
 	"num_class": {attribute.Int, nil, `Number of classes.
 range: [2, Infinity]`, attribute.IntLowerBoundChecker(2, true)},
-	"objective": {attribute.String, nil, `Learning objective`, nil},
+	"objective":   {attribute.String, nil, `Learning objective`, nil},
+	"eval_metric": {attribute.String, nil, `eval metric`, nil},
 	"train.num_boost_round": {attribute.Int, 10, `[default=10]
 The number of rounds for boosting.
 range: [1, Infinity]`, attribute.IntLowerBoundChecker(1, true)},

--- a/pkg/sql/codegen/xgboost/codegen_test.go
+++ b/pkg/sql/codegen/xgboost/codegen_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestAttributes(t *testing.T) {
 	a := assert.New(t)
-	a.Equal(5, len(attributeDictionary))
-	a.Equal(27, len(fullAttrValidator))
+	a.Equal(6, len(attributeDictionary))
+	a.Equal(28, len(fullAttrValidator))
 }
 
 func mockSession() *pb.Session {


### PR DESCRIPTION
Fix https://github.com/sql-machine-learning/sqlflow/issues/1801. Usage `WITH eval_metric=auc`.