### PR TITLE
append semicolon at the end of sqlprogram

### DIFF
--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -184,8 +184,13 @@ func assertConnectable(ds string) {
 func repl(scanner *bufio.Scanner, modelDir string, ds string) {
 	for {
 		statements, err := readStmt(scanner)
-		if err == io.EOF && len(statements) == 0 {
-			return
+		if err == io.EOF {
+			n := len(statements)
+			if n > 0 && !strings.HasSuffix(strings.TrimSpace(statements[n-1]), ";") {
+				statements[len(statements)-1] += ";"
+			} else {
+				return
+			}
 		}
 		for _, stmt := range statements {
 			if err := runStmt(stmt, false, modelDir, ds); err != nil {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -184,13 +184,12 @@ func assertConnectable(ds string) {
 func repl(scanner *bufio.Scanner, modelDir string, ds string) {
 	for {
 		statements, err := readStmt(scanner)
-		if err == io.EOF {
-			n := len(statements)
-			if n > 0 && !strings.HasSuffix(strings.TrimSpace(statements[n-1]), ";") {
-				statements[len(statements)-1] += ";"
-			} else {
-				return
-			}
+		if err == io.EOF && len(statements) == 0 {
+			return
+		}
+		n := len(statements)
+		if n > 0 && !strings.HasSuffix(strings.TrimSpace(statements[n-1]), ";") {
+			statements[len(statements)-1] += ";"
 		}
 		for _, stmt := range statements {
 			if err := runStmt(stmt, false, modelDir, ds); err != nil {

--- a/cmd/repl/repl.go
+++ b/cmd/repl/repl.go
@@ -187,6 +187,9 @@ func repl(scanner *bufio.Scanner, modelDir string, ds string) {
 		if err == io.EOF && len(statements) == 0 {
 			return
 		}
+		// The collaborative parsing algorithm requires that each statement ends
+		// with a semi-colon, as the definition of `end_of_stmt`
+		// in /pkg/parser/extended_syntax_parser.y#L176 .
 		n := len(statements)
 		if n > 0 && !strings.HasSuffix(strings.TrimSpace(statements[n-1]), ";") {
 			statements[len(statements)-1] += ";"

--- a/cmd/repl/repl_test.go
+++ b/cmd/repl/repl_test.go
@@ -133,6 +133,26 @@ INTO sqlflow_models.repl_dnn_model;`)
 	a.Contains(output, "| repl_dnn_model           |")
 }
 
+func TestReplWithoutSemicolon(t *testing.T) {
+	a := assert.New(t)
+	a.NoError(prepareTestDataOrSkip(t))
+	session.DbConnStr = dbConnStr
+	sql := `
+select * from iris.train to train DNNClassifier
+WITH model.hidden_units=[10,10], model.n_classes=3, validation.select="select * from iris.test"
+label class
+INTO sqlflow_models.repl_dnn_model`
+	scanner := bufio.NewScanner(strings.NewReader(sql))
+	output, err := step.GetStdout(func() error { repl(scanner, "", dbConnStr); return nil })
+	a.NoError(err)
+	a.Contains(output, `
+select * from iris.train to train DNNClassifier
+WITH model.hidden_units=[10,10], model.n_classes=3, validation.select="select * from iris.test"
+label class
+INTO sqlflow_models.repl_dnn_model;`)
+	a.Contains(output, "'global_step': 110")
+}
+
 func TestMain(t *testing.T) {
 	a := assert.New(t)
 	a.Nil(prepareTestDataOrSkip(t))


### PR DESCRIPTION
Fix #1276 

The collaborative parsing algorithm requires that each statement ends with a semi-colon, as described in 

https://github.com/sql-machine-learning/sqlflow/blob/79fb70334a21ea09ce3ccbcba7526ecf09352027/pkg/parser/extended_syntax_parser.y#L154-L178

So, if a SQL program doesn't end with a semicolon, we need to add one.