### PR TITLE
Add Python linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,24 @@ repos:
     entry: bash ./scripts/pre-commit/yamlfmt.sh
     language: system
     files: \.(yaml|yml)$
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.20
+  hooks:
+  - id: isort
+    # - repo: https://github.com/psf/black
+    #   sha: master
+    #   hooks:
+    #   - id: black
+    #     args: [--line-length=79]
+    # - repo: https://github.com/pre-commit/pre-commit-hooks
+    #   rev: v2.2.3
+    #   hooks:
+    #   - id: flake8
+    # - repo: git://github.com/skorokithakis/pre-commit-mypy
+    #   rev: v0.701
+    #   hooks:
+    #   - id: mypy
+    # - repo: https://github.com/asottile/seed-isort-config
+    #   rev: v1.9.1
+    #   hooks:
+    #   - id: seed-isort-config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,16 +51,3 @@ repos:
   rev: v4.3.21
   hooks:
   - id: isort
-- repo: https://github.com/psf/black
-  sha: master
-  hooks:
-  - id: black
-    args: [--line-length=79]
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
-  hooks:
-  - id: flake8
-- repo: git://github.com/skorokithakis/pre-commit-mypy
-  rev: v0.701
-  hooks:
-  - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,11 +53,11 @@ repos:
   rev: v4.3.20
   hooks:
   - id: isort
-    # - repo: https://github.com/psf/black
-    #   sha: master
-    #   hooks:
-    #   - id: black
-    #     args: [--line-length=79]
+- repo: https://github.com/psf/black
+  sha: master
+  hooks:
+  - id: black
+    args: [--line-length=79]
     # - repo: https://github.com/pre-commit/pre-commit-hooks
     #   rev: v2.2.3
     #   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,15 +58,11 @@ repos:
   hooks:
   - id: black
     args: [--line-length=79]
-    # - repo: https://github.com/pre-commit/pre-commit-hooks
-    #   rev: v2.2.3
-    #   hooks:
-    #   - id: flake8
-    # - repo: git://github.com/skorokithakis/pre-commit-mypy
-    #   rev: v0.701
-    #   hooks:
-    #   - id: mypy
-    # - repo: https://github.com/asottile/seed-isort-config
-    #   rev: v1.9.1
-    #   hooks:
-    #   - id: seed-isort-config
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.2.3
+  hooks:
+  - id: flake8
+- repo: git://github.com/skorokithakis/pre-commit-mypy
+  rev: v0.701
+  hooks:
+  - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: python3
 repos:
 - repo: git://github.com/dnephin/pre-commit-golang
   rev: v0.3.5
@@ -19,14 +21,6 @@ repos:
     name: documentation_checker
     entry: bash ./scripts/pre-commit/docgen.sh
     language: system
-- repo: https://github.com/pre-commit/mirrors-yapf
-  rev: v0.29.0
-  hooks:
-  - id: yapf
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
-  hooks:
-  - id: isort
 - repo: local
   hooks:
   - id: google_style_java
@@ -49,8 +43,12 @@ repos:
     entry: bash ./scripts/pre-commit/yamlfmt.sh
     language: system
     files: \.(yaml|yml)$
+- repo: https://github.com/pre-commit/mirrors-yapf
+  rev: v0.29.0
+  hooks:
+  - id: yapf
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.20
+  rev: v4.3.21
   hooks:
   - id: isort
 - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3
 repos:
 - repo: git://github.com/dnephin/pre-commit-golang
   rev: v0.3.5
@@ -57,5 +55,5 @@ repos:
     name: pylint
     entry: bash ./scripts/pre-commit/pylint.sh
     language: system
-    files: \.(py)$
+    files: \.py$
     verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,11 @@ repos:
   rev: v4.3.21
   hooks:
   - id: isort
+- repo: local
+  hooks:
+  - id: pylint
+    name: pylint
+    entry: bash ./scripts/pre-commit/pylint.sh
+    language: system
+    files: \.(py)$
+    verbose: true

--- a/scripts/docker/install-python.bash
+++ b/scripts/docker/install-python.bash
@@ -47,7 +47,6 @@ pip install \
     plotille==3.7 \
     seaborn==0.9.0 \
     jsbeautifier \
+    yapf \
     isort \
-    black \
-    seed-isort-config \
-    mypy
+    pylint

--- a/scripts/docker/install-python.bash
+++ b/scripts/docker/install-python.bash
@@ -30,8 +30,6 @@ apt-get install -y build-essential  libssl-dev # for building mysqlclient pip
 # NOTE: shap == 0.30.1 depends on dill but not include dill as it's dependency, need to install manually.
 # NOTE: mysqlclient depends on apt-get install mysqlclient in install-mysql.bash.
 pip install \
-    yapf==0.29.0 \
-    isort==4.3.21 \
     numpy==1.16.2 \
     tensorflow==2.0.1 \
     mysqlclient==1.4.4 \
@@ -49,6 +47,7 @@ pip install \
     plotille==3.7 \
     seaborn==0.9.0 \
     jsbeautifier \
+    isort \
     black \
     seed-isort-config \
     mypy

--- a/scripts/docker/install-python.bash
+++ b/scripts/docker/install-python.bash
@@ -48,4 +48,8 @@ pip install \
     oss2==2.9.0 \
     plotille==3.7 \
     seaborn==0.9.0 \
-    jsbeautifier
+    jsbeautifier \
+    black \
+    seed-isort-config \
+    mypy \
+    isort

--- a/scripts/docker/install-python.bash
+++ b/scripts/docker/install-python.bash
@@ -51,5 +51,4 @@ pip install \
     jsbeautifier \
     black \
     seed-isort-config \
-    mypy \
-    isort
+    mypy

--- a/scripts/pre-commit/pylint.sh
+++ b/scripts/pre-commit/pylint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+changed_js_files=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.py$' )
+if [[ $changed_js_files == "" ]]; then
+    exit 0
+fi
+pylint $changed_js_files


### PR DESCRIPTION
Fix https://github.com/sql-machine-learning/sqlflow/issues/2033 by ading pylint check to pre-commit.

This change introduce our own bash script scripts/pre-commit/pylint.sh that calls pylint only with changed files. Without this script, we would have to fix too many Python source files to make them pylint-compatible before we can merge this PR.