### PR TITLE
Disable wildcard for tensorflow model attributes to detect input errorr earlier

### DIFF
--- a/doc/model_parameter.md
+++ b/doc/model_parameter.md
@@ -208,11 +208,6 @@ INTO sqlflow_models.my_dnn_model;
 	<td>Description</td>
 </tr>
 <tr>
-	<td>model.*</td>
-	<td>attribute.unknown</td>
-	<td>Any model parameters defined in custom models</td>
-</tr>
-<tr>
 	<td>train.batch_size</td>
 	<td>int</td>
 	<td>[default=1]<br>The training batch size.<br>range: [1,Infinity]</td>

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -306,6 +306,17 @@ func InitializeAttributes(trainStmt *ir.TrainStmt) error {
 	constructOptimizers(trainStmt)
 	constructLosses(trainStmt)
 	attrValidator := modelAttr.Update(commonAttributes)
+	if len(modelAttr) == 0 {
+		// TODO(shendiaomo): Use the same mechanism as `sqlflow_models` to extract parameters automatically
+		// Unknown custom models
+		modelAttr.Update(attribute.Dictionary{"model.*": {attribute.Unknown, nil, "Any model parameters defined in custom models", nil}})
+	}
+	if strings.HasPrefix(trainStmt.Estimator, "sqlflow_models.") {
+		// Special attributes defined as global variables in `sqlflow_models`
+		modelAttr.Update(attribute.Dictionary{
+			"model.optimizer": {attribute.Unknown, nil, "Specify optimizer", nil},
+			"model.loss":      {attribute.Unknown, nil, "Specify loss", nil}})
+	}
 	return attrValidator.Validate(trainStmt.Attributes)
 }
 

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -54,7 +54,6 @@ Specify the dataset for validation.
 example: "SELECT * FROM iris.train LIMIT 100"`, nil},
 	"validation.steps": {attribute.Int, 1, `[default=1]
 Specify steps for validation.`, attribute.IntLowerBoundChecker(1, true)},
-	"model.*": {attribute.Unknown, "", "Any model parameters defined in custom models", nil},
 }
 
 func intArrayToJSONString(ia []int) string {


### PR DESCRIPTION
```sql
SELECT * FROM iris.train TO TRAIN DNNClassifier WITH model.n_class=3, model.hidden_units=[20, 20] LABEL class INTO iris.dnn_model;
```
The above statement will throw a very long error message.
After this change, the error message is
```
2020/03/10 11:45:05 runSQLProgram error: unsupported attribute model.n_class
```