### PR TITLE
Fix couler YAML

### DIFF
--- a/pkg/sql/codegen/couler/codegen.go
+++ b/pkg/sql/codegen/couler/codegen.go
@@ -61,6 +61,7 @@ func getStepEnvs(session *pb.Session) (map[string]string, error) {
 	if _, ok := envs["SQLFLOW_submitter"]; !ok {
 		envs["SQLFLOW_submitter"] = os.Getenv("SQLFLOW_submitter")
 	}
+	envs["SQLFLOW_PARSER_SERVER_PORT"] = os.Getenv("SQLFLOW_PARSER_SERVER_PORT")
 	return envs, nil
 }
 

--- a/python/couler/couler/argo.py
+++ b/python/couler/couler/argo.py
@@ -640,7 +640,7 @@ def _convert_dict_to_env_list(d):
 
     env_list = []
     for k, v in d.items():
-        if isinstance(v, bool):
+        if isinstance(v, bool) or isinstance(v, int):
             value = "'%s'" % v
             env_list.append({"name": str(k), "value": value})
         elif k == "secrets":


### PR DESCRIPTION
If the env type in YAML is not str, it should be quoted by `""`