### PR TITLE
Fix xgb validation with split dataset

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1799,9 +1799,11 @@ func CasePAIMaxComputeTrainXGBoost(t *testing.T) {
 		objective="multi:softprob",
 		train.num_boost_round = 30,
 		eta = 0.4,
-		num_class = 3
+		num_class = 3,
+		train.batch_size=10,
+		validation.select="select * from %s"
 	LABEL class
-	INTO e2etest_xgb_classi_model;`, caseTrainTable)
+	INTO e2etest_xgb_classi_model;`, caseTrainTable, caseTrainTable)
 	_, _, _, err := connectAndRunSQL(trainSQL)
 	if err != nil {
 		a.Fail("Run trainSQL error: %v", err)

--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -84,8 +84,14 @@ def dump_dmatrix(filename, generator, has_label, batch_size=None):
     return row_id
 
 
-def pai_dataset(filename, feature_specs, feature_column_names, label_spec,
-                pai_table, single_file, cache):
+def pai_dataset(filename,
+                feature_specs,
+                feature_column_names,
+                label_spec,
+                pai_table,
+                single_file,
+                cache,
+                batch_size=None):
     from subprocess import Popen, PIPE
     import threading
     import queue
@@ -113,7 +119,14 @@ def pai_dataset(filename, feature_specs, feature_column_names, label_spec,
         t.start()
         threads.append(t)
 
-    map(lambda t: t.join(), threads)
+    # map(lambda t: t.join(), threads)
+
+    # Use all data at once if batch size == None, else use a static SLICE_NUM
+    # FIXME(typhoonzero): pai xgboost only support fixed SLICE_NUM now.
+    if batch_size == None:
+        map(lambda t: t.join(), threads)
+        yield xgb.DMatrix('{0}#{0}.cache'.format(dname) if cache else dname)
+        return
 
     downloaded_slice_count = 0
     while True:

--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -37,9 +37,14 @@ def xgb_dataset(datasource,
 
     if is_pai:
         for dmatrix in pai_dataset(
-                fn, feature_specs, feature_column_names, label_spec,
+                fn,
+                feature_specs,
+                feature_column_names,
+                label_spec,
                 "odps://{}/tables/{}".format(*pai_table.split(".")),
-                pai_single_file, cache):
+                pai_single_file,
+                cache,
+                batch_size=batch_size):
             yield dmatrix
         return
 

--- a/python/sqlflow_submitter/xgboost/train.py
+++ b/python/sqlflow_submitter/xgboost/train.py
@@ -44,14 +44,15 @@ def train(datasource,
                          cache=disk_cache,
                          batch_size=batch_size,
                          epoch=epoch)
+    if len(validation_select.strip()) > 0:
+        dvalidate = list(
+            xgb_dataset(datasource, 'validate.txt', validation_select,
+                        feature_metas, feature_column_names, label_meta,
+                        is_pai, pai_validate_table))[0]
     bst = None
     for per_batch_dmatrix in dtrain:
         watchlist = [(per_batch_dmatrix, "train")]
         if len(validation_select.strip()) > 0:
-            dvalidate = list(
-                xgb_dataset(datasource, 'validate.txt', validation_select,
-                            feature_metas, feature_column_names, label_meta,
-                            is_pai, pai_validate_table))[0]
             watchlist.append((dvalidate, "validate"))
 
         re = dict()


### PR DESCRIPTION
Fix XGBoost training with validation dataset on PAI.

Default not to use iterative training unless `train.batch_size` is set.