### PR TITLE
bring the mysql setup alone function back

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -24,10 +24,6 @@ function sleep_until_mysql_is_ready() {
 }
 
 function setup_mysql() {
-  # Start mysqld
-  sed -i "s/.*bind-address.*/bind-address = ${SQLFLOW_MYSQL_HOST}/" /etc/mysql/mysql.conf.d/mysqld.cnf
-  service mysql start
-  sleep 1
   populate_example_dataset
   # Grant all privileges to all the remote hosts so that the sqlflow server can
   # be scaled to more than one replicas.
@@ -36,6 +32,10 @@ function setup_mysql() {
 }
 
 function populate_example_dataset() {
+  # Start mysqld
+  sed -i "s/.*bind-address.*/bind-address = ${SQLFLOW_MYSQL_HOST}/" /etc/mysql/mysql.conf.d/mysqld.cnf
+  service mysql start
+  sleep 1
   sleep_until_mysql_is_ready
   # FIXME(typhoonzero): should let docker-entrypoint.sh do this work
   for f in /docker-entrypoint-initdb.d/*; do
@@ -73,6 +73,7 @@ function main() {
   case $ARG in
     mysql)
       setup_mysql
+      sleep infinity
       ;;
     populate-example-dataset-mysql)
       populate_example_dataset

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -73,7 +73,6 @@ function main() {
   case $ARG in
     mysql)
       setup_mysql
-      sleep infinity
       ;;
     populate-example-dataset-mysql)
       populate_example_dataset

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -23,7 +23,15 @@ function sleep_until_mysql_is_ready() {
   done
 }
 
+function start_mysql() {
+  # Start mysqld
+  sed -i "s/.*bind-address.*/bind-address = ${SQLFLOW_MYSQL_HOST}/" /etc/mysql/mysql.conf.d/mysqld.cnf
+  service mysql start
+  sleep 1
+}
+
 function setup_mysql() {
+  start_mysql
   populate_example_dataset
   # Grant all privileges to all the remote hosts so that the sqlflow server can
   # be scaled to more than one replicas.
@@ -32,10 +40,6 @@ function setup_mysql() {
 }
 
 function populate_example_dataset() {
-  # Start mysqld
-  sed -i "s/.*bind-address.*/bind-address = ${SQLFLOW_MYSQL_HOST}/" /etc/mysql/mysql.conf.d/mysqld.cnf
-  service mysql start
-  sleep 1
   sleep_until_mysql_is_ready
   # FIXME(typhoonzero): should let docker-entrypoint.sh do this work
   for f in /docker-entrypoint-initdb.d/*; do
@@ -76,6 +80,10 @@ function main() {
       sleep infinity
       ;;
     populate-example-dataset-mysql)
+      populate_example_dataset
+      ;;
+    populate-example-dataset-mysql-local)
+      start_mysql
       populate_example_dataset
       ;;
     sqlflow-server)

--- a/scripts/test/workflow.sh
+++ b/scripts/test/workflow.sh
@@ -74,7 +74,7 @@ check_ret $? "Test Couler failed"
 ############# Run SQLFLow test with Argo Mode #############
 function test_workflow() {
     # start a SQLFlow MySQL Pod with testdata
-    kubectl run mysql --port 3306 --env="SQLFLOW_MYSQL_HOST=0.0.0.0" --env="SQLFLOW_MYSQL_PORT=3306" --image=${SQLFLOW_WORKFLOW_STEP_IMAGE} --command -- bash start.sh mysql
+    kubectl run mysql --port 3306 --env="SQLFLOW_MYSQL_HOST=0.0.0.0" --env="SQLFLOW_MYSQL_PORT=3306" --image=${SQLFLOW_WORKFLOW_STEP_IMAGE} --command -- bash /start.sh mysql
     MYSQL_POD_NAME=$(kubectl get pod -l run=mysql -o jsonpath="{.items[0].metadata.name}")
 
     for i in {1..30}

--- a/scripts/test/workflow.sh
+++ b/scripts/test/workflow.sh
@@ -74,7 +74,7 @@ check_ret $? "Test Couler failed"
 ############# Run SQLFLow test with Argo Mode #############
 function test_workflow() {
     # start a SQLFlow MySQL Pod with testdata
-    kubectl run mysql --port 3306 --env="SQLFLOW_MYSQL_HOST=0.0.0.0" --env="SQLFLOW_MYSQL_PORT=3306" --image=${SQLFLOW_WORKFLOW_STEP_IMAGE} --command -- bash /start.sh mysql
+    kubectl run mysql --port 3306 --env="SQLFLOW_MYSQL_HOST=0.0.0.0" --env="SQLFLOW_MYSQL_PORT=3306" --image=${SQLFLOW_WORKFLOW_STEP_IMAGE} --command -- bash start.sh mysql
     MYSQL_POD_NAME=$(kubectl get pod -l run=mysql -o jsonpath="{.items[0].metadata.name}")
 
     for i in {1..30}


### PR DESCRIPTION
Context: I was using this ./start.sh mysql to setup the database to run some examples to learn the code base.

Remove the line of "sleep infinity".  Do let me know if this line of code was added on some purpose please. Thank you!