### PR TITLE
Fix typos in the comments in Python code

### DIFF
--- a/python/couler/tests/test_sqlflow_step.py
+++ b/python/couler/tests/test_sqlflow_step.py
@@ -19,7 +19,7 @@ import couler.steps as steps
 class TestSQLFlowStep(unittest.TestCase):
     ''' Test SQLFlow step'''
     def test_sql_with_special_char(self):
-        '''Test escapeted SQL'''
+        '''Test escaped SQL'''
         special_char_sql = '`$\"\\;'
         actural = steps.sqlflow_step.escape_sql(special_char_sql)
         expected = r'\`\$\"\\;'

--- a/python/sqlflow_submitter/db.py
+++ b/python/sqlflow_submitter/db.py
@@ -209,7 +209,7 @@ def db_generator(driver,
             if driver == "mysql":
                 conn.ping(True)
             for row in rows:
-                # NOTE: If there is no label clause in the extened SQL, the default label value would
+                # NOTE: If there is no label clause in the extended SQL, the default label value would
                 # be -1, the Model implementation can determine use it or not.
                 label = row[label_idx] if label_idx is not None else -1
                 if label_spec and label_spec["delimiter"] != "":

--- a/python/sqlflow_submitter/maxcompute.py
+++ b/python/sqlflow_submitter/maxcompute.py
@@ -66,7 +66,7 @@ class MaxCompute:
             while i < r.count:
                 expected = r.count - i if r.count - i < fetch_size else fetch_size
                 for row in [[v[1] for v in rec] for rec in r[i:i + expected]]:
-                    # NOTE: If there is no label clause in the extened SQL, the default label value would
+                    # NOTE: If there is no label clause in the extended SQL, the default label value would
                     # be -1, the Model implementation can determine use it or not.
                     label = row[label_idx] if label_idx is not None else None
                     if label_spec and label_spec["delimiter"] != "":

--- a/python/sqlflow_submitter/xgboost/dataset.py
+++ b/python/sqlflow_submitter/xgboost/dataset.py
@@ -80,7 +80,7 @@ def dump_dmatrix(filename, generator, has_label, batch_size=None):
                 continue
             if row_id >= batch_size:
                 break
-    # return rows writed
+    # return rows written
     return row_id
 
 

--- a/python/sqlflow_submitter/xgboost/explain_test.py
+++ b/python/sqlflow_submitter/xgboost/explain_test.py
@@ -155,7 +155,7 @@ class ExplainXGBModeTestCase(TestCase):
                   feature_column_names=feature_column_names,
                   label_meta=label_field_meta,
                   validation_select="")
-        # TODO(Yancey1989): keep shap codegen consistant with XGBoost
+        # TODO(Yancey1989): keep shap codegen consistent with XGBoost
         label_field_meta['name'] = label_field_meta['feature_name']
         x = xgb_shap_dataset(datasource, select, feature_column_names,
                              label_field_meta, feature_metas, False, "")


### PR DESCRIPTION
The fix uses #2071 to detect typos.