### PR TITLE
Support using external memory to train XGBoost models

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -407,7 +407,7 @@ USING sqlflow_models.my_xgb_binary_classification_model;`
 func CaseXgboostExternalMemory(t *testing.T) {
 	a := assert.New(t)
 	trainSQL := `SELECT * FROM iris.train WHERE class in (0, 1) TO TRAIN xgboost.gbtree
-WITH objective="binary:logistic", eval_metric=auc, train.cache=True
+WITH objective="binary:logistic", eval_metric=auc, train.disk_cache=True
 LABEL class
 INTO sqlflow_models.my_xgb_binary_classification_model;`
 	_, _, _, err := connectAndRunSQL(trainSQL)

--- a/doc/model_parameter.md
+++ b/doc/model_parameter.md
@@ -159,6 +159,11 @@ INTO sqlflow_models.my_xgb_regression_model;
 	<td>Subsample ratio of the training instance.</td>
 </tr>
 <tr>
+	<td>train.cache</td>
+	<td>bool</td>
+	<td>whether use external memory to cache train data</td>
+</tr>
+<tr>
 	<td>train.num_boost_round</td>
 	<td>int</td>
 	<td>[default=10]<br>The number of rounds for boosting.<br>range: [1, Infinity]</td>

--- a/doc/model_parameter.md
+++ b/doc/model_parameter.md
@@ -159,7 +159,7 @@ INTO sqlflow_models.my_xgb_regression_model;
 	<td>Subsample ratio of the training instance.</td>
 </tr>
 <tr>
-	<td>train.cache</td>
+	<td>train.disk_cache</td>
 	<td>bool</td>
 	<td>whether use external memory to cache train data</td>
 </tr>

--- a/pkg/sql/codegen/xgboost/codegen.go
+++ b/pkg/sql/codegen/xgboost/codegen.go
@@ -37,6 +37,7 @@ range: [0,1]`, attribute.Float32RangeChecker(0, 1, true, true)},
 range: [2, Infinity]`, attribute.IntLowerBoundChecker(2, true)},
 	"objective":   {attribute.String, nil, `Learning objective`, objectiveChecker},
 	"eval_metric": {attribute.String, nil, `eval metric`, nil},
+	"train.cache": {attribute.Bool, false, `whether use external memory to cache train data`, nil},
 	"train.num_boost_round": {attribute.Int, 10, `[default=10]
 The number of rounds for boosting.
 range: [1, Infinity]`, attribute.IntLowerBoundChecker(1, true)},
@@ -167,6 +168,9 @@ func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 		return "", err
 	}
 	params[""]["booster"] = booster
+	useCache := params["train."]["cache"].(bool)
+	fmt.Println(useCache)
+	delete(params["train."], "cache")
 
 	if len(trainStmt.Features) != 1 {
 		return "", fmt.Errorf("xgboost only support 1 feature column set, received %d", len(trainStmt.Features))
@@ -208,6 +212,7 @@ func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 		FieldDescJSON:      string(f),
 		FeatureColumnNames: fs,
 		LabelJSON:          string(l),
+		Cache:              useCache,
 		IsPAI:              tf.IsPAI(),
 		PAITrainTable:      paiTrainTable,
 		PAIValidateTable:   paiValidateTable}

--- a/pkg/sql/codegen/xgboost/codegen.go
+++ b/pkg/sql/codegen/xgboost/codegen.go
@@ -169,7 +169,6 @@ func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 	}
 	params[""]["booster"] = booster
 	useCache := params["train."]["cache"].(bool)
-	fmt.Println(useCache)
 	delete(params["train."], "cache")
 
 	if len(trainStmt.Features) != 1 {

--- a/pkg/sql/codegen/xgboost/codegen.go
+++ b/pkg/sql/codegen/xgboost/codegen.go
@@ -35,9 +35,9 @@ Step size shrinkage used in update to prevents overfitting. After each boosting 
 range: [0,1]`, attribute.Float32RangeChecker(0, 1, true, true)},
 	"num_class": {attribute.Int, nil, `Number of classes.
 range: [2, Infinity]`, attribute.IntLowerBoundChecker(2, true)},
-	"objective":   {attribute.String, nil, `Learning objective`, objectiveChecker},
-	"eval_metric": {attribute.String, nil, `eval metric`, nil},
-	"train.cache": {attribute.Bool, false, `whether use external memory to cache train data`, nil},
+	"objective":        {attribute.String, nil, `Learning objective`, objectiveChecker},
+	"eval_metric":      {attribute.String, nil, `eval metric`, nil},
+	"train.disk_cache": {attribute.Bool, false, `whether use external memory to cache train data`, nil},
 	"train.num_boost_round": {attribute.Int, 10, `[default=10]
 The number of rounds for boosting.
 range: [1, Infinity]`, attribute.IntLowerBoundChecker(1, true)},
@@ -168,8 +168,8 @@ func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 		return "", err
 	}
 	params[""]["booster"] = booster
-	useCache := params["train."]["cache"].(bool)
-	delete(params["train."], "cache")
+	diskCache := params["train."]["disk_cache"].(bool)
+	delete(params["train."], "disk_cache")
 
 	if len(trainStmt.Features) != 1 {
 		return "", fmt.Errorf("xgboost only support 1 feature column set, received %d", len(trainStmt.Features))
@@ -211,7 +211,7 @@ func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 		FieldDescJSON:      string(f),
 		FeatureColumnNames: fs,
 		LabelJSON:          string(l),
-		Cache:              useCache,
+		DiskCache:          diskCache,
 		IsPAI:              tf.IsPAI(),
 		PAITrainTable:      paiTrainTable,
 		PAIValidateTable:   paiValidateTable}

--- a/pkg/sql/codegen/xgboost/codegen_test.go
+++ b/pkg/sql/codegen/xgboost/codegen_test.go
@@ -32,8 +32,8 @@ func TestParseAttribute(t *testing.T) {
 
 func TestAttributes(t *testing.T) {
 	a := assert.New(t)
-	a.Equal(6, len(attributeDictionary))
-	a.Equal(29, len(fullAttrValidator))
+	a.Equal(7, len(attributeDictionary))
+	a.Equal(30, len(fullAttrValidator))
 
 	a.Error(objectiveChecker("binaray:logistic"))
 	a.NoError(objectiveChecker("binary:logistic"))
@@ -46,6 +46,7 @@ func mockSession() *pb.Session {
 func TestTrainAndPredict(t *testing.T) {
 	a := assert.New(t)
 	tir := ir.MockTrainStmt(true)
+	a.NoError(InitializeAttributes(tir))
 	_, err := Train(tir, mockSession())
 	a.NoError(err)
 

--- a/pkg/sql/codegen/xgboost/template_train.go
+++ b/pkg/sql/codegen/xgboost/template_train.go
@@ -24,7 +24,7 @@ type trainFiller struct {
 	FieldDescJSON      string
 	FeatureColumnNames []string
 	LabelJSON          string
-	Cache              bool
+	DiskCache          bool
 	IsPAI              bool
 	PAITrainTable      string
 	PAIValidateTable   string
@@ -51,7 +51,7 @@ train(datasource='''{{.DataSource}}''',
         feature_column_names=feature_column_names,
         label_meta=label_meta,
         validation_select='''{{.ValidationSelect}}''',
-		cache="{{.Cache}}" == "true",
+        cache="{{.DiskCache}}" == "true",
         is_pai="{{.IsPAI}}" == "true",
         pai_train_table="{{.PAITrainTable}}",
         pai_validate_table="{{.PAIValidateTable}}")

--- a/pkg/sql/codegen/xgboost/template_train.go
+++ b/pkg/sql/codegen/xgboost/template_train.go
@@ -24,6 +24,7 @@ type trainFiller struct {
 	FieldDescJSON      string
 	FeatureColumnNames []string
 	LabelJSON          string
+	Cache              bool
 	IsPAI              bool
 	PAITrainTable      string
 	PAIValidateTable   string
@@ -50,6 +51,7 @@ train(datasource='''{{.DataSource}}''',
         feature_column_names=feature_column_names,
         label_meta=label_meta,
         validation_select='''{{.ValidationSelect}}''',
+		cache="{{.Cache}}" == "true",
         is_pai="{{.IsPAI}}" == "true",
         pai_train_table="{{.PAITrainTable}}",
         pai_validate_table="{{.PAIValidateTable}}")

--- a/python/sqlflow_submitter/xgboost/predict.py
+++ b/python/sqlflow_submitter/xgboost/predict.py
@@ -36,7 +36,8 @@ def pred(datasource,
         conn = db.connect_with_data_source(datasource)
     label_name = label_meta["feature_name"]
     dpred = xgb_dataset(datasource, 'predict.txt', select, feature_metas,
-                        feature_column_names, None, is_pai, pai_table, True)
+                        feature_column_names, None, is_pai, pai_table, True,
+                        True)  # NOTE: default to use external memory
     bst = xgb.Booster({'nthread': 4})  # init model
     bst.load_model("my_model")  # load data
     print("Start predicting XGBoost model...")

--- a/python/sqlflow_submitter/xgboost/train.py
+++ b/python/sqlflow_submitter/xgboost/train.py
@@ -23,13 +23,20 @@ def train(datasource,
           feature_column_names,
           label_meta,
           validation_select,
+          cache=False,
           is_pai=False,
           pai_train_table="",
           pai_validate_table=""):
 
-    dtrain = xgb_dataset(datasource, 'train.txt', select, feature_metas,
-                         feature_column_names, label_meta, is_pai,
-                         pai_train_table)
+    dtrain = xgb_dataset(datasource,
+                         'train.txt',
+                         select,
+                         feature_metas,
+                         feature_column_names,
+                         label_meta,
+                         is_pai,
+                         pai_train_table,
+                         cache=cache)
     watchlist = [(dtrain, "train")]
 
     if len(validation_select.strip()) > 0:


### PR DESCRIPTION
This is for training data that is bigger than memory. 
See https://xgboost.readthedocs.io/en/latest/tutorials/external_memory.html as a reference.