### PR TITLE
fix empty tablwriter

### DIFF
--- a/cmd/repl/tablewriter/ascii_test.go
+++ b/cmd/repl/tablewriter/ascii_test.go
@@ -66,3 +66,11 @@ func TestASCIIWriter(t *testing.T) {
 	a.NoError(e)
 	a.Equal(expectedTableASCII, b.String())
 }
+
+func TestEmptyASCIIWriter(t *testing.T) {
+	a := assert.New(t)
+	b := new(bytes.Buffer)
+	table, e := Create("ascii", 1000, b)
+	a.NoError(e)
+	a.NoError(table.Flush())
+}

--- a/cmd/repl/tablewriter/protobuf.go
+++ b/cmd/repl/tablewriter/protobuf.go
@@ -14,7 +14,6 @@
 package tablewriter
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/golang/protobuf/proto"
@@ -92,7 +91,7 @@ func (table *ProtobufWriter) formateWrite(msg proto.Message) error {
 
 func (table *ProtobufWriter) writeHead() error {
 	if len(table.head) == 0 {
-		return fmt.Errorf("should set header")
+		return nil
 	}
 	// skip write head if it has been writen to table.out
 	if table.hasWritenHeader {

--- a/cmd/repl/tablewriter/protobuf_test.go
+++ b/cmd/repl/tablewriter/protobuf_test.go
@@ -66,3 +66,12 @@ func TestProtobufWriter(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyProtobufWriter(t *testing.T) {
+	a := assert.New(t)
+	b := new(bytes.Buffer)
+	table, e := Create("protobuf", 1, b)
+	a.NoError(e)
+	// no output if step execute an extended sql
+	a.NoError(table.Flush())
+}


### PR DESCRIPTION
Workflow step raised an error for an extended SQL which has no query result.
``` text
...
2020/02/28 00:25:29 run SQL statement failed: should set header
```