### PR TITLE
Do not use project specific training checkpoint credentials

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1587,7 +1587,7 @@ INTO e2etest_dense_input;`, caseTrainTable)
 }
 
 func CasePAIMaxComputeTrainXGBoost(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN xgboost.gbtree
@@ -1762,17 +1762,18 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 
 	go start(modelDir, caCrt, caKey, unitTestPort, false)
 	waitPortReady(fmt.Sprintf("localhost:%d", unitTestPort), 0)
+	t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
 
-	t.Run("group", func(t *testing.T) {
-		t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)
-		// t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
-		// t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
-		// t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
-		// t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
+	// t.Run("group", func(t *testing.T) {
+	// t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)
+	// t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
+	// t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
+	// t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
+	// t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
 
-		// FIXME(typhoonzero): Add this test back when we solve error: model already exist issue on the CI.
-		// t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
-	})
+	// FIXME(typhoonzero): Add this test back when we solve error: model already exist issue on the CI.
+	// t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
+	// })
 
 }
 

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1398,7 +1398,7 @@ FROM housing.xgb_predict LIMIT 5;`)
 }
 
 func CasePAIMaxComputeTrainDistributed(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN DNNClassifier
@@ -1587,7 +1587,7 @@ INTO e2etest_dense_input;`, caseTrainTable)
 }
 
 func CasePAIMaxComputeTrainXGBoost(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN xgboost.gbtree
@@ -1623,7 +1623,7 @@ INTO %s.e2etest_xgb_explain_result;`, caseTrainTable, caseDB)
 }
 
 func CasePAIMaxComputeTrainCustomModel(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN sqlflow_models.DNNClassifier
@@ -1762,7 +1762,7 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 
 	go start(modelDir, caCrt, caKey, unitTestPort, false)
 	waitPortReady(fmt.Sprintf("localhost:%d", unitTestPort), 0)
-	t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
+	t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
 
 	// t.Run("group", func(t *testing.T) {
 	// t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1765,12 +1765,13 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)
-		t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
+		// t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
+		// t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
+		// t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
+		// t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
+
 		// FIXME(typhoonzero): Add this test back when we solve error: model already exist issue on the CI.
 		// t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
-		t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
-		t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
-		t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
 	})
 
 }

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1398,7 +1398,7 @@ FROM housing.xgb_predict LIMIT 5;`)
 }
 
 func CasePAIMaxComputeTrainDistributed(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN DNNClassifier
@@ -1623,7 +1623,7 @@ INTO %s.e2etest_xgb_explain_result;`, caseTrainTable, caseDB)
 }
 
 func CasePAIMaxComputeTrainCustomModel(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN sqlflow_models.DNNClassifier
@@ -1762,19 +1762,17 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 
 	go start(modelDir, caCrt, caKey, unitTestPort, false)
 	waitPortReady(fmt.Sprintf("localhost:%d", unitTestPort), 0)
-	t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
 
-	// t.Run("group", func(t *testing.T) {
-	// t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)
-	// t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
-	// t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
-	// t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
-	// t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
+	t.Run("group", func(t *testing.T) {
+		t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)
+		t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
+		t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
+		t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
+		t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)
 
-	// FIXME(typhoonzero): Add this test back when we solve error: model already exist issue on the CI.
-	// t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
-	// })
-
+		// FIXME(typhoonzero): Add this test back when we solve error: model already exist issue on the CI.
+		// t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
+	})
 }
 
 func TestEnd2EndWorkflow(t *testing.T) {

--- a/pkg/sql/alisa_submitter.go
+++ b/pkg/sql/alisa_submitter.go
@@ -200,27 +200,18 @@ func findPyModulePath(pyModuleName string) (string, error) {
 
 // FIXME(typhoonzero): use the same model bucket name e.g. sqlflow-models
 func getModelBucket(project string) (*oss.Bucket, error) {
-	ossCkptDir, err := pai.GetOSSCheckpointDir(project)
-	if err != nil {
-		return nil, err
-	}
 	ak := os.Getenv("SQLFLOW_OSS_AK")
 	sk := os.Getenv("SQLFLOW_OSS_SK")
 	ep := os.Getenv("SQLFLOW_OSS_MODEL_ENDPOINT")
-	if ak == "" || sk == "" || ep == "" || ossCkptDir == "" {
+	if ak == "" || sk == "" || ep == "" {
 		return nil, fmt.Errorf("should define SQLFLOW_OSS_MODEL_ENDPOINT, SQLFLOW_OSS_CHECKPOINT_DIR, SQLFLOW_OSS_AK, SQLFLOW_OSS_SK when using submitter alisa")
 	}
 
-	sub := reOSS.FindStringSubmatch(ossCkptDir)
-	if len(sub) != 3 {
-		return nil, fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR should be format: oss://bucket/?role_arn=xxx&host=xxx")
-	}
-	bucketName := sub[1]
 	cli, e := oss.New(ep, ak, sk)
 	if e != nil {
 		return nil, e
 	}
-	return cli.Bucket(bucketName)
+	return cli.Bucket(pai.BucketName)
 }
 
 func getAlisaBucket() (*oss.Bucket, error) {

--- a/pkg/sql/codegen/pai/codegen.go
+++ b/pkg/sql/codegen/pai/codegen.go
@@ -41,8 +41,8 @@ const entryFile = "entry.py"
 // BucketName is the OSS bucket to save trained models
 const BucketName = "sqlflow-models"
 
-// checkpointURL returns model path on OSS like: oss://bucket/your/path/modelname/
-func checkpointURL(modelName string, project string) string {
+// ossModelURL returns model path on OSS like: oss://bucket/your/path/modelname/
+func ossModelURL(modelName string, project string) string {
 	ossBucketURI := fmt.Sprintf("oss://%s/", BucketName)
 	ossDir := strings.Join([]string{strings.TrimRight(ossBucketURI, "/"), modelName}, "/")
 	return ossDir
@@ -125,7 +125,7 @@ func Train(ir *ir.TrainStmt, session *pb.Session, tarball, modelName, ossModelPa
 		if code, e = xgboost.Train(ir, session); e != nil {
 			return
 		}
-		ossURI := checkpointURL(ossModelPath, currProject)
+		ossURI := ossModelURL(ossModelPath, currProject)
 		var tpl = template.Must(template.New("xgbSaveModel").Parse(xgbSaveModelTmplText))
 		var saveCode bytes.Buffer
 		if e = tpl.Execute(&saveCode, &xgbSaveModelFiller{OSSModelDir: ossURI}); e != nil {
@@ -165,7 +165,7 @@ func Predict(ir *ir.PredictStmt, session *pb.Session, tarball, modelName, ossMod
 		}
 	} else if modelType == ModelTypeXGBoost {
 		requirements, e = genRequirements(true)
-		ossURI := checkpointURL(ossModelPath, currProject)
+		ossURI := ossModelURL(ossModelPath, currProject)
 		var xgbPredCode bytes.Buffer
 		var tpl = template.Must(template.New("xgbPredTemplate").Parse(xgbPredTemplateText))
 		paiPredictTable := ""
@@ -236,7 +236,7 @@ func Explain(ir *ir.ExplainStmt, session *pb.Session, tarball, modelName, ossMod
 		if expn.Requirements, err = genRequirements(true); err != nil {
 			return nil, err
 		}
-		ossURI := checkpointURL(ossModelPath, currProject)
+		ossURI := ossModelURL(ossModelPath, currProject)
 		var xgbExplainCode bytes.Buffer
 		var tpl = template.Must(template.New("xgbExplainTemplate").Parse(xgbExplainTemplateText))
 		filler := &xgbExplainFiller{

--- a/pkg/sql/codegen/pai/codegen.go
+++ b/pkg/sql/codegen/pai/codegen.go
@@ -60,17 +60,19 @@ func GetOSSCheckpointDir(project string) (string, error) {
 
 // checkpointURL returns the saved model path on OSS
 func checkpointURL(modelName string, project string) (string, error) {
-	ossChekpointDir, err := GetOSSCheckpointDir(project)
-	if err != nil {
-		return "", err
-	}
-	ossURIParts := strings.Split(ossChekpointDir, "?")
-	if len(ossURIParts) != 2 {
-		return "", fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR must be of format: oss://bucket/?role_arn=xxx&host=xxx")
-	}
-	ossDir := strings.Join([]string{strings.TrimRight(ossURIParts[0], "/"), modelName}, "/")
+	// ossChekpointDir, err := GetOSSCheckpointDir(project)
+	// if err != nil {
+	// 	return "", err
+	// }
+	// ossURIParts := strings.Split(ossChekpointDir, "?")
+	// if len(ossURIParts) != 2 {
+	// 	return "", fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR must be of format: oss://bucket/?role_arn=xxx&host=xxx")
+	// }
+	ossBucketURI := "oss://sqlflow-models/"
+	ossDir := strings.Join([]string{strings.TrimRight(ossBucketURI, "/"), modelName}, "/")
 	// Form URI like: oss://bucket/your/path/modelname/?args=...
-	return strings.Join([]string{ossDir + "/", ossURIParts[1]}, "?"), nil
+	// return strings.Join([]string{ossDir + "/", ossURIParts[1]}, "?"), nil
+	return ossDir, nil
 }
 
 func maxComputeTableURL(table string) (string, error) {

--- a/pkg/sql/codegen/pai/codegen_test.go
+++ b/pkg/sql/codegen/pai/codegen_test.go
@@ -135,7 +135,7 @@ func TestTrainCodegen(t *testing.T) {
 	a.False(hasUnknownParameters(paiTFCode, knownTrainParams))
 
 	// check pai command string
-	ckpDir := checkpointURL(ossModelPath, "project")
+	ckpDir := ossModelURL(ossModelPath, "project")
 	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/train,odps://iris/tables/test  -DhyperParameters=\"file://%s\" -DgpuRequired='0'", scriptPath, ckpDir)
 	a.Equal(expectedPAICmd, paiCmd)
 }
@@ -149,7 +149,7 @@ func TestPredictCodegen(t *testing.T) {
 	sess := mockSession()
 	ossModelPath := "iris/sqlflow/my_dnn_model"
 	scriptPath := "file:///tmp/task.tar.gz"
-	ckpDir, err := checkpointURL(ossModelPath, "project")
+	ckpDir, err := ossModelURL(ossModelPath, "project")
 	a.NoError(err)
 	paiTFCode, paiCmd, _, e := Predict(ir, sess, scriptPath, "my_dnn_model", ossModelPath, "", ModelTypeTF)
 	a.NoError(e)

--- a/pkg/sql/codegen/pai/codegen_test.go
+++ b/pkg/sql/codegen/pai/codegen_test.go
@@ -134,10 +134,10 @@ func TestTrainCodegen(t *testing.T) {
 	a.True(hasExportedLocal(tfCode))
 	a.False(hasUnknownParameters(paiTFCode, knownTrainParams))
 
-	// check pai command string
-	ckpDir := ossModelURL(ossModelPath, "project")
-	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/train,odps://iris/tables/test  -DhyperParameters=\"file://%s\" -DgpuRequired='0'", scriptPath, ckpDir)
-	a.Equal(expectedPAICmd, paiCmd)
+	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/train,odps://iris/tables/test  -DhyperParameters=\"file://.*\" -DgpuRequired='0'", scriptPath)
+	re, err := regexp.Compile(expectedPAICmd)
+	a.NoError(err)
+	a.True(re.MatchString(paiCmd))
 }
 
 func TestPredictCodegen(t *testing.T) {
@@ -149,8 +149,6 @@ func TestPredictCodegen(t *testing.T) {
 	sess := mockSession()
 	ossModelPath := "iris/sqlflow/my_dnn_model"
 	scriptPath := "file:///tmp/task.tar.gz"
-	ckpDir, err := ossModelURL(ossModelPath, "project")
-	a.NoError(err)
 	paiTFCode, paiCmd, _, e := Predict(ir, sess, scriptPath, "my_dnn_model", ossModelPath, "", ModelTypeTF)
 	a.NoError(e)
 	a.False(hasUnknownParameters(paiTFCode, knownPredictParams))
@@ -159,6 +157,8 @@ func TestPredictCodegen(t *testing.T) {
 
 	a.True(hasExportedLocal(tfCode))
 	a.False(hasUnknownParameters(tfCode, knownPredictParams))
-	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/predict -Doutputs=odps://iris/tables/predict -DcheckpointDir=\"%s\" -DgpuRequired='0'", scriptPath, ckpDir)
-	a.Equal(expectedPAICmd, paiCmd)
+	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/predict -Doutputs=odps://iris/tables/predict -DhyperParameters=\"file://.*\" -DgpuRequired='0'", scriptPath)
+	re, err := regexp.Compile(expectedPAICmd)
+	a.NoError(err)
+	a.True(re.MatchString(paiCmd))
 }

--- a/pkg/sql/codegen/pai/codegen_test.go
+++ b/pkg/sql/codegen/pai/codegen_test.go
@@ -135,9 +135,8 @@ func TestTrainCodegen(t *testing.T) {
 	a.False(hasUnknownParameters(paiTFCode, knownTrainParams))
 
 	// check pai command string
-	ckpDir, err := checkpointURL(ossModelPath, "project")
-	a.NoError(err)
-	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/train,odps://iris/tables/test  -DcheckpointDir=\"%s\" -DgpuRequired='0'", scriptPath, ckpDir)
+	ckpDir := checkpointURL(ossModelPath, "project")
+	expectedPAICmd := fmt.Sprintf("pai -name tensorflow1150 -project algo_public_dev -DmaxHungTimeBeforeGCInSeconds=0 -DjobName=sqlflow_my_dnn_model -Dtags=dnn -Dscript=%s -DentryFile=entry.py -Dtables=odps://iris/tables/train,odps://iris/tables/test  -DhyperParameters=\"file://%s\" -DgpuRequired='0'", scriptPath, ckpDir)
 	a.Equal(expectedPAICmd, paiCmd)
 }
 

--- a/pkg/sql/codegen/pai/template_tf.go
+++ b/pkg/sql/codegen/pai/template_tf.go
@@ -101,7 +101,7 @@ import types
 import tensorflow as tf
 from tensorflow.estimator import DNNClassifier, DNNRegressor, LinearClassifier, LinearRegressor, BoostedTreesClassifier, BoostedTreesRegressor, DNNLinearCombinedClassifier, DNNLinearCombinedRegressor
 from sqlflow_submitter.pai import model
-from sqlflow_submitter.pai.pai_distributed import define_tf_flags, set_oss_environs
+from sqlflow_submitter.tensorflow.pai_distributed import define_tf_flags, set_oss_environs
 from sqlflow_submitter.tensorflow import predict
 try:
     import sqlflow_models
@@ -167,16 +167,21 @@ if os.environ.get('DISPLAY', '') == '':
 	matplotlib.use('Agg')
 
 import json
+import types
 import sys
 import tensorflow as tf
 from tensorflow.estimator import DNNClassifier, DNNRegressor, LinearClassifier, LinearRegressor, BoostedTreesClassifier, BoostedTreesRegressor, DNNLinearCombinedClassifier, DNNLinearCombinedRegressor
 from sqlflow_submitter.pai import model
+from sqlflow_submitter.tensorflow.pai_distributed import define_tf_flags, set_oss_environs
 from sqlflow_submitter.tensorflow import explain
 try:
     tf.enable_eager_execution()
 except Exception as e:
     sys.stderr.write("warning: failed to enable_eager_execution: %s" % e)
     pass
+
+FLAGS = define_tf_flags()
+set_oss_environs(FLAGS)
 
 (estimator,
 feature_column_names,
@@ -188,7 +193,24 @@ feature_columns_code) = model.load_metas("{{.OSSModelDir}}", "tensorflow_model_d
 feature_columns = eval(feature_columns_code)
 # NOTE(typhoonzero): No need to eval model_params["optimizer"] and model_params["loss"]
 # because predicting do not need these parameters.
- 
+
+if isinstance(estimator, types.FunctionType):
+    is_estimator = False
+else:
+    is_estimator = issubclass(
+        eval(estimator),
+        (tf.estimator.Estimator, tf.estimator.BoostedTreesClassifier,
+            tf.estimator.BoostedTreesRegressor))
+
+# Keras single node is using h5 format to save the model, no need to deal with export model format.
+# Keras distributed mode will use estimator, so this is also needed.
+if is_estimator:
+    model.load_file("{{.OSSModelDir}}", "exported_path")
+    # NOTE(typhoonzero): directory "model_save" is hardcoded in codegen/tensorflow/codegen.go
+    model.load_dir("{{.OSSModelDir}}/model_save")
+else:
+    model.load_file("{{.OSSModelDir}}", "model_save")
+
 explain.explain(datasource="{{.DataSource}}",
                 estimator_cls=eval(estimator),
                 select="""{{.Select}}""",
@@ -197,7 +219,7 @@ explain.explain(datasource="{{.DataSource}}",
                 feature_metas=feature_metas,
                 label_meta=label_meta,
                 model_params=model_params,
-                save="{{.OSSModelDir}}",
+                save="model_save",
                 result_table="{{.ResultTable}}",
                 is_pai="{{.IsPAI}}" == "true",
                 pai_table="{{.PAITable}}",

--- a/pkg/sql/codegen/pai/template_xgboost.go
+++ b/pkg/sql/codegen/pai/template_xgboost.go
@@ -19,6 +19,11 @@ type xgbSaveModelFiller struct {
 
 const xgbSaveModelTmplText = `
 from sqlflow_submitter.pai import model
+from sqlflow_submitter.tensorflow.pai_distributed import define_tf_flags, set_oss_environs
+
+FLAGS = define_tf_flags()
+set_oss_environs(FLAGS)
+
 # NOTE(typhoonzero): the xgboost model file "my_model" is hard coded in xgboost/train.py
 model.save_file("{{.OSSModelDir}}", "my_model")
 model.save_metas("{{.OSSModelDir}}",
@@ -30,10 +35,6 @@ model.save_metas("{{.OSSModelDir}}",
            feature_metas,
            feature_column_names,
            label_meta)
-`
-
-const xgbLoadModelTmplText = `
-
 `
 
 type xgbPredictFiller struct {
@@ -52,6 +53,10 @@ const xgbPredTemplateText = `
 import json
 from sqlflow_submitter.xgboost.predict import pred
 from sqlflow_submitter.pai import model
+from sqlflow_submitter.tensorflow.pai_distributed import define_tf_flags, set_oss_environs
+
+FLAGS = define_tf_flags()
+set_oss_environs(FLAGS)
 
 # NOTE(typhoonzero): the xgboost model file "my_model" is hard coded in xgboost/train.py
 model.load_file("{{.OSSModelDir}}", "my_model")
@@ -105,6 +110,10 @@ if os.environ.get('DISPLAY', '') == '':
 import json
 from sqlflow_submitter.xgboost.explain import explain
 from sqlflow_submitter.pai import model
+from sqlflow_submitter.tensorflow.pai_distributed import define_tf_flags, set_oss_environs
+
+FLAGS = define_tf_flags()
+set_oss_environs(FLAGS)
 
 # NOTE(typhoonzero): the xgboost model file "my_model" is hard coded in xgboost/train.py
 model.load_file("{{.OSSModelDir}}", "my_model")

--- a/pkg/sql/codegen/pai/template_xgboost.go
+++ b/pkg/sql/codegen/pai/template_xgboost.go
@@ -117,6 +117,7 @@ set_oss_environs(FLAGS)
 
 # NOTE(typhoonzero): the xgboost model file "my_model" is hard coded in xgboost/train.py
 model.load_file("{{.OSSModelDir}}", "my_model")
+
 (estimator,
 model_params,
 train_params,

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -270,19 +270,20 @@ func getOSSModelBucket(project string) (*oss.Bucket, error) {
 		return nil, fmt.Errorf("must define SQLFLOW_OSS_MODEL_ENDPOINT, SQLFLOW_OSS_AK, SQLFLOW_OSS_SK when using submitter maxcompute")
 	}
 
-	ossCheckpointDir, err := pai.GetOSSCheckpointDir(project)
-	if err != nil {
-		return nil, err
-	}
-	ckptParts := strings.Split(ossCheckpointDir, "?")
-	if len(ckptParts) != 2 {
-		return nil, fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR got wrong format")
-	}
-	urlParts := strings.Split(ckptParts[0], "://")
-	if len(urlParts) != 2 {
-		err = fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR got wrong format")
-	}
-	bucketName := strings.Split(urlParts[1], "/")[0]
+	// ossCheckpointDir, err := pai.GetOSSCheckpointDir(project)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// ckptParts := strings.Split(ossCheckpointDir, "?")
+	// if len(ckptParts) != 2 {
+	// 	return nil, fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR got wrong format")
+	// }
+	// urlParts := strings.Split(ckptParts[0], "://")
+	// if len(urlParts) != 2 {
+	// 	err = fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR got wrong format")
+	// }
+	// bucketName := strings.Split(urlParts[1], "/")[0]
+	bucketName := "sqlflow-models"
 
 	cli, err := oss.New(endpoint, ak, sk)
 	if err != nil {

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -29,11 +29,11 @@ import (
 	"sqlflow.org/sqlflow/pkg/sql/codegen/pai"
 )
 
-var tarball = "job.tar.gz"
+const tarball = "job.tar.gz"
 
 // lifecycleOnTmpTable indicates 7 days for the temporary table
 // which create from SELECT statement
-var lifecycleOnTmpTable = 7
+const lifecycleOnTmpTable = 7
 
 type paiSubmitter struct{ *defaultSubmitter }
 
@@ -270,26 +270,11 @@ func getOSSModelBucket(project string) (*oss.Bucket, error) {
 		return nil, fmt.Errorf("must define SQLFLOW_OSS_MODEL_ENDPOINT, SQLFLOW_OSS_AK, SQLFLOW_OSS_SK when using submitter maxcompute")
 	}
 
-	// ossCheckpointDir, err := pai.GetOSSCheckpointDir(project)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// ckptParts := strings.Split(ossCheckpointDir, "?")
-	// if len(ckptParts) != 2 {
-	// 	return nil, fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR got wrong format")
-	// }
-	// urlParts := strings.Split(ckptParts[0], "://")
-	// if len(urlParts) != 2 {
-	// 	err = fmt.Errorf("SQLFLOW_OSS_CHECKPOINT_DIR got wrong format")
-	// }
-	// bucketName := strings.Split(urlParts[1], "/")[0]
-	bucketName := "sqlflow-models"
-
 	cli, err := oss.New(endpoint, ak, sk)
 	if err != nil {
 		return nil, err
 	}
-	return cli.Bucket(bucketName)
+	return cli.Bucket(pai.BucketName)
 }
 
 // getOSSSavedModelType returns the saved model type when training, can be:

--- a/python/sqlflow_submitter/pai/model.py
+++ b/python/sqlflow_submitter/pai/model.py
@@ -88,11 +88,15 @@ def save_dir(oss_model_dir, local_dir):
 def load_dir(oss_model_dir):
     bucket = get_models_bucket()
     path = remove_bucket_prefix(oss_model_dir)
+    prefix = "/".join(path.split("/")[:-1]) + "/"
     for obj in oss2.ObjectIterator(bucket, prefix=path):
+        # remove prefix when writing to local, e.g.
+        # remote: path/to/my/dir/
+        # local: dir/
         if obj.key.endswith("/"):
-            os.makedirs(obj.key)
+            os.makedirs(obj.key.replace(prefix, ""))
         else:
-            bucket.get_object_to_file(obj.key, obj.key)
+            bucket.get_object_to_file(obj.key, obj.key.replace(prefix, ""))
 
 
 def save_file(oss_model_dir, file_name):
@@ -122,9 +126,10 @@ def load_file(oss_model_dir, file_name):
     '''
     Load file from OSS to local directory.
     '''
-    oss_path = remove_bucket_prefix(oss_model_dir)
+    oss_file_path = "/".join([oss_model_dir.rstrip("/"), file_name])
+    oss_file_path = remove_bucket_prefix(oss_file_path)
     bucket = get_models_bucket()
-    bucket.get_object_to_file(oss_path, file_name)
+    bucket.get_object_to_file(oss_file_path, file_name)
 
 
 def load_string(oss_file_path):

--- a/python/sqlflow_submitter/pai/model.py
+++ b/python/sqlflow_submitter/pai/model.py
@@ -57,7 +57,6 @@ def mkdir(bucket, oss_dir):
     if not oss_dir.endswith("/"):
         oss_dir = oss_dir + "/"
     path = remove_bucket_prefix(oss_dir)
-    print("getting path", path)
     has_dir = True
     try:
         meta = bucket.get_object_meta(path)

--- a/python/sqlflow_submitter/pai/model.py
+++ b/python/sqlflow_submitter/pai/model.py
@@ -16,63 +16,122 @@ import os
 import pickle
 import tarfile
 
-import odps
+import oss2
 import tensorflow as tf
 from sqlflow_submitter import db
-from tensorflow.python.platform import gfile
+
+# NOTE(typhoonzero): hard code bucket name "sqlflow-models" as the bucket to save models trained.
+SQLFLOW_MODELS_BUCKET = "sqlflow-models"
+
+
+def get_models_bucket():
+    ak = os.getenv("SQLFLOW_OSS_AK")
+    sk = os.getenv("SQLFLOW_OSS_SK")
+    if ak == "" or sk == "":
+        raise ValueError(
+            "must configure SQLFLOW_OSS_AK and SQLFLOW_OSS_SK when submitting to PAI"
+        )
+    auth = oss2.Auth(ak, sk)
+    endpoint = os.getenv("SQLFLOW_OSS_MODEL_ENDPOINT")
+    if endpoint == "":
+        raise ValueError(
+            "must configure SQLFLOW_OSS_MODEL_ENDPOINT when submitting to PAI")
+
+    bucket = oss2.Bucket(auth, endpoint, SQLFLOW_MODELS_BUCKET)
+    return bucket
+
+
+def remove_bucket_prefix(oss_uri):
+    return oss_uri.replace("oss://%s/" % SQLFLOW_MODELS_BUCKET, "")
 
 
 def get_oss_path_from_uri(oss_model_dir, file_name):
-    uri_parts = oss_model_dir.split("?")
-    if len(uri_parts) < 1:
-        raise ValueError("error oss_model_dir: ", oss_model_dir)
-    oss_path = "/".join([uri_parts[0].rstrip("/"), file_name])
-    return oss_path
+    # oss_model_dir is of format: oss://bucket/path/to/dir/
+    assert (oss_model_dir.startswith("oss://"))
+    oss_file_path = "/".join([oss_model_dir.rstrip("/"), file_name])
+    return oss_file_path
+
+
+def mkdir(bucket, oss_dir):
+    assert (oss_dir.startswith("oss://"))
+    if not oss_dir.endswith("/"):
+        oss_dir = oss_dir + "/"
+    path = remove_bucket_prefix(oss_dir)
+    print("getting path", path)
+    has_dir = True
+    try:
+        meta = bucket.get_object_meta(path)
+    except oss2.exceptions.NoSuchKey:
+        has_dir = False
+    except Exception as e:
+        raise e
+
+    if not has_dir:
+        bucket.put_object(path, "")
 
 
 def save_dir(oss_model_dir, local_dir):
-    oss_dir = oss_model_dir.split("?")[0]
+    '''
+    Recursively upload local_dir under oss_model_dir
+    '''
+    bucket = get_models_bucket()
     for (root, dirs, files) in os.walk(local_dir, topdown=True):
-        dst_dir = "/".join([oss_dir, root])
-        gfile.MakeDirs(dst_dir)
+        dst_dir = "/".join([oss_model_dir.rstrip("/"), root])
+        mkdir(bucket, dst_dir)
         for file_name in files:
             curr_file_path = os.path.join(root, file_name)
-            remote_file_path = "/".join([dst_dir, file_name])
-            gfile.Copy(curr_file_path, remote_file_path)
-    # oss://bucket/path/to/checkpoint   <-   my_model/exported_path
+            remote_file_path = "/".join([dst_dir.rstrip("/"), file_name])
+            remote_file_path = remove_bucket_prefix(remote_file_path)
+            bucket.put_object_from_file(remote_file_path, curr_file_path)
+
+
+def load_dir(oss_model_dir):
+    bucket = get_models_bucket()
+    path = remove_bucket_prefix(oss_model_dir)
+    for obj in oss2.ObjectIterator(bucket, prefix=path):
+        if obj.key.endswith("/"):
+            os.makedirs(obj.key)
+        else:
+            bucket.get_object_to_file(obj.key, obj.key)
 
 
 def save_file(oss_model_dir, file_name):
     '''
-    Save the local file to OSS direcotory using GFile.
+    Save the local file (file_name is a file under current directory) to OSS direcotory.
     '''
+    bucket = get_models_bucket()
     oss_path = get_oss_path_from_uri(oss_model_dir, file_name)
-    oss_dir = oss_model_dir.split("?")[0]
-    gfile.MakeDirs(oss_dir)
-    fn = open(file_name, "r")
-    with gfile.GFile(oss_path, mode='w') as f:
-        while True:
-            buf = fn.read(4096)
-            if not buf:
-                break
-            f.write(buf)
-    fn.close()
+    oss_path = remove_bucket_prefix(oss_path)
+
+    mkdir(bucket, oss_model_dir)
+    bucket.put_object_from_file(oss_path, file_name)
+
+
+def save_string(oss_file_path, data):
+    '''
+    Save a string into an oss_file_path
+    '''
+    bucket = get_models_bucket()
+    oss_dir = "/".join(oss_file_path.split("/")[:-1])
+    mkdir(bucket, oss_dir)
+    oss_file_path = remove_bucket_prefix(oss_file_path)
+    bucket.put_object(oss_file_path, data)
 
 
 def load_file(oss_model_dir, file_name):
     '''
     Load file from OSS to local directory.
     '''
-    oss_path = get_oss_path_from_uri(oss_model_dir, file_name)
-    fn = open(file_name, "w")
-    reader = gfile.GFile(oss_path, mode="r")
-    while True:
-        buf = reader.read(4096)
-        if not buf:
-            break
-        fn.write(buf)
-    reader.close()
-    fn.close()
+    oss_path = remove_bucket_prefix(oss_model_dir)
+    bucket = get_models_bucket()
+    bucket.get_object_to_file(oss_path, file_name)
+
+
+def load_string(oss_file_path):
+    bucket = get_models_bucket()
+    oss_file_path = remove_bucket_prefix(oss_file_path)
+    data = bucket.get_object(oss_file_path).read()
+    return data.decode("utf-8")
 
 
 def save_metas(oss_model_dir, num_workers, file_name, *meta):
@@ -92,14 +151,14 @@ def save_metas(oss_model_dir, num_workers, file_name, *meta):
             print("skip saving model desc on workers other than worker 0")
             return
     oss_path = get_oss_path_from_uri(oss_model_dir, file_name)
-    with gfile.GFile(oss_path, mode='w') as f:
-        pickle.dump(list(meta), f)
+    serialized = pickle.dumps(list(meta))
+    save_string(oss_path, serialized)
+
     # write a file "file_name_estimator" to store the estimator name, so we
     # can determine if the estimator is BoostedTrees* when explaining the model.
-    oss_path = get_oss_path_from_uri(oss_model_dir,
-                                     "_".join([file_name, "estimator"]))
-    with gfile.GFile(oss_path, mode='w') as f:
-        f.write(meta[0])
+    estimator_file_name = "_".join([file_name, "estimator"])
+    oss_path = get_oss_path_from_uri(oss_model_dir, estimator_file_name)
+    save_string(oss_path, meta[0])
 
 
 def load_metas(oss_model_dir, file_name):
@@ -111,10 +170,6 @@ def load_metas(oss_model_dir, file_name):
     Return:
         A list contains the saved python objects
     '''
-    uri_parts = oss_model_dir.split("?")
-    if len(uri_parts) != 2:
-        raise ValueError("error oss_model_dir: ", oss_model_dir)
-    oss_path = "/".join([uri_parts[0].rstrip("/"), file_name])
-
-    reader = gfile.GFile(oss_path, mode='r')
-    return pickle.load(reader)
+    oss_path = "/".join([oss_model_dir.rstrip("/"), file_name])
+    serialized = load_string(oss_path)
+    return pickle.loads(serialized)

--- a/python/sqlflow_submitter/tensorflow/explain.py
+++ b/python/sqlflow_submitter/tensorflow/explain.py
@@ -71,11 +71,8 @@ def explain(datasource,
             oss_sk=None,
             oss_endpoint=None,
             oss_bucket_name=None):
-    if is_pai:
-        FLAGS = define_tf_flags()
-        model_params["model_dir"] = FLAGS.checkpointDir
-    else:
-        model_params['model_dir'] = save
+
+    model_params['model_dir'] = save
 
     def _input_fn():
         if is_pai:

--- a/python/sqlflow_submitter/tensorflow/explain.py
+++ b/python/sqlflow_submitter/tensorflow/explain.py
@@ -72,7 +72,11 @@ def explain(datasource,
             oss_endpoint=None,
             oss_bucket_name=None):
 
-    model_params['model_dir'] = save
+    if is_pai:
+        FLAGS = tf.app.flags.FLAGS
+        model_params["model_dir"] = FLAGS.sqlflow_hdfs_ckpt
+    else:
+        model_params['model_dir'] = save
 
     def _input_fn():
         if is_pai:

--- a/python/sqlflow_submitter/tensorflow/pai_distributed.py
+++ b/python/sqlflow_submitter/tensorflow/pai_distributed.py
@@ -30,8 +30,26 @@ def define_tf_flags():
     tf.app.flags.DEFINE_string("checkpointDir", "", "oss info")
     tf.app.flags.DEFINE_string("tables", "", "required by PAI-TF 1.15")
     tf.app.flags.DEFINE_string("outputs", "", "required by PAI-TF 1.15")
+
+    tf.app.flags.DEFINE_string("sqlflow_oss_ak", "",
+                               "oss ak, for writing saved models")
+    tf.app.flags.DEFINE_string("sqlflow_oss_sk", "",
+                               "oss sk, for writing saved models")
+    tf.app.flags.DEFINE_string("sqlflow_oss_ep", "",
+                               "oss endpoint, for writing saved models")
+    tf.app.flags.DEFINE_string(
+        "sqlflow_oss_ckpt", "",
+        "oss checkpoint dir, where the model will be saved")
+
     FLAGS = tf.app.flags.FLAGS
     return FLAGS
+
+
+def set_oss_environs(FLAGS):
+    # set OSS credentials env from pai flags for later model saving
+    os.environ["SQLFLOW_OSS_AK"] = FLAGS.sqlflow_oss_ak
+    os.environ["SQLFLOW_OSS_SK"] = FLAGS.sqlflow_oss_sk
+    os.environ["SQLFLOW_OSS_MODEL_ENDPOINT"] = FLAGS.sqlflow_oss_ep
 
 
 # make_distributed_info_without_evaluator and dump_into_tf_config are used to dump

--- a/python/sqlflow_submitter/tensorflow/pai_distributed.py
+++ b/python/sqlflow_submitter/tensorflow/pai_distributed.py
@@ -37,9 +37,11 @@ def define_tf_flags():
                                "oss sk, for writing saved models")
     tf.app.flags.DEFINE_string("sqlflow_oss_ep", "",
                                "oss endpoint, for writing saved models")
+    tf.app.flags.DEFINE_string("sqlflow_oss_modeldir", "",
+                               "oss model dir, where the model will be saved")
     tf.app.flags.DEFINE_string(
-        "sqlflow_oss_ckpt", "",
-        "oss checkpoint dir, where the model will be saved")
+        "sqlflow_hdfs_ckpt", "",
+        "hdfs tmp checkpoint dir, where the model will be saved")
 
     FLAGS = tf.app.flags.FLAGS
     return FLAGS

--- a/python/sqlflow_submitter/tensorflow/predict.py
+++ b/python/sqlflow_submitter/tensorflow/predict.py
@@ -92,13 +92,13 @@ def keras_predict(estimator, model_params, save, result_table, is_pai,
     # NOTE: must run predict one batch to initialize parameters
     # see: https://www.tensorflow.org/alpha/guide/keras/saving_and_serializing#saving_subclassed_models
     classifier.predict_on_batch(one_batch)
-    if is_pai:
-        print("loading from %s" % save)
-        # NOTE(typhoonzero): h5 file name is hard coded in tensorflow/codegen.go
-        model.load_file(save, "model_save")
-        classifier.load_weights("model_save")
-    else:
-        classifier.load_weights(save)
+    # if is_pai:
+    #     print("loading from %s" % save)
+    #     # NOTE(typhoonzero): h5 file name is hard coded in tensorflow/codegen.go
+    #     model.load_file(save, "model_save")
+    #     classifier.load_weights("model_save")
+    # else:
+    classifier.load_weights(save)
     pred_dataset = eval_input_fn(1, cache=True).make_one_shot_iterator()
     buff_rows = []
     column_names = feature_column_names[:]
@@ -261,11 +261,7 @@ def pred(datasource,
                       result_col_name, datasource, select, hdfs_namenode_addr,
                       hive_location, hdfs_user, hdfs_pass)
     else:
-        if is_pai:
-            FLAGS = define_tf_flags()
-            model_params["model_dir"] = FLAGS.checkpointDir
-        else:
-            model_params['model_dir'] = save
+        model_params['model_dir'] = save
         print("Start predicting using estimator model...")
         estimator_predict(estimator, model_params, save, result_table,
                           feature_column_names, feature_metas, result_col_name,

--- a/python/sqlflow_submitter/tensorflow/predict.py
+++ b/python/sqlflow_submitter/tensorflow/predict.py
@@ -92,12 +92,6 @@ def keras_predict(estimator, model_params, save, result_table, is_pai,
     # NOTE: must run predict one batch to initialize parameters
     # see: https://www.tensorflow.org/alpha/guide/keras/saving_and_serializing#saving_subclassed_models
     classifier.predict_on_batch(one_batch)
-    # if is_pai:
-    #     print("loading from %s" % save)
-    #     # NOTE(typhoonzero): h5 file name is hard coded in tensorflow/codegen.go
-    #     model.load_file(save, "model_save")
-    #     classifier.load_weights("model_save")
-    # else:
     classifier.load_weights(save)
     pred_dataset = eval_input_fn(1, cache=True).make_one_shot_iterator()
     buff_rows = []

--- a/python/sqlflow_submitter/tensorflow/predict.py
+++ b/python/sqlflow_submitter/tensorflow/predict.py
@@ -150,22 +150,12 @@ def estimator_predict(estimator, model_params, save, result_table,
                                             feature_column_names, None,
                                             feature_metas)()
     # load from the exported model
-    if save.startswith("oss://"):
-        with open("exported_path", "r") as fn:
-            export_path = fn.read()
-        parts = save.split("?")
-        export_path_oss = parts[0] + export_path
-        if TF_VERSION_2:
-            imported = tf.saved_model.load(export_path_oss)
-        else:
-            imported = tf.saved_model.load_v2(export_path_oss)
+    with open("exported_path", "r") as fn:
+        export_path = fn.read()
+    if TF_VERSION_2:
+        imported = tf.saved_model.load(export_path)
     else:
-        with open("exported_path", "r") as fn:
-            export_path = fn.read()
-        if TF_VERSION_2:
-            imported = tf.saved_model.load(export_path)
-        else:
-            imported = tf.saved_model.load_v2(export_path)
+        imported = tf.saved_model.load_v2(export_path)
 
     def add_to_example(example, x, i):
         feature_name = feature_column_names[i]

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -321,6 +321,17 @@ def train(datasource,
                              validate_select, batch_size, epochs, verbose,
                              metric_names, validation_steps)
     else:
+        # Remove the checkpoint dir on HDFS before training.
+        # NOTE(typhoonzero): checkpoints will be used by explaining (explaining BoostedTrees model
+        # requires calling estimator.experimental_predict_with_explanations),
+        # yet, predicting will use the saved model on OSS only.
+        if is_pai and FLAGS.task_index == 0:
+            for root, dirs, files in tf.io.gfile.walk(FLAGS.sqlflow_hdfs_ckpt,
+                                                      topdown=False):
+                for f in files:
+                    tf.io.gfile.remove("/".join([root, f]))
+                tf.io.gfile.rmtree(root)
+
         if is_distributed:
             cluster, task_type, task_index = make_distributed_info_without_evaluator(
                 FLAGS)
@@ -330,13 +341,16 @@ def train(datasource,
                 save_checkpoints_steps=save_checkpoints_steps,
                 train_distribute=dist_strategy,
                 session_config=tf.ConfigProto(log_device_placement=True))
-            print("Using checkpoint path: %s" % FLAGS.sqlflow_hdfs_ckpt)
-            model_params["model_dir"] = FLAGS.sqlflow_hdfs_ckpt
         else:
             model_params["config"] = tf.estimator.RunConfig(
                 save_checkpoints_steps=save_checkpoints_steps)
-            # Do not set model_dir when distributed training
+
+        if is_pai:
+            print("Using checkpoint path: %s" % FLAGS.sqlflow_hdfs_ckpt)
+            model_params["model_dir"] = FLAGS.sqlflow_hdfs_ckpt
+        else:
             model_params["model_dir"] = save
+
         print("Start training using estimator model...")
         estimator_train_and_save(
             estimator, model_params, save, is_pai, FLAGS, pai_table,
@@ -344,14 +358,6 @@ def train(datasource,
             datasource, select, validate_select, batch_size, epochs, verbose,
             log_every_n_iter, train_max_steps, eval_start_delay_secs,
             eval_throttle_secs, metric_names)
-
-        if is_distributed and FLAGS.task_index == 0:
-            # Remove the checkpoint dir on HDFS, use the exported model on OSS for prediction.
-            for root, dirs, files in tf.io.gfile.walk(
-                    model_params["model_dir"], topdown=False):
-                for f in files:
-                    tf.io.gfile.remove("/".join([root, f]))
-                tf.io.gfile.rmtree(root)
 
     any(map(os.remove, glob.glob('cache_train.*')))  # remove cache files
     print("Done training")

--- a/python/sqlflow_submitter/tensorflow/train.py
+++ b/python/sqlflow_submitter/tensorflow/train.py
@@ -333,8 +333,8 @@ def train(datasource,
         else:
             model_params["config"] = tf.estimator.RunConfig(
                 save_checkpoints_steps=save_checkpoints_steps)
-
-        model_params["model_dir"] = save
+            # Do not set model_dir when distributed training
+            model_params["model_dir"] = save
         print("Start training using estimator model...")
         estimator_train_and_save(
             estimator, model_params, save, is_pai, FLAGS, pai_table,


### PR DESCRIPTION
Do not use `-DcheckpointDir` to specify PAI Tensorflow training OSS checkpoint directory. Save checkpoint locally and export the model then write it to OSS using AK/SK from the environment variable.

Pass the environment variables using `-DhyperParameters`.
