### PR TITLE
Custom teamcity statistics plugin

### DIFF
--- a/scripts/teamcity_statistics.py
+++ b/scripts/teamcity_statistics.py
@@ -1,0 +1,67 @@
+#!/bin/env python
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+import xml.etree.ElementTree as ET
+
+
+class TeamcityReport(object):
+    """
+    TeamcityReport reports a custom statistics on TeamCity system.
+    Ref: https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-ReportingCustomStatistics 
+    """
+    def __init__(self, out):
+        self._out = out
+        self._metrics = []
+
+    def add_metrics(self, key, value):
+        self._metrics.append((key, value))
+
+    def flush(self):
+        root = ET.Element('build')
+        for m in self._metrics:
+            ET.SubElement(root,
+                          "statisticValue",
+                          attrib={
+                              "key": str(m[0]),
+                              "value": str(m[1])
+                          })
+        tree = ET.ElementTree(root)
+        tree.write(self._out)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('--file',
+                        type=str,
+                        required=True,
+                        help='a file of `gotest -v | tee ...` ')
+    parser.add_argument(
+        '--case',
+        type=str,
+        required=True,
+        help='matching the regular expression test cases of Go')
+    args = parser.parse_args()
+    # the XML file name should be `teamcity-info.xml`
+    r = TeamcityReport("teamcity-info.xml")
+    with open(args.file) as f:
+        for line in f:
+            content = line.strip()
+            if len(content) == 0:
+                continue
+            m = re.search('PASS: (%s.*) \((.*)s\)' % args.case, content)
+            if m:
+                r.add_metrics(m.group(1), m.group(2))
+    r.flush()


### PR DESCRIPTION
This script generates an XML file contains the test cases duration time, the XML file can used on TeamCity as the custom statistics. 
Ref: https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-ReportingCustomStatistics

Demo:
![image](https://user-images.githubusercontent.com/1426912/76088880-bc5b1980-5ff3-11ea-91bf-0ecb3ae2d77c.png)
