### PR TITLE
Fix verify COLUMN EMBEDDING(CATEGORY_ID(col, ...))

### DIFF
--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -98,8 +98,9 @@ func getExpressionFieldName(expr *parser.Expr) (string, error) {
 	if len(expr.Sexp) < 2 {
 		return "", fmt.Errorf("error column clause format: %s, expected FEATURE_COLUMN(key, ...)", expr.Sexp)
 	}
-	fcNameExpr := expr.Sexp[1]
-	return fcNameExpr.Value, nil
+	// NOTE(typhoonzero): recursively get the expression field name: the expression
+	// maybe: func(func(func(key, ...)))
+	return getExpressionFieldName(expr.Sexp[1])
 }
 
 // VerifyColumnNameAndType check train and pred clause uses has the same feature columns


### PR DESCRIPTION
Fix verify  column clauses like `COLUMN EMBEDDING(CATEGORY_ID(col, ...))` when predicting