### PR TITLE
Save typing in COLUMN clause with regex

### DIFF
--- a/pkg/ir/feature_column.go
+++ b/pkg/ir/feature_column.go
@@ -13,9 +13,12 @@
 
 package ir
 
+import "fmt"
+
 // FeatureColumn corresponds to the COLUMN clause in TO TRAIN.
 type FeatureColumn interface {
 	GetFieldDesc() []*FieldDesc
+	ApplyTo(string) (FeatureColumn, error)
 }
 
 // FieldDesc describes a field used as the input to a feature column.
@@ -49,8 +52,21 @@ type NumericColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (nc *NumericColumn) GetFieldDesc() []*FieldDesc {
-	return []*FieldDesc{nc.FieldDesc}
+func (c *NumericColumn) GetFieldDesc() []*FieldDesc {
+	return []*FieldDesc{c.FieldDesc}
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *NumericColumn) ApplyTo(name string) (FeatureColumn, error) {
+	return &NumericColumn{&FieldDesc{
+		Name:       name,
+		DType:      c.FieldDesc.DType,
+		Delimiter:  c.FieldDesc.Delimiter,
+		Shape:      c.FieldDesc.Shape,
+		IsSparse:   c.FieldDesc.IsSparse,
+		Vocabulary: c.FieldDesc.Vocabulary,
+		MaxID:      c.FieldDesc.MaxID,
+	}}, nil
 }
 
 // BucketColumn represents `tf.feature_column.bucketized_column`
@@ -61,8 +77,20 @@ type BucketColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (bc *BucketColumn) GetFieldDesc() []*FieldDesc {
-	return bc.SourceColumn.GetFieldDesc()
+func (c *BucketColumn) GetFieldDesc() []*FieldDesc {
+	return c.SourceColumn.GetFieldDesc()
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *BucketColumn) ApplyTo(name string) (FeatureColumn, error) {
+	sourceColumn, err := c.SourceColumn.ApplyTo(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BucketColumn{
+		SourceColumn: sourceColumn.(*NumericColumn),
+		Boundaries:   c.Boundaries,
+	}, nil
 }
 
 // CrossColumn represents `tf.feature_column.crossed_column`
@@ -73,18 +101,23 @@ type CrossColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (cc *CrossColumn) GetFieldDesc() []*FieldDesc {
+func (c *CrossColumn) GetFieldDesc() []*FieldDesc {
 	var retKeys []*FieldDesc
-	for idx, k := range cc.Keys {
+	for idx, k := range c.Keys {
 		if _, ok := k.(string); ok {
 			continue
 		} else if _, ok := k.(FeatureColumn); ok {
-			retKeys = append(retKeys, cc.Keys[idx].(*NumericColumn).GetFieldDesc()[0])
+			retKeys = append(retKeys, c.Keys[idx].(*NumericColumn).GetFieldDesc()[0])
 		}
 		// k is not possible to be neither string and FeatureColumn, the ir_generator should
 		// catch the syntax error.
 	}
 	return retKeys
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *CrossColumn) ApplyTo(name string) (FeatureColumn, error) {
+	return nil, fmt.Errorf("CrossColumn doesn't support the method ApplyTo")
 }
 
 // CategoryIDColumn represents `tf.feature_column.categorical_column_with_identity`
@@ -95,8 +128,21 @@ type CategoryIDColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (cc *CategoryIDColumn) GetFieldDesc() []*FieldDesc {
-	return []*FieldDesc{cc.FieldDesc}
+func (c *CategoryIDColumn) GetFieldDesc() []*FieldDesc {
+	return []*FieldDesc{c.FieldDesc}
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *CategoryIDColumn) ApplyTo(name string) (FeatureColumn, error) {
+	return &CategoryIDColumn{&FieldDesc{
+		Name:       name,
+		DType:      c.FieldDesc.DType,
+		Delimiter:  c.FieldDesc.Delimiter,
+		Shape:      c.FieldDesc.Shape,
+		IsSparse:   c.FieldDesc.IsSparse,
+		Vocabulary: c.FieldDesc.Vocabulary,
+		MaxID:      c.FieldDesc.MaxID,
+	}, c.BucketSize}, nil
 }
 
 // CategoryHashColumn represents `tf.feature_column.categorical_column_with_hash_bucket`
@@ -107,8 +153,23 @@ type CategoryHashColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (cc *CategoryHashColumn) GetFieldDesc() []*FieldDesc {
-	return []*FieldDesc{cc.FieldDesc}
+func (c *CategoryHashColumn) GetFieldDesc() []*FieldDesc {
+	return []*FieldDesc{c.FieldDesc}
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *CategoryHashColumn) ApplyTo(name string) (FeatureColumn, error) {
+	return &CategoryHashColumn{
+		&FieldDesc{
+			Name:       name,
+			DType:      c.FieldDesc.DType,
+			Delimiter:  c.FieldDesc.Delimiter,
+			Shape:      c.FieldDesc.Shape,
+			IsSparse:   c.FieldDesc.IsSparse,
+			Vocabulary: c.FieldDesc.Vocabulary,
+			MaxID:      c.FieldDesc.MaxID,
+		},
+		c.BucketSize}, nil
 }
 
 // SeqCategoryIDColumn represents `tf.feature_column.sequence_categorical_column_with_identity`
@@ -119,8 +180,23 @@ type SeqCategoryIDColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (scc *SeqCategoryIDColumn) GetFieldDesc() []*FieldDesc {
-	return []*FieldDesc{scc.FieldDesc}
+func (c *SeqCategoryIDColumn) GetFieldDesc() []*FieldDesc {
+	return []*FieldDesc{c.FieldDesc}
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *SeqCategoryIDColumn) ApplyTo(name string) (FeatureColumn, error) {
+	return &SeqCategoryIDColumn{
+		&FieldDesc{
+			Name:       name,
+			DType:      c.FieldDesc.DType,
+			Delimiter:  c.FieldDesc.Delimiter,
+			Shape:      c.FieldDesc.Shape,
+			IsSparse:   c.FieldDesc.IsSparse,
+			Vocabulary: c.FieldDesc.Vocabulary,
+			MaxID:      c.FieldDesc.MaxID,
+		},
+		c.BucketSize}, nil
 }
 
 // EmbeddingColumn represents `tf.feature_column.embedding_column`
@@ -136,11 +212,29 @@ type EmbeddingColumn struct {
 }
 
 // GetFieldDesc returns FieldDesc member
-func (ec *EmbeddingColumn) GetFieldDesc() []*FieldDesc {
-	if ec.CategoryColumn == nil {
+func (c *EmbeddingColumn) GetFieldDesc() []*FieldDesc {
+	if c.CategoryColumn == nil {
 		return []*FieldDesc{}
 	}
-	return ec.CategoryColumn.(FeatureColumn).GetFieldDesc()
+	return c.CategoryColumn.(FeatureColumn).GetFieldDesc()
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *EmbeddingColumn) ApplyTo(name string) (FeatureColumn, error) {
+	ret := &EmbeddingColumn{
+		Dimension:   c.Dimension,
+		Combiner:    c.Combiner,
+		Initializer: c.Initializer,
+		Name:        name,
+	}
+	if c.CategoryColumn != nil {
+		var err error
+		ret.CategoryColumn, err = c.CategoryColumn.ApplyTo(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
 }
 
 // IndicatorColumn represents `tf.feature_column.indicator_column`
@@ -158,4 +252,17 @@ func (c *IndicatorColumn) GetFieldDesc() []*FieldDesc {
 		return []*FieldDesc{}
 	}
 	return c.CategoryColumn.(FeatureColumn).GetFieldDesc()
+}
+
+// ApplyTo applies the FeatureColumn to a new field
+func (c *IndicatorColumn) ApplyTo(name string) (FeatureColumn, error) {
+	ret := &IndicatorColumn{Name: name}
+	if c.CategoryColumn != nil {
+		var err error
+		ret.CategoryColumn, err = c.CategoryColumn.ApplyTo(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
 }

--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -640,13 +640,15 @@ func parseCategoryHashColumn(el *parser.ExprList) (*ir.CategoryHashColumn, error
 
 func buildCategoryIDForEmbeddingOrIndicator(el *parser.ExprList) (ir.FeatureColumn, string, error) {
 	var catColumn ir.FeatureColumn
-	colName := "" // only used when catColumn == nil
 	sourceExprList := (*el)[1]
 	if sourceExprList.Type != 0 {
 		// 1. key is a IDET string: EMBEDDING(col_name, size), fill a nil in CategoryColumn for later
 		// feature derivation.
-		catColumn = nil
-		return nil, sourceExprList.Value, nil
+		name, err := expression2string(sourceExprList)
+		if err != nil {
+			return nil, "", fmt.Errorf("bad INDICATOR/EMBEDDING key: %s, err: %s", sourceExprList, err)
+		}
+		return nil, name, nil
 	}
 	source, err := parseFeatureColumn(&sourceExprList.Sexp)
 	if err != nil {
@@ -681,7 +683,7 @@ func buildCategoryIDForEmbeddingOrIndicator(el *parser.ExprList) (ir.FeatureColu
 		}
 		catColumn = tmpCatColumn
 	}
-	return catColumn, colName, nil
+	return catColumn, "", nil
 }
 
 func parseEmbeddingColumn(el *parser.ExprList) (*ir.EmbeddingColumn, error) {

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -92,8 +92,8 @@ func Verify(q string, db *database.DB) (FieldTypes, error) {
 	return ft, nil
 }
 
-// VerifyColumnNameAndType check train and pred clause uses has the same feature columns
-// 1. every column field in the training clause is selected in the pred clause, and they are of the same type
+// VerifyColumnNameAndType requires that every column field in the training statement other than the label is
+// selected in the predicting statement and of the same data type
 func VerifyColumnNameAndType(trainParsed, predParsed *parser.SQLFlowSelectStmt, db *database.DB) error {
 	trainFields, e := Verify(trainParsed.StandardSelect.String(), db)
 	if e != nil {
@@ -104,6 +104,9 @@ func VerifyColumnNameAndType(trainParsed, predParsed *parser.SQLFlowSelectStmt, 
 		return e
 	}
 	for n, t := range trainFields {
+		if n == trainParsed.Label {
+			continue
+		}
 		pt, ok := predFields.Get(n)
 		if !ok {
 			return fmt.Errorf("the predict statement doesn't contain column %s", n)

--- a/pkg/verifier/verifier_test.go
+++ b/pkg/verifier/verifier_test.go
@@ -81,7 +81,7 @@ TO PREDICT iris.predict.class
 USING sqlflow_models.my_dnn_model;`)
 	a.NoError(e)
 	a.EqualError(VerifyColumnNameAndType(trainParse.SQLFlowSelectStmt, predParse.SQLFlowSelectStmt, database.GetTestingDBSingleton()),
-		"predFields doesn't contain column totalcharges")
+		"the predict statement doesn't contain column totalcharges")
 }
 
 func TestDescribeEmptyTables(t *testing.T) {


### PR DESCRIPTION
Sometimes typing the `COLUMN` clause is very tedious because there're many fields that have to apply the same logic. For example, the titanic dataset has many fields that are best used as indicators:
```sql
use titanic;
desc train;
```
```
+--------------+---------+------+-----+---------+-------+
|    FIELD     |  TYPE   | NULL | KEY | DEFAULT | EXTRA |
+--------------+---------+------+-----+---------+-------+
| pclass_1     | int(11) | YES  |     | <nil>   |       |
| pclass_2     | int(11) | YES  |     | <nil>   |       |
| pclass_3     | int(11) | YES  |     | <nil>   |       |
| sex_female   | int(11) | YES  |     | <nil>   |       |
| sex_male     | int(11) | YES  |     | <nil>   |       |
| embarked_c   | int(11) | YES  |     | <nil>   |       |
| embarked_q   | int(11) | YES  |     | <nil>   |       |
| embarked_s   | int(11) | YES  |     | <nil>   |       |
| title_master | int(11) | YES  |     | <nil>   |       |
| title_misc   | int(11) | YES  |     | <nil>   |       |
| title_miss   | int(11) | YES  |     | <nil>   |       |
| title_mr     | int(11) | YES  |     | <nil>   |       |
| title_mrs    | int(11) | YES  |     | <nil>   |       |
| nosibsp      | int(11) | YES  |     | <nil>   |       |
| noparch      | int(11) | YES  |     | <nil>   |       |
| nullcabin    | int(11) | YES  |     | <nil>   |       |
| cabinalpha   | int(11) | YES  |     | <nil>   |       |
| family       | int(11) | YES  |     | <nil>   |       |
| isalone      | int(11) | YES  |     | <nil>   |       |
| ismother     | int(11) | YES  |     | <nil>   |       |
| age          | float   | YES  |     | <nil>   |       |
| realfare     | float   | YES  |     | <nil>   |       |
| survived     | int(11) | YES  |     | <nil>   |       |
+--------------+---------+------+-----+---------+-------+
```
If we try to train a `BoostedTreesClassifier`, we have to write
```sql
SELECT * FROM train TO TRAIN BoostedTreesClassifier
WITH model.n_batches_per_layer=4, 
     train.batch_size=100, 
     model.center_bias=True 
COLUMN INDICATOR(CATEGORY_ID(sex_male, 2)), 
       INDICATOR(CATEGORY_ID(sex_female, 2)),
       INDICATOR(CATEGORY_ID(pclass_1, 2)), 
       INDICATOR(CATEGORY_ID(pclass_2, 2)), 
       INDICATOR(CATEGORY_ID(pclass_3, 2)),
       -- many similar lines
LABEL survived INTO tfbt_model;
```

This PR try to leverage regular expressions to simplify typing, the above training statement can now be written as
```sql
SELECT * FROM train TO TRAIN BoostedTreesClassifier
WITH model.n_batches_per_layer=4, 
     train.batch_size=100, 
     model.center_bias=True 
-- age and  realfare are floats, family has a max value of 11, others are binary
COLUMN INDICATOR(CATEGORY_ID("[^arf].*, 2)),
       INDICATOR(CATEGORY_ID(family, 12)),
LABEL survived INTO tfbt_model;
```

**Known limitation**: the golang `regexp` module doesn't support lookahead syntax. This makes it hard to write regex to exclude some fields.