### PR TITLE
Add flake8

### DIFF
--- a/scripts/docker/install-python.bash
+++ b/scripts/docker/install-python.bash
@@ -49,4 +49,5 @@ pip install \
     jsbeautifier \
     yapf \
     isort \
-    pylint
+    pylint \
+    flake8

--- a/scripts/pre-commit/pylint.sh
+++ b/scripts/pre-commit/pylint.sh
@@ -17,3 +17,4 @@ if [[ $changed_js_files == "" ]]; then
     exit 0
 fi
 pylint $changed_js_files
+flake8 $changed_js_files


### PR DESCRIPTION
According to online discussions like this one https://www.reddit.com/r/Python/comments/82hgzm/any_advantages_of_flake8_over_pylint/, people use flake8 with pylint, which produce different groups of code style suggestions.  So, I am adding flake8 to our pre-commit hooks in addition to pylint added in https://github.com/sql-machine-learning/sqlflow/pull/2034.

Again, flake8 checks only changed files.

