### PR TITLE
Add log formatter to print log orderly

### DIFF
--- a/cmd/sqlflow/main.go
+++ b/cmd/sqlflow/main.go
@@ -58,7 +58,7 @@ func main() {
 	flag.StringVar(sqlFileName, "f", "", "short for --file")
 	flag.Parse()
 
-	log.SetOutput(*logPath)
+	log.InitLogger(*logPath, log.OrderedTextFormatter)
 	logger := log.GetDefaultLogger()
 
 	sqlProgram, e := ioutil.ReadFile(*sqlFileName)

--- a/cmd/sqlflowserver/main.go
+++ b/cmd/sqlflowserver/main.go
@@ -88,6 +88,6 @@ func main() {
 	port := flag.Int("port", 50051, "TCP port to listen on.")
 	isArgoMode := flag.Bool("argo-mode", false, "Enable Argo workflow model.")
 	flag.Parse()
-	log.SetOutput(*logPath)
+	log.InitLogger(*logPath, log.OrderedTextFormatter)
 	start(*modelDir, *caCrt, *caKey, *port, *isArgoMode)
 }

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -1,0 +1,90 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Formatter is for user to specific the log formatter
+type Formatter int
+
+const (
+	// TextFormatter means unordered fields
+	TextFormatter Formatter = iota
+	// OrderedTextFormatter writes the fields(only but not level&msg) orderly
+	OrderedTextFormatter
+	// JSON, easy to support but we don't need it right now
+)
+
+// InitLogger set the output and formatter
+func InitLogger(filename string, f Formatter) {
+	setOutput(filename)
+	if f == OrderedTextFormatter {
+		fm := &orderedFieldsTextFormatter{}
+		logrus.SetFormatter(fm)
+	}
+}
+
+// setOutput sets log output to filename globally.
+// filename="/var/log/sqlflow.log": write the log to file
+// filename="": write the file to stdout
+func setOutput(filename string) {
+	if len(strings.Trim(filename, " ")) > 0 {
+		logrus.SetOutput(&lumberjack.Logger{
+			Filename:   filename,
+			MaxSize:    32, // megabytes
+			MaxBackups: 64,
+			MaxAge:     10, // days
+			Compress:   true,
+		})
+	}
+}
+
+// orderedFieldsTextFormatter writes the fields(only but not level or msg) orderly
+type orderedFieldsTextFormatter struct {
+}
+
+func (f *orderedFieldsTextFormatter) Format(logger *logrus.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	if logger.Buffer != nil {
+		b = logger.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+	fmt.Fprintf(b, "%s %s msg=\"%s\"", logger.Time.Format("2006-01-02 15:04:05"), logger.Level.String(), logger.Message)
+
+	keys := make([]string, 0, len(logger.Data))
+	for k := range logger.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := logger.Data[k]
+		_, ok := v.(string)
+		if ok {
+			fmt.Fprintf(b, " %s=\"%s\"", k, v)
+		} else {
+			fmt.Fprintf(b, " %s=%v", k, v)
+		}
+	}
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}

--- a/pkg/log/config_test.go
+++ b/pkg/log/config_test.go
@@ -14,23 +14,23 @@
 package log
 
 import (
+	"bytes"
 	"strings"
+	"testing"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/natefinch/lumberjack.v2"
+	"github.com/stretchr/testify/assert"
 )
 
-// SetOutput sets log output to filename globally.
-// filename="/var/log/sqlflow.log": write the log to file
-// filename="": write the file to stdout
-func SetOutput(filename string) {
-	if len(strings.Trim(filename, " ")) > 0 {
-		logrus.SetOutput(&lumberjack.Logger{
-			Filename:   filename,
-			MaxSize:    32, // megabytes
-			MaxBackups: 64,
-			MaxAge:     10, // days
-			Compress:   true,
-		})
-	}
+func TestOrderedTextFormatter(t *testing.T) {
+	a := assert.New(t)
+	InitLogger("", OrderedTextFormatter)
+	b := &bytes.Buffer{}
+	logrus.SetOutput(b)
+
+	logger := WithFields(Fields{"a": 1, "z": 26, "c": "7 3", "s": 5, "e": 3, "f": "true"})
+	logger.Info("this is a message")
+	logContent := b.String()
+	expectedWithoutTime := " info msg=\"this is a message\" a=1 c=\"7 3\" e=3 f=\"true\" s=5 z=26\n"
+	a.Truef(strings.HasSuffix(logContent, expectedWithoutTime), "must contain: %s, but got: %s", expectedWithoutTime, logContent)
 }


### PR DESCRIPTION
Part of #1988 
``` go
log.InitLogger("YourFile.log", log.OrderedTextFormatter)
logger := WithFields(Fields{"a": 1, "z": 26, "c": "7 3", "s": 5, "e": 3, "f": "true"})
logger.Info("follow by alphabeta fields")
```
Only sort the fields.
=> `2020-03-18 18:14:23 info msg="follow by alphabeta fields" a=1 c="7 3" e=3 f="true" s=5 z=26`