### PR TITLE
Add tablewriter interface in repl

### DIFF
--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -33,11 +33,11 @@ import (
 	"syscall"
 
 	"github.com/mattn/go-sixel"
-	"github.com/olekukonko/tablewriter"
 	"golang.org/x/crypto/ssh/terminal"
 	"sqlflow.org/goalisa"
 	"sqlflow.org/gohive"
 	"sqlflow.org/gomaxcompute"
+	"sqlflow.org/sqlflow/cmd/repl/tablewriter"
 	"sqlflow.org/sqlflow/pkg/database"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	"sqlflow.org/sqlflow/pkg/sql"
@@ -179,21 +179,20 @@ func imageCat(imageBytes []byte) error {
 
 var it2Check = false
 
-func render(rsp interface{}, table *tablewriter.Table, isTerminal bool) (bool, error) {
+func render(rsp interface{}, table tablewriter.TableWriter, isTerminal bool) error {
 	switch s := rsp.(type) {
 	case map[string]interface{}: // table header
 		cols, e := header(s)
 		if e == nil {
 			table.SetHeader(cols)
 		}
-		return true, nil
+		return nil
 	case []interface{}: // row
 		row := make([]string, len(s))
 		for i, v := range s {
 			row[i] = fmt.Sprint(v)
 		}
-		table.Append(row)
-		return true, nil
+		return table.AppendRow(row)
 	case error:
 		if os.Getenv("SQLFLOW_log_dir") != "" { // To avoid printing duplicated error message to console
 			log.New(os.Stderr, "", 0).Printf("ERROR: %v\n", s)
@@ -201,7 +200,7 @@ func render(rsp interface{}, table *tablewriter.Table, isTerminal bool) (bool, e
 		if !isTerminal {
 			os.Exit(1)
 		}
-		return false, s
+		return s
 	case sql.EndOfExecution:
 	case sql.Figures:
 		if isHTMLSnippet(s.Image) {
@@ -228,7 +227,7 @@ func render(rsp interface{}, table *tablewriter.Table, isTerminal bool) (bool, e
 	default:
 		log.Fatalf("unrecognized response type: %v", s)
 	}
-	return false, nil
+	return nil
 }
 
 func flagPassed(name ...string) bool {
@@ -248,8 +247,10 @@ func runStmt(stmt string, isTerminal bool, modelDir string, ds string) error {
 	if !isTerminal {
 		fmt.Println("sqlflow>", stmt)
 	}
-	tableRendered := false
-	table := tablewriter.NewWriter(os.Stdout)
+	table, err := tablewriter.NewTableWriter("ascii", tablePageSize, os.Stdout)
+	if err != nil {
+		return err
+	}
 	sess := sql.MakeSessionFromEnv()
 	sess.DbConnStr = getDataSource(ds, currentDB)
 	parts := strings.Fields(strings.ReplaceAll(stmt, ";", ""))
@@ -257,27 +258,16 @@ func runStmt(stmt string, isTerminal bool, modelDir string, ds string) error {
 		return switchDatabase(parts[1], sess)
 	}
 	stream := sql.RunSQLProgram(stmt, modelDir, sess)
-	var isTable bool
-	var err error
 	for rsp := range stream.ReadAll() {
-		// pagination. avoid exceed memory
-		isTable, err = render(rsp, table, isTerminal)
+		err = render(rsp, table, isTerminal)
 		if err != nil {
 			break
 		}
-		if isTable && table.NumLines() == tablePageSize {
-			table.Render()
-			tableRendered = true
-			table.ClearRows()
-		}
 	}
-	if table.NumLines() > 0 && !tableRendered {
-		table.Render()
+	if e := table.Flush(); e != nil {
+		return e
 	}
 	if err == nil {
-		if isTable {
-			fmt.Printf("%d rows in set ", table.NumLines())
-		}
 		fmt.Printf("(%.2f sec)\n", float64(time.Now().UnixNano()-startTime)/1e9)
 		fmt.Println()
 	}

--- a/cmd/repl/tablewriter/ascii.go
+++ b/cmd/repl/tablewriter/ascii.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tablewriter
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// TableWriter write the Table a speicial format,
+// the example code of ASCII formater:
+//
+// table := NewTableWriter("ascii", 1024, os.Stdout)
+// defer table.Flush()
+// table.SetHeader("col1", "col2")
+// table.AppendRow([]string{"1.0", "1.1"})
+// table.AppendRow([]string{"2.0", "2.1"})
+// if e := table.Flush(); e != nil {
+//   log.Falt(e)
+// }
+//
+type TableWriter interface {
+	SetHeader([]string) error
+	AppendRow([]string) error
+	Flush() error
+}
+
+// NewTableWriter a TableWriter instance
+func NewTableWriter(formater string, bufSize int, w io.Writer) (TableWriter, error) {
+	if formater == "ascii" {
+		return newASCIITableWriter(bufSize, w), nil
+	}
+	return nil, fmt.Errorf("SQLFLow does not support the table formater: %s", formater)
+}
+
+// ASCIITableWriter write table as ASCII formate
+type ASCIITableWriter struct {
+	table   *tablewriter.Table
+	bufSize int
+}
+
+func newASCIITableWriter(bufSize int, w io.Writer) *ASCIITableWriter {
+	return &ASCIITableWriter{
+		table:   tablewriter.NewWriter(w),
+		bufSize: bufSize,
+	}
+}
+
+// SetHeader set the table header
+func (s *ASCIITableWriter) SetHeader(header []string) error {
+	if len(header) == 0 {
+		return fmt.Errorf("header columns should not be empty")
+	}
+	s.table.SetHeader(header)
+	return nil
+}
+
+// AppendRow append row data
+func (s *ASCIITableWriter) AppendRow(rows []string) error {
+	s.table.Append(rows)
+	if s.table.NumLines() >= s.bufSize {
+		s.table.Render()
+		s.table.ClearRows()
+	}
+	return nil
+}
+
+// Flush the buffer
+func (s *ASCIITableWriter) Flush() error {
+	if s.table.NumLines() > 0 {
+		s.table.Render()
+		s.table.ClearRows()
+	}
+	return nil
+}

--- a/cmd/repl/tablewriter/ascii_test.go
+++ b/cmd/repl/tablewriter/ascii_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tablewriter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var expectedTableASCII = `+------+------+
+| COL1 | COL2 |
++------+------+
+|  1.0 |  1.1 |
+|  2.0 |  2.1 |
++------+------+
+`
+
+func TestASCIIWriter(t *testing.T) {
+	a := assert.New(t)
+	b := new(bytes.Buffer)
+	table, e := NewTableWriter("ascii", 1000, b)
+	table.SetHeader([]string{"col1", "col2"})
+	table.AppendRow([]string{"1.0", "1.1"})
+	table.AppendRow([]string{"2.0", "2.1"})
+	a.NoError(table.Flush())
+	a.NoError(e)
+	a.Equal(b.String(), expectedTableASCII)
+}


### PR DESCRIPTION
A part work of #1873 
related design doc #1887

TODO: add `ProtobufTablWriter` to format a table with the protobuf text format.
 