### PR TITLE
Reset navigate cursor to the start

### DIFF
--- a/cmd/repl/prompt.go
+++ b/cmd/repl/prompt.go
@@ -310,6 +310,7 @@ func (p *promptState) navigateHistory(origInput string, older bool, buf *prompt.
 }
 
 func (p *promptState) updateHistory() {
+	p.historyNavPos = 0
 	input := strings.Join(p.statements, " ")
 	lastInput := strings.Join(p.lastStatements, " ")
 	if len(p.statements) != 0 && input != lastInput {


### PR DESCRIPTION
The original code will stay at the navigate position even the user has executed the history statement. The change fix this.