### PR TITLE
Enable UNION clause for calcite and mysql

### DIFF
--- a/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
+++ b/java/parser/src/main/java/org/sqlflow/parser/CalciteParserAdaptor.java
@@ -66,7 +66,7 @@ public class CalciteParserAdaptor {
           // Make sure the left hand side is a query, so that
           // we can try parse the right hand side with the SQLFlow parser
           // SqlKind.QUERY is {SELECT, EXCEPT, INTERSECT, UNION, VALUES, ORDER_BY, EXPLICIT_TABLE}
-          if (!SqlKind.QUERY.contains(sqlnode.getKind())) {
+          if (!SqlKind.QUERY.contains(sqlnode.getKind()) && sqlnode.getKind() != SqlKind.UNION) {
             // return original error
             parse_result.Statements = new ArrayList<String>();
             parse_result.Position = -1;

--- a/pkg/parser/external/tidb_parser.go
+++ b/pkg/parser/external/tidb_parser.go
@@ -74,7 +74,9 @@ func (p *tidbParser) Parse(program string) ([]string, int, error) {
 
 		// Make sure the left hand side is a select statement, so that
 		// we can try parse the right hand side with the SQLFlow parser
-		if _, ok := nodes[len(nodes)-1].(*ast.SelectStmt); !ok {
+		switch nodes[len(nodes)-1].(type) {
+		case *ast.SelectStmt, *ast.UnionStmt:
+		default:
 			// return the original parsing error
 			return nil, -1, err
 		}

--- a/pkg/parser/sqlflow_parser_test.go
+++ b/pkg/parser/sqlflow_parser_test.go
@@ -135,6 +135,14 @@ func commonTestCases(dbms string, a *assert.Assertions) {
 		a.Equal(0, len(s))
 	}
 
+	{ // SELECT...UNION...SELECT statement
+		sql := `select * from (select 1 limit 1) a union select * from (select 1) b to explain model;`
+
+		s, err := Parse(dbms, sql)
+		a.Nil(err)
+		a.Equal(1, len(s))
+	}
+
 	// two SQL statements, the second standard SQL has an error.
 	for _, sql := range external.SelectCases {
 		sqls := fmt.Sprintf(`%s %s; select select 1;`, sql, extendedSQL)


### PR DESCRIPTION
This is similar to #1849 .
The following statement is supported now
```sql
(SELECT *  FROM fraud.train WHERE class=0 LIMIT 1024) UNION (SELECT * FROM fraud.train WHERE class=1) TO TRAIN ...;
```