### PR TITLE
Fix the wrong row of step logs

### DIFF
--- a/pkg/sql/cmd.go
+++ b/pkg/sql/cmd.go
@@ -65,7 +65,8 @@ func sqlflowCmd(cwd, driverName string) (cmd *exec.Cmd) {
 	} else if hasDocker() {
 		const tfImg = "sqlflow/sqlflow"
 		if !hasDockerImage(tfImg) {
-			log.Printf("sqlflowCmd: No local Docker image %s.  It will take a long time to pull.", tfImg)
+			// TODO(yancey1989): write log into pipe to avoid the wrong row/
+			//log.Printf("sqlflowCmd: No local Docker image %s.  It will take a long time to pull.", tfImg)
 		}
 		cmd = exec.Command("docker", "run", "--rm",
 			fmt.Sprintf("-v%s:/work", cwd),

--- a/pkg/sql/codegen/pai/codegen.go
+++ b/pkg/sql/codegen/pai/codegen.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"text/template"
@@ -189,7 +188,6 @@ func Predict(ir *ir.PredictStmt, session *pb.Session, tarball, modelName, ossMod
 		return
 	}
 	if modelType == ModelTypePAIML {
-		log.Printf("predicting using pai prediction tookit")
 		if paiCmd, e = getPAIPredictCmd(ir, session); e != nil {
 			return
 		}
@@ -265,13 +263,11 @@ func Explain(ir *ir.ExplainStmt, session *pb.Session, tarball, modelName, ossMod
 		if expn.Requirements, err = genRequirements(false); err != nil {
 			return nil, err
 		}
-		log.Printf("explain using pai random forests")
 		expn.PaiCmd, err = getExplainRandomForestsPAICmd(ir, session)
 	} else if modelType == ModelTypeXGBoost {
 		if expn.Requirements, err = genRequirements(true); err != nil {
 			return nil, err
 		}
-		log.Printf("explain using pai xgboost")
 		ossURI, err := checkpointURL(ossModelPath, currProject)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"text/template"
@@ -395,7 +394,6 @@ func Pred(predStmt *ir.PredictStmt, session *pb.Session) (string, error) {
 	}
 	labelFM := predStmt.TrainStmt.Label.GetFieldDesc()[0]
 	if labelFM.Name == "" {
-		log.Printf("clustering model, got result table: %s, result column: %s", predStmt.ResultTable, predStmt.ResultColumn)
 		// no label in train SQL means a clustering model, generate a fieldDesc using result table's column
 		labelFM = &ir.FieldDesc{
 			Name:  predStmt.ResultColumn,

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -16,7 +16,6 @@ package sql
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -64,7 +63,6 @@ func createTmpTableFromSelect(selectStmt, dataSource string) (string, string, er
 	}
 	// NOTE(typhoonzero): MaxCompute do not support "CREATE	TABLE XXX AS (SELECT ...)"
 	createSQL := fmt.Sprintf("CREATE TABLE %s LIFECYCLE %d AS %s", tableName, lifecycleOnTmpTable, selectStmt)
-	log.Printf(createSQL)
 	_, err = db.Exec(createSQL)
 	return databaseName, tableName, err
 }
@@ -76,7 +74,8 @@ func dropTmpTables(tableNames []string, dataSource string) error {
 		return err
 	}
 	for _, tbName := range tableNames {
-		log.Printf("drop tmp table %s", tbName)
+		// TODO(yancey1989): write log into pipe to avoid the wrong row
+		// log.Printf("drop tmp table %s", tbName)
 		if tbName != "" {
 			_, err = db.Exec(fmt.Sprintf("DROP TABLE %s", tbName))
 			if err != nil {


### PR DESCRIPTION
The base64 HTML code may be in the wrong row, because of `log.Printf` and `pipe` in the different goroutine, I remoted `log.Printf` in this PR.

``` text
8eP069fPwCWL1/O8uXLXa/FxcW5vl+yZAkLFy4kPj4eb29vWrRowahRo2jVqpVbew6Hg48++ojFixeTmJhIzZo1GTlyZIF9x8fH8+mnn7J9+3ZOnDiB3W6nbt26DBo0iHvuucdVb+7cuUyePJmpU6fSoUMHtzZsNht33XUXDRs2ZPr06cU+/govPQvu+QekpDu3TS
v3zv49Fdnn+ds8PIPDppVhkGNdd1aRK4d2020/03/02 13:28:55 drop tmp table alifin_jtest_dev.lM6xIagpvf1IZh57
CtpK6MMPP2T69OncdtttDBw4EIvFwvHjx/n++++x2WyXHbSlpKQwduxYAAYOHEj16tVJSUlhz549/PTTT66gLc/UqVOx2+0MHTqU3NxcPvnkE8aNG8eECRN47bXXGDBgAHfddRerVq1i+vTp1KhRg969ewPOAOHxxx+ncuXKDB06lPDwcJKSkti5cyf79u0rVtA2a
```