### PR TITLE
Use multiple process and threading to speed up  data downloading for xgboost

### DIFF
--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -17,7 +17,6 @@ import sys
 
 import xgboost as xgb
 from sqlflow_submitter import db
-from sqlflow_submitter.tensorflow.input_fn import pai_maxcompute_db_generator
 
 SLICE_NUM = 128
 
@@ -85,12 +84,12 @@ def pai_download_table_data_worker(dir_or_file_name, feature_specs,
                                    feature_column_names, label_spec, pai_table,
                                    slice_id, single_file):
     label_column_name = label_spec['feature_name'] if label_spec else None
-    gen = pai_maxcompute_db_generator(pai_table,
-                                      feature_column_names,
-                                      label_column_name,
-                                      feature_specs,
-                                      slice_id=slice_id,
-                                      slice_count=SLICE_NUM)
+    gen = db.pai_maxcompute_db_generator(pai_table,
+                                         feature_column_names,
+                                         label_column_name,
+                                         feature_specs,
+                                         slice_id=slice_id,
+                                         slice_count=SLICE_NUM)
     if single_file:
         filename = dir_or_file_name
     else:

--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -1,0 +1,77 @@
+import sys
+import os
+import json
+from sqlflow_submitter import db
+from sqlflow_submitter.tensorflow.input_fn import pai_maxcompute_db_generator
+import xgboost as xgb
+
+SLICE_NUM=128
+
+def xgb_dataset(datasource,
+                fn,
+                dataset_sql,
+                feature_specs,
+                feature_column_names,
+                label_spec,
+                is_pai=False,
+                pai_table=""):
+
+    if is_pai:
+        pai_dataset(fn, feature_specs, feature_column_names, label_spec, "odps://{}/tables/{}".format(*pai_table.split(".")))
+    else:
+        conn = db.connect_with_data_source(datasource)
+        gen = db.db_generator(conn.driver, conn, dataset_sql,
+                              feature_column_names, label_spec, feature_specs)
+        dump_dmatrix(fn, gen, label_spec)
+    return xgb.DMatrix(fn)
+
+
+def dump_dmatrix(filename, generator, has_label):
+    # TODO(yancey1989): generate group and weight text file if necessary
+    with open(filename, 'w') as f:
+        for item in generator():
+            if not has_label:
+                row_data = ["%d:%f" % (i, v[0]) for i, v in enumerate(item[0])]
+            else:
+                features, label = item
+                row_data = [str(label)] + [
+                    "%d:%f" % (i, v[0]) for i, v in enumerate(features)
+                ]
+            f.write("\t".join(row_data) + "\n")
+
+
+def pai_dataset(dir_name, feature_specs, feature_column_names, label_spec, pai_table):
+    from subprocess import Popen, PIPE
+    import threading
+    threads = []
+    os.mkdir(dir_name)
+
+    def thread_worker(slice_id):
+        p = Popen("{} -m {}".format(sys.executable, __name__),
+                  shell=True, stdin=PIPE)
+        p.communicate(
+            json.dumps(
+                [dir_name, feature_specs, feature_column_names, label_spec, pai_table, slice_id]))
+
+    for i in range(SLICE_NUM):
+        t = threading.Thread(target=thread_worker, args=(i,))
+        t.start()
+        threads.append(t)
+    map(lambda t: t.join(), threads)
+
+
+def pai_download_table_data_worker(dir_name, feature_specs, feature_column_names, label_spec, pai_table, slice_id):
+    label_column_name = label_spec['feature_name'] if label_spec else None
+    gen = pai_maxcompute_db_generator(
+        pai_table, feature_column_names, label_column_name, feature_specs,
+        slice_id=slice_id, slice_count=SLICE_NUM)
+    with open("{}/{}".format(dir_name, slice_id), 'w') as f:
+        for item in gen():
+            row_data = ["%d:%f" % (i, v[0]) for i, v in enumerate(item[0])]
+            if label_spec:
+                row_data = [str(item[1])] + row_data
+            f.write("\t".join(row_data) + "\n")
+
+
+if __name__ == "__main__":
+    pai_download_table_data_worker(*json.load(sys.stdin))

--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import os
 import json

--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -92,7 +92,9 @@ def pai_download_table_data_worker(dir_name, feature_specs,
                                       slice_count=SLICE_NUM)
     with open("{}/{}".format(dir_name, slice_id), 'w') as f:
         for item in gen():
-            row_data = ["%d:%f" % (i, v[0]) for i, v in enumerate(item[0])]
+            row_data = [
+                "%d:%f" % (i, v[0] or 0) for i, v in enumerate(item[0])
+            ]
             if label_spec:
                 row_data = [str(item[1])] + row_data
             f.write("\t".join(row_data) + "\n")

--- a/python/sqlflow_submitter/xgboost/predict.py
+++ b/python/sqlflow_submitter/xgboost/predict.py
@@ -35,7 +35,7 @@ def pred(datasource,
     label_name = label_meta["feature_name"]
 
     dpred = xgb_dataset(datasource, 'predict.txt', select, feature_metas,
-                        feature_column_names, None, is_pai, pai_table)
+                        feature_column_names, None, is_pai, pai_table, True)
 
     bst = xgb.Booster({'nthread': 4})  # init model
     bst.load_model("my_model")  # load data

--- a/python/sqlflow_submitter/xgboost/predict.py
+++ b/python/sqlflow_submitter/xgboost/predict.py
@@ -14,8 +14,7 @@
 import numpy as np
 import xgboost as xgb
 from sqlflow_submitter import db
-
-from .train import xgb_dataset
+from sqlflow_submitter.xgboost.dataset import xgb_dataset
 
 
 def pred(datasource,

--- a/python/sqlflow_submitter/xgboost/train.py
+++ b/python/sqlflow_submitter/xgboost/train.py
@@ -12,45 +12,7 @@
 # limitations under the License.
 
 import xgboost as xgb
-from sqlflow_submitter import db
-
-
-def xgb_dataset(datasource,
-                fn,
-                dataset_sql,
-                feature_metas,
-                feature_column_names,
-                label_meta,
-                is_pai=False,
-                pai_table=""):
-
-    if is_pai:
-        pai_table_parts = pai_table.split(".")
-        formated_pai_table = "odps://%s/tables/%s" % (pai_table_parts[0],
-                                                      pai_table_parts[1])
-        if label_meta:
-            label_column_name = label_meta['feature_name']
-        else:
-            label_column_name = None
-        gen = db.pai_maxcompute_db_generator(formated_pai_table,
-                                             feature_column_names,
-                                             label_column_name, feature_metas)
-    else:
-        conn = db.connect_with_data_source(datasource)
-        gen = db.db_generator(conn.driver, conn, dataset_sql,
-                              feature_column_names, label_meta, feature_metas)
-    with open(fn, 'w') as f:
-        for item in gen():
-            if label_meta is None:
-                row_data = ["%d:%f" % (i, v[0]) for i, v in enumerate(item[0])]
-            else:
-                features, label = item
-                row_data = [str(label)] + [
-                    "%d:%f" % (i, v[0]) for i, v in enumerate(features)
-                ]
-            f.write("\t".join(row_data) + "\n")
-    # TODO(yancey1989): generate group and weight text file if necessary
-    return xgb.DMatrix(fn)
+from sqlflow_submitter.xgboost.dataset import xgb_dataset
 
 
 def train(datasource,


### PR DESCRIPTION
This is a follow-up of #1910. #1910 only improves the training speed of TensorFlow. This PR improves the training speed of XGBoost by reducing the downloading overhead by much times.