### PR TITLE
Distributed train must specify validation.select

### DIFF
--- a/pkg/sql/codegen/pai/template_tf.go
+++ b/pkg/sql/codegen/pai/template_tf.go
@@ -64,11 +64,12 @@ else:
 # Keras single node is using h5 format to save the model, no need to deal with export model format.
 # Keras distributed mode will use estimator, so this is also needed.
 if is_estimator or {{.NumWorkers}} > 1:
-    with open("exported_path", "r") as fn:
-        saved_model_path = fn.read()
-
-    model.save_dir("{{.OSSModelDir}}", saved_model_path)
-    model.save_file("{{.OSSModelDir}}", "exported_path")
+    FLAGS = tf.app.flags.FLAGS
+    if FLAGS.task_index == 0:
+        with open("exported_path", "r") as fn:
+            saved_model_path = fn.read()
+        model.save_dir("{{.OSSModelDir}}", saved_model_path)
+        model.save_file("{{.OSSModelDir}}", "exported_path")
 
 model.save_metas("{{.OSSModelDir}}",
            {{.NumWorkers}},

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -238,7 +238,7 @@ def estimator_train_and_save(
         # NOTE(typhoonzero): if only do training, no validation result will be printed.
         classifier.train(lambda: train_input_fn(), max_steps=train_max_steps)
 
-    if FLAGS.task_index != 0:
+    if is_pai and FLAGS.task_index != 0:
         print("skip exporting model on woker != 0")
         return
     # export saved model for prediction

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -239,7 +239,7 @@ def estimator_train_and_save(
         classifier.train(lambda: train_input_fn(), max_steps=train_max_steps)
 
     if is_pai and FLAGS.task_index != 0:
-        print("skip exporting model on woker != 0")
+        print("skip exporting model on worker != 0")
         return
     # export saved model for prediction
     if "feature_columns" in model_params:

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -238,6 +238,9 @@ def estimator_train_and_save(
         # NOTE(typhoonzero): if only do training, no validation result will be printed.
         classifier.train(lambda: train_input_fn(), max_steps=train_max_steps)
 
+    if FLAGS.task_index != 0:
+        print("skip exporting model on woker != 0")
+        return
     # export saved model for prediction
     if "feature_columns" in model_params:
         all_feature_columns = model_params["feature_columns"]


### PR DESCRIPTION
Estimator only support distributed training by calling `train_and_evaluate`, so fail fast if distributed training with no `validation.select` specified.