### PR TITLE
Verifier do not fetch the whole data

### DIFF
--- a/pkg/sql/ir_generator.go
+++ b/pkg/sql/ir_generator.go
@@ -46,15 +46,17 @@ func generateTrainStmtWithInferredColumns(slct *parser.SQLFlowSelectStmt, connSt
 	if err != nil {
 		return nil, err
 	}
-	if err := feature.InferFeatureColumns(trainStmt, connStr); err != nil {
-		return nil, err
-	}
 
 	db, err := database.OpenAndConnectDB(connStr)
 	if err != nil {
 		return nil, err
 	}
 	defer db.Close()
+
+	if err := feature.InferFeatureColumns(trainStmt, db); err != nil {
+		return nil, err
+	}
+
 	err = verifyTrainStmt(trainStmt, db, verifyLabel)
 	if err != nil {
 		return nil, err

--- a/pkg/step/feature/derivation.go
+++ b/pkg/step/feature/derivation.go
@@ -268,7 +268,7 @@ func InferFeatureColumns(trainStmt *ir.TrainStmt, dataSource string) error {
 
 	// TODO(typhoonzero): find a way to using subqueries like select * from (%s) AS a LIMIT 100
 	// q := trainStmt.Select
-	rows, err := fetchSamples(dataSource, trainStmt.Select)
+	rows, err := FetchSamples(dataSource, trainStmt.Select)
 	if err != nil {
 		return err
 	}
@@ -371,7 +371,8 @@ func deriveFeatureColumn(fcMap ColumnMap, columnTargets []string, fmMap FieldDes
 	return nil
 }
 
-func fetchSamples(dataSource string, query string) (*sql.Rows, error) {
+// FetchSamples returns Rows accoding to the input Query
+func FetchSamples(dataSource string, query string) (*sql.Rows, error) {
 	db, err := database.OpenAndConnectDB(dataSource)
 	if err != nil {
 		return nil, err

--- a/pkg/step/feature/derivation.go
+++ b/pkg/step/feature/derivation.go
@@ -262,13 +262,13 @@ func fillFieldDesc(columnTypeList []*sql.ColumnType, rowdata []interface{}, fiel
 // InferFeatureColumns fill up featureColumn and columnSpec structs
 // for all fields.
 // if wr is not nil, then write
-func InferFeatureColumns(trainStmt *ir.TrainStmt, dataSource string) error {
+func InferFeatureColumns(trainStmt *ir.TrainStmt, db *database.DB) error {
 	fcMap := makeColumnMap(trainStmt.Features)
 	fmMap := makeFieldDescMap(trainStmt.Features)
 
 	// TODO(typhoonzero): find a way to using subqueries like select * from (%s) AS a LIMIT 100
 	// q := trainStmt.Select
-	rows, err := FetchSamples(dataSource, trainStmt.Select)
+	rows, err := FetchSamples(db, trainStmt.Select)
 	if err != nil {
 		return err
 	}
@@ -372,11 +372,7 @@ func deriveFeatureColumn(fcMap ColumnMap, columnTargets []string, fmMap FieldDes
 }
 
 // FetchSamples returns Rows accoding to the input Query
-func FetchSamples(dataSource string, query string) (*sql.Rows, error) {
-	db, err := database.OpenAndConnectDB(dataSource)
-	if err != nil {
-		return nil, err
-	}
+func FetchSamples(db *database.DB, query string) (*sql.Rows, error) {
 	re, err := regexp.Compile("(?i)LIMIT [0-9]+")
 	if err != nil {
 		return nil, err

--- a/pkg/step/feature/derivation_test.go
+++ b/pkg/step/feature/derivation_test.go
@@ -176,7 +176,7 @@ func TestFeatureDerivation(t *testing.T) {
 	}
 
 	trainStmt := mockTrainStmtNormal()
-	e := InferFeatureColumns(trainStmt, dataSource)
+	e := InferFeatureColumns(trainStmt, db)
 	a.NoError(e)
 
 	fc1 := trainStmt.Features["feature_columns"][0]
@@ -237,7 +237,7 @@ func TestFeatureDerivation(t *testing.T) {
 	a.Equal(6, len(trainStmt.Features["feature_columns"]))
 
 	trainStmt = mockTrainStmtCross()
-	e = InferFeatureColumns(trainStmt, dataSource)
+	e = InferFeatureColumns(trainStmt, db)
 	a.NoError(e)
 
 	fc1 = trainStmt.Features["feature_columns"][0]
@@ -285,7 +285,7 @@ func TestFeatureDerivationNoColumnClause(t *testing.T) {
 	}
 
 	trainStmt := mockTrainStmtIrisNoColumnClause()
-	e := InferFeatureColumns(trainStmt, dataSource)
+	e := InferFeatureColumns(trainStmt, db)
 	a.NoError(e)
 
 	a.Equal(4, len(trainStmt.Features["feature_columns"]))
@@ -306,7 +306,7 @@ func TestHiveFeatureDerivation(t *testing.T) {
 		Attributes:       map[string]interface{}{},
 		Features:         map[string][]ir.FeatureColumn{},
 		Label:            &ir.NumericColumn{&ir.FieldDesc{"class", ir.Int, "", []int{1}, false, nil, 0}}}
-	e := InferFeatureColumns(trainStmt, database.GetTestingDBSingleton().URL())
+	e := InferFeatureColumns(trainStmt, database.GetTestingDBSingleton())
 	a.NoError(e)
 	a.Equal(4, len(trainStmt.Features["feature_columns"]))
 }

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -60,7 +60,7 @@ func Decomp(ident string) (tbl string, fld string) {
 //
 // It returns a FieldTypes describing types of fields in SELECT.
 func Verify(q string, db *database.DB) (FieldTypes, error) {
-	rows, err := feature.FetchSamples(db.URL(), q)
+	rows, err := feature.FetchSamples(db, q)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -20,6 +20,7 @@ import (
 
 	"sqlflow.org/sqlflow/pkg/database"
 	"sqlflow.org/sqlflow/pkg/parser"
+	"sqlflow.org/sqlflow/pkg/step/feature"
 )
 
 // FieldTypes type records a mapping from field name to field type name.
@@ -59,7 +60,7 @@ func Decomp(ident string) (tbl string, fld string) {
 //
 // It returns a FieldTypes describing types of fields in SELECT.
 func Verify(q string, db *database.DB) (FieldTypes, error) {
-	rows, err := db.Query(q)
+	rows, err := feature.FetchSamples(db.URL(), q)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR avoid fetching the whole data on the verifier stage.

TODO: refactor `Verifer` and `InferColumnsType` API, and pass in `Rows` instead of `SQL` to avoid execute `SELECT statmet` twice.
