### PR TITLE
Ensure explain dtypes

### DIFF
--- a/python/sqlflow_submitter/xgboost/explain.py
+++ b/python/sqlflow_submitter/xgboost/explain.py
@@ -41,6 +41,17 @@ def xgb_shap_dataset(datasource, select, feature_column_names, label_spec,
     for row in stream():
         xs.loc[i] = [item[0] for item in row[0]]
         i += 1
+    # NOTE(typhoonzero): set dtype to the feature's actual type, or the dtype
+    # may be "object". Use below code to reproduce:
+    # import pandas as pd
+    # feature_column_names=["a", "b"]
+    # xs = pd.DataFrame(columns=feature_column_names)
+    # for i in range(10):
+    #     xs.loc[i] = [int(j) for j in range(2)]
+    # print(xs.dtypes)
+    for fname in feature_column_names:
+        dtype = feature_specs[fname]["dtype"]
+        xs[fname] = xs[fname].astype(dtype)
     return xs
 
 

--- a/python/sqlflow_submitter/xgboost/explain_test.py
+++ b/python/sqlflow_submitter/xgboost/explain_test.py
@@ -25,7 +25,7 @@ select = "SELECT * FROM boston.train;"
 
 feature_field_meta = [{
     'feature_name': 'crim',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -33,7 +33,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'zn',
-    'dtype': 1,
+    'dtype': "int32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -41,7 +41,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'indus',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -49,7 +49,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'chas',
-    'dtype': 0,
+    'dtype': "int32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -57,7 +57,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'nox',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -65,7 +65,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'rm',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -73,7 +73,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'age',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -81,7 +81,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'dis',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -89,7 +89,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'rad',
-    'dtype': 0,
+    'dtype': "int32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -97,7 +97,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'tax',
-    'dtype': 0,
+    'dtype': "int32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -105,7 +105,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'ptratio',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -113,7 +113,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'b',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -121,7 +121,7 @@ feature_field_meta = [{
     'MaxID': 0
 }, {
     'feature_name': 'lstat',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,
@@ -131,7 +131,7 @@ feature_field_meta = [{
 
 label_field_meta = {
     'feature_name': 'medv',
-    'dtype': 1,
+    'dtype': "float32",
     'delimiter': '',
     'shape': [1],
     'is_sparse': False,


### PR DESCRIPTION
If the input feature is int, the explain will got an error:

```
sqlflow_submitter/xgboost/explain.py", line 59, in xgb_shap_values

return explainer.shap_values(x), explainer.shap_interaction_values(

File "/usr/lib64/python2.7/site-packages/shap/explainers/tree.py", line 174, in shap_values

X = xgboost.DMatrix(X)

File "/usr/lib/python2.7/site-packages/xgboost/core.py", line 384, in __init__

feature_types)

File "/usr/lib/python2.7/site-packages/xgboost/core.py", line 241, in _maybe_pandas_data

raise ValueError(msg + ', '.join(bad_fields))

ValueError: DataFrame.dtypes for data must be int, float or bool.
```

to reproduce:

```python
import pandas as pd

feature_column_names=["a", "b"]
xs = pd.DataFrame(columns=feature_column_names)
for i in range(10):
    xs.loc[i] = [int(j) for j in range(2)]

print(xs.dtypes)
```