### PR TITLE
Add Fluid codegen

### DIFF
--- a/pkg/ir/mock_ir.go
+++ b/pkg/ir/mock_ir.go
@@ -15,9 +15,15 @@ package ir
 
 // MockTrainStmt generates a sample TrainStmt for test.
 func MockTrainStmt(isxgboost bool) *TrainStmt {
-	// SELECT * FROM iris_train TO TRAIN DNNClassifier
-	// WITH train.batch_size=4, train.epoch=3, model.hidden_units=[10,20], model.n_classes=3
-	// LABEL class INTO my_dnn_model;
+	originalSQL := `SELECT * FROM iris_train
+TO TRAIN DNNClassifier WITH
+	train.batch_size=4,
+	train.epoch=3,
+	model.hidden_units=[10,20],
+	model.n_classes=3
+LABEL class
+INTO my_dnn_model;
+	`
 	attrs := map[string]interface{}{}
 	estimator := "DNNClassifier"
 	if isxgboost {
@@ -33,6 +39,7 @@ func MockTrainStmt(isxgboost bool) *TrainStmt {
 		attrs["model.n_classes"] = 3
 	}
 	return &TrainStmt{
+		OriginalSQL:      originalSQL,
 		Select:           "select * from iris.train;",
 		ValidationSelect: "select * from iris.test;",
 		Estimator:        estimator,

--- a/pkg/workflow/couler/codegen.go
+++ b/pkg/workflow/couler/codegen.go
@@ -153,7 +153,7 @@ func GenFiller(programIR []ir.SQLFlowStmt, session *pb.Session) (*Filler, error)
 	return r, nil
 }
 
-// GenCode generates Couler program
+// GenCode generates a Couler program
 func (cg *Codegen) GenCode(programIR []ir.SQLFlowStmt, session *pb.Session) (string, error) {
 	r, e := GenFiller(programIR, session)
 	if e != nil {
@@ -166,7 +166,7 @@ func (cg *Codegen) GenCode(programIR []ir.SQLFlowStmt, session *pb.Session) (str
 	return program.String(), nil
 }
 
-// GenYAML translate Couler program into Argo YAML
+// GenYAML translate the Couler program into Argo YAML
 func (cg *Codegen) GenYAML(coulerProgram string) (string, error) {
 	cmdline := bytes.Buffer{}
 	fmt.Fprintf(&cmdline, "couler run --mode argo --workflow_name sqlflow ")

--- a/pkg/workflow/couler/codegen.go
+++ b/pkg/workflow/couler/codegen.go
@@ -186,3 +186,10 @@ func (cg *Codegen) GenYAML(coulerProgram string) (string, error) {
 	}
 	return string(out), nil
 }
+
+// MockSQLProgramIR mock a SQLFLow program which contains multiple statements
+func MockSQLProgramIR() []ir.SQLFlowStmt {
+	normalStmt := ir.NormalStmt("SELECT * FROM iris.train limit 10;")
+	trainStmt := ir.MockTrainStmt(true)
+	return []ir.SQLFlowStmt{&normalStmt, trainStmt}
+}

--- a/pkg/workflow/couler/codegen_test.go
+++ b/pkg/workflow/couler/codegen_test.go
@@ -81,7 +81,7 @@ couler.run_container(image="docker/whalesay", command='echo "SQLFlow bridges AI 
 
 func TestCoulerCodegen(t *testing.T) {
 	a := assert.New(t)
-	sqlIR := mockSQLProgramIR()
+	sqlIR := MockSQLProgramIR()
 	os.Setenv("SQLFLOW_OSS_AK", "oss_key")
 	os.Setenv("SQLFLOW_WORKFLOW_SECRET", `{"sqlflow-secret":{"oss_sk": "oss_sk"}}`)
 	defer os.Unsetenv("SQLFLOW_OSS_AK")

--- a/pkg/workflow/couler/template.go
+++ b/pkg/workflow/couler/template.go
@@ -26,7 +26,9 @@ type sqlStatement struct {
 	Parameters     string
 	IsKatibTrain   bool
 }
-type coulerFiller struct {
+
+// Filler filles the template
+type Filler struct {
 	DataSource       string
 	SQLStatements    []*sqlStatement
 	SQLFlowSubmitter string

--- a/pkg/workflow/couler/template.go
+++ b/pkg/workflow/couler/template.go
@@ -27,7 +27,7 @@ type sqlStatement struct {
 	IsKatibTrain   bool
 }
 
-// Filler filles the template
+// Filler is used to fill the template
 type Filler struct {
 	DataSource       string
 	SQLStatements    []*sqlStatement

--- a/pkg/workflow/fluid/codegen.go
+++ b/pkg/workflow/fluid/codegen.go
@@ -23,7 +23,7 @@ import (
 	"sqlflow.org/sqlflow/pkg/workflow/couler"
 )
 
-// Codegen generates Fluid program
+// Codegen generates a Fluid program
 type Codegen struct{}
 
 // GenCode generates a Fluid program
@@ -40,7 +40,7 @@ func (cg *Codegen) GenCode(programIR []ir.SQLFlowStmt, session *pb.Session) (str
 	return program.String(), nil
 }
 
-// GenYAML translate Fluid program into YAML
+// GenYAML translate the Fluid program into Tekton YAML
 func (cg *Codegen) GenYAML(fluidProgram string) (string, error) {
 	cmd := exec.Command("python", "-u")
 	cmd.Stdin = bytes.NewBufferString(fluidProgram)

--- a/pkg/workflow/fluid/codegen.go
+++ b/pkg/workflow/fluid/codegen.go
@@ -26,7 +26,7 @@ import (
 // Codegen generates Fluid program
 type Codegen struct{}
 
-// GenCode generates Fluid program
+// GenCode generates a Fluid program
 func (cg *Codegen) GenCode(programIR []ir.SQLFlowStmt, session *pb.Session) (string, error) {
 	r, e := couler.GenFiller(programIR, session)
 	if e != nil {
@@ -49,11 +49,4 @@ func (cg *Codegen) GenYAML(fluidProgram string) (string, error) {
 		return "", fmt.Errorf("failed %s, %v %s", cmd, err, out)
 	}
 	return string(out), nil
-}
-
-// MockSQLProgramIR mock a SQLFLow program which contains multiple statements
-func MockSQLProgramIR() []ir.SQLFlowStmt {
-	normalStmt := ir.NormalStmt("SELECT * FROM iris.train limit 10;")
-	trainStmt := ir.MockTrainStmt(true)
-	return []ir.SQLFlowStmt{&normalStmt, trainStmt}
 }

--- a/pkg/workflow/fluid/codegen.go
+++ b/pkg/workflow/fluid/codegen.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluid
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"sqlflow.org/sqlflow/pkg/ir"
+	pb "sqlflow.org/sqlflow/pkg/proto"
+	"sqlflow.org/sqlflow/pkg/workflow/couler"
+)
+
+// Codegen generates Fluid program
+type Codegen struct{}
+
+// GenCode generates Fluid program
+func (cg *Codegen) GenCode(programIR []ir.SQLFlowStmt, session *pb.Session) (string, error) {
+	r, e := couler.GenFiller(programIR, session)
+	if e != nil {
+		return "", e
+	}
+
+	var program bytes.Buffer
+	if e = fluidTemplate.Execute(&program, r); e != nil {
+		return "", e
+	}
+	return program.String(), nil
+}
+
+// GenYAML translate Fluid program into YAML
+func (cg *Codegen) GenYAML(fluidProgram string) (string, error) {
+	cmd := exec.Command("python", "-u")
+	cmd.Stdin = bytes.NewBufferString(fluidProgram)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed %s, %v %s", cmd, err, out)
+	}
+	return string(out), nil
+}
+
+// MockSQLProgramIR mock a SQLFLow program which contains multiple statements
+func MockSQLProgramIR() []ir.SQLFlowStmt {
+	normalStmt := ir.NormalStmt("SELECT * FROM iris.train limit 10;")
+	trainStmt := ir.MockTrainStmt(true)
+	return []ir.SQLFlowStmt{&normalStmt, trainStmt}
+}

--- a/pkg/workflow/fluid/codegen_test.go
+++ b/pkg/workflow/fluid/codegen_test.go
@@ -1,0 +1,146 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluid
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pb "sqlflow.org/sqlflow/pkg/proto"
+)
+
+const (
+	expectedFluid = `
+import fluid
+
+step_envs = dict()
+
+step_envs["SQLFLOW_DATASOURCE"] = '''mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0'''
+
+step_envs["SQLFLOW_OSS_AK"] = '''oss_key'''
+
+step_envs["SQLFLOW_TEST"] = '''workflow'''
+
+step_envs["SQLFLOW_TEST_DATASOURCE"] = '''mysql://root:root@tcp(172.17.0.9:3306)/?maxAllowedPacket=0'''
+
+step_envs["SQLFLOW_TEST_DB"] = '''mysql'''
+
+step_envs["SQLFLOW_submitter"] = ''''''
+
+
+@fluid.task
+def sqlflow_workflow():
+
+    fluid.step(image="sqlflow/sqlflow:step", cmd=["step"], args=["-e", '''SELECT * FROM iris.train limit 10;'''], env=step_envs)
+
+    fluid.step(image="sqlflow/sqlflow:step", cmd=["step"], args=["-e", '''SELECT * FROM iris_train
+TO TRAIN DNNClassifier WITH
+	train.batch_size=4,
+	train.epoch=3,
+	model.hidden_units=[10,20],
+	model.n_classes=3
+LABEL class
+INTO my_dnn_model;
+	'''], env=step_envs)
+
+
+sqlflow_workflow()
+`
+	expectedYAML = `---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: sqlflow-workflow
+spec:
+  inputs:
+    params: []
+    resources: []
+  outputs:
+    resources: []
+  steps:
+  - args:
+    - -e
+    - SELECT * FROM iris.train limit 10;
+    command:
+    - step
+    env:
+    - name: SQLFLOW_DATASOURCE
+      value: mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0
+    - name: SQLFLOW_OSS_AK
+      value: oss_key
+    - name: SQLFLOW_TEST
+      value: workflow
+    - name: SQLFLOW_TEST_DATASOURCE
+      value: mysql://root:root@tcp(172.17.0.9:3306)/?maxAllowedPacket=0
+    - name: SQLFLOW_TEST_DB
+      value: mysql
+    - name: SQLFLOW_submitter
+      value: ''
+    image: sqlflow/sqlflow:step
+    name: <stdin>-22
+  - args:
+    - -e
+    - "SELECT * FROM iris_train\nTO TRAIN DNNClassifier WITH\n\ttrain.batch_size=4,\n\
+      \ttrain.epoch=3,\n\tmodel.hidden_units=[10,20],\n\tmodel.n_classes=3\nLABEL\
+      \ class\nINTO my_dnn_model;\n\t"
+    command:
+    - step
+    env:
+    - name: SQLFLOW_DATASOURCE
+      value: mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0
+    - name: SQLFLOW_OSS_AK
+      value: oss_key
+    - name: SQLFLOW_TEST
+      value: workflow
+    - name: SQLFLOW_TEST_DATASOURCE
+      value: mysql://root:root@tcp(172.17.0.9:3306)/?maxAllowedPacket=0
+    - name: SQLFLOW_TEST_DB
+      value: mysql
+    - name: SQLFLOW_submitter
+      value: ''
+    image: sqlflow/sqlflow:step
+    name: <stdin>-32
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: sqlflow-workflow-run
+spec:
+  inputs:
+    params: []
+    resources: []
+  outputs:
+    resources: []
+  taskRef:
+    name: sqlflow-workflow
+`
+)
+
+func TestFluidCodegen(t *testing.T) {
+	a := assert.New(t)
+	// Test step environment variables, the prefix `SQLFLOW_WORKFLOW_` would not be in step container
+	os.Setenv("SQLFLOW_OSS_AK", "oss_key")
+	os.Setenv("SQLFLOW_WORKFLOW_STEP_IMAGE", "sqlflow/sqlflow:step")
+
+	sqlIR := MockSQLProgramIR()
+	cg := &Codegen{}
+	code, err := cg.GenCode(sqlIR, &pb.Session{})
+	a.NoError(err)
+	a.Equal(expectedFluid, code)
+
+	yaml, e := cg.GenYAML(code)
+	a.NoError(e)
+	a.Equal(expectedYAML, yaml)
+}

--- a/pkg/workflow/fluid/codegen_test.go
+++ b/pkg/workflow/fluid/codegen_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	pb "sqlflow.org/sqlflow/pkg/proto"
+	"sqlflow.org/sqlflow/pkg/workflow/couler"
 )
 
 const (
@@ -131,7 +132,7 @@ func TestFluidCodegen(t *testing.T) {
 	os.Setenv("SQLFLOW_DATASOURCE", "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0")
 	os.Setenv("SQLFLOW_submitter", "pai")
 	defer applyEnvs(stashedEnvs)
-	sqlIR := MockSQLProgramIR()
+	sqlIR := couler.MockSQLProgramIR()
 	cg := &Codegen{}
 	code, err := cg.GenCode(sqlIR, &pb.Session{})
 	a.NoError(err)

--- a/pkg/workflow/fluid/template.go
+++ b/pkg/workflow/fluid/template.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluid
+
+import "text/template"
+
+const fluidTemplateText = `
+import fluid
+
+step_envs = dict()
+{{range $k, $v := .StepEnvs}}
+step_envs["{{$k}}"] = '''{{$v}}'''
+{{end}}
+
+@fluid.task
+def sqlflow_workflow():
+{{ range $ss := .SQLStatements }}
+    fluid.step(image="{{ $ss.DockerImage }}", cmd=["step"], args=["-e", '''{{ $ss.OriginalSQL }}'''], env=step_envs)
+{{ end }}
+
+sqlflow_workflow()
+`
+
+var fluidTemplate = template.Must(template.New("Fluid").Parse(fluidTemplateText))


### PR DESCRIPTION
related issue #1980

This PR implements `fluid/codegen.go` to generate a Fluid program.

The generated YAML file is not valid, some TODO tasks should be fixed:
https://github.com/sql-machine-learning/fluid/issues/24
https://github.com/sql-machine-learning/fluid/issues/23