### PR TITLE
Enable LIMIT clause for calcite

### DIFF
--- a/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
+++ b/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
@@ -63,9 +63,10 @@ public class CalciteParserAdaptor {
             continue;
           }
 
-          // Make sure the left hand side is a select statement, so that
+          // Make sure the left hand side is a query, so that
           // we can try parse the right hand side with the SQLFlow parser
-          if (sqlnode.getKind() != SqlKind.SELECT) {
+          // SqlKind.QUERY is {SELECT, EXCEPT, INTERSECT, UNION, VALUES, ORDER_BY, EXPLICIT_TABLE}
+          if (!SqlKind.QUERY.contains(sqlnode.getKind())) {
             // return original error
             parse_result.Statements = new ArrayList<String>();
             parse_result.Position = -1;

--- a/pkg/parser/external/test_cases.go
+++ b/pkg/parser/external/test_cases.go
@@ -54,6 +54,6 @@ WHERE
         WHERE
             customerNumber = customers.customerNumber
         GROUP BY orderNumber
-        HAVING SUM(priceEach * quantityOrdered) > 60000)`,
+        HAVING SUM(priceEach * quantityOrdered) > 60000) LIMIT 0`,
 	}
 )


### PR DESCRIPTION
A `SELECT` statement with `LIMIT` is `SqlKind.ORDER_BY` rather than `SqlKind.SELECT`.