### PR TITLE
Do not save tensorflow checkpoints on HDFS

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1726,7 +1726,7 @@ func CasePAIMaxComputeDNNTrainPredictExplain(t *testing.T) {
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT * FROM %s
 TO TRAIN DNNClassifier
-WITH model.n_classes = 3, model.hidden_units = [10, 20]
+WITH model.n_classes = 3, model.hidden_units = [1024,512,256]
 LABEL class
 INTO e2etest_pai_dnn;`, caseTrainTable)
 	_, _, _, err := connectAndRunSQL(trainSQL)

--- a/pkg/sql/codegen/pai/template_tf.go
+++ b/pkg/sql/codegen/pai/template_tf.go
@@ -64,12 +64,17 @@ else:
 # Keras single node is using h5 format to save the model, no need to deal with export model format.
 # Keras distributed mode will use estimator, so this is also needed.
 FLAGS = tf.app.flags.FLAGS
+
 if is_estimator:
     if FLAGS.task_index == 0:
-        with open("exported_path", "r") as fn:
-            saved_model_path = fn.read()
-        model.save_dir("{{.OSSModelDir}}", saved_model_path)
+        model.save_dir("{{.OSSModelDir}}", "model_save")
         model.save_file("{{.OSSModelDir}}", "exported_path")
+else:
+    if len(FLAGS.worker_hosts.split(",")) > 1 and FLAGS.task_index == 0:
+        model.save_dir("{{.OSSModelDir}}", "model_save")
+        model.save_file("{{.OSSModelDir}}", "exported_path")
+    else:
+        model.save_file("{{.OSSModelDir}}", "model_save")
 
 model.save_metas("{{.OSSModelDir}}",
            {{.NumWorkers}},

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -123,10 +123,6 @@ func createPAIHyperParamFile(cwd string, filename string, modelPath string) erro
 		return fmt.Errorf("must define SQLFLOW_OSS_AK, SQLFLOW_OSS_SK, SQLFLOW_OSS_MODEL_ENDPOINT, SQLFLOW_HDFS_MODEL_CKPT_DIR when submitting to PAI")
 	}
 
-	hdfsDir := fmt.Sprintf("%s/%s",
-		strings.TrimRight(hdfsCkpt, "/"),
-		strings.TrimLeft(modelPath, "/"))
-
 	if _, err := f.Write([]byte(fmt.Sprintf("sqlflow_oss_ak=\"%s\"\n", ossAk))); err != nil {
 		return err
 	}
@@ -138,9 +134,6 @@ func createPAIHyperParamFile(cwd string, filename string, modelPath string) erro
 	}
 	ossModelURL := pai.OSSModelURL(modelPath)
 	if _, err := f.Write([]byte(fmt.Sprintf("sqlflow_oss_modeldir=\"%s\"\n", ossModelURL))); err != nil {
-		return err
-	}
-	if _, err := f.Write([]byte(fmt.Sprintf("sqlflow_hdfs_ckpt=\"%s\"\n", hdfsDir))); err != nil {
 		return err
 	}
 	return nil

--- a/python/sqlflow_submitter/tensorflow/explain.py
+++ b/python/sqlflow_submitter/tensorflow/explain.py
@@ -67,11 +67,7 @@ def explain(datasource,
             oss_endpoint=None,
             oss_bucket_name=None):
 
-    if is_pai:
-        FLAGS = tf.app.flags.FLAGS
-        model_params["model_dir"] = FLAGS.sqlflow_hdfs_ckpt
-    else:
-        model_params['model_dir'] = save
+    model_params['model_dir'] = save
 
     def _input_fn():
         if is_pai:
@@ -206,7 +202,7 @@ def write_shap_values(shap_values, driver, conn, result_table,
     with buffered_db_writer(driver, conn, result_table, feature_column_names,
                             100, hdfs_namenode_addr, hive_location, hdfs_user,
                             hdfs_pass) as w:
-        for row in shap_values:
+        for row in shap_values[0]:
             w.write(list(row))
 
 

--- a/python/sqlflow_submitter/tensorflow/pai_distributed.py
+++ b/python/sqlflow_submitter/tensorflow/pai_distributed.py
@@ -39,10 +39,6 @@ def define_tf_flags():
                                "oss endpoint, for writing saved models")
     tf.app.flags.DEFINE_string("sqlflow_oss_modeldir", "",
                                "oss model dir, where the model will be saved")
-    tf.app.flags.DEFINE_string(
-        "sqlflow_hdfs_ckpt", "",
-        "hdfs tmp checkpoint dir, where the model will be saved")
-
     FLAGS = tf.app.flags.FLAGS
     return FLAGS
 

--- a/python/sqlflow_submitter/tensorflow/train_estimator.py
+++ b/python/sqlflow_submitter/tensorflow/train_estimator.py
@@ -26,17 +26,6 @@ def estimator_train_and_save(estimator, model_params, save, is_pai, FLAGS,
                              save_checkpoints_steps, metric_names):
 
     print("Start training using estimator model...")
-    # Remove the checkpoint dir on HDFS before training.
-    # NOTE(typhoonzero): checkpoints will be used by explaining (explaining BoostedTrees model
-    # requires calling estimator.experimental_predict_with_explanations),
-    # yet, predicting will use the saved model on OSS only.
-    if is_pai and FLAGS.task_index == 0 and FLAGS.job_name == "worker":
-        for root, dirs, files in tf.io.gfile.walk(FLAGS.sqlflow_hdfs_ckpt,
-                                                  topdown=False):
-            for f in files:
-                tf.io.gfile.remove("/".join([root, f]))
-            tf.io.gfile.rmtree(root)
-
     is_distributed = False
     if is_pai and len(FLAGS.worker_hosts.split(",")) > 1:
         is_distributed = True
@@ -45,11 +34,8 @@ def estimator_train_and_save(estimator, model_params, save, is_pai, FLAGS,
         estimator,
         is_distributed,
         save_checkpoints_steps=save_checkpoints_steps)
-    if is_pai:
-        print("Using checkpoint path: %s" % FLAGS.sqlflow_hdfs_ckpt)
-        model_params["model_dir"] = FLAGS.sqlflow_hdfs_ckpt
-    else:
-        model_params["model_dir"] = save
+
+    model_params["model_dir"] = save
 
     classifier = estimator(**model_params)
 

--- a/python/sqlflow_submitter/tensorflow/train_keras.py
+++ b/python/sqlflow_submitter/tensorflow/train_keras.py
@@ -85,10 +85,9 @@ def keras_train_and_save(estimator, model_params, save, is_pai, FLAGS,
                                             session_config=tf.ConfigProto(
                                                 log_device_placement=True,
                                                 device_filters=None))
-        model_dir = FLAGS.sqlflow_hdfs_ckpt
 
         keras_estimator = tf.keras.estimator.model_to_estimator(
-            classifier, model_dir=model_dir, config=run_config)
+            classifier, model_dir=save, config=run_config)
         estimator_train_compiled(
             keras_estimator,
             is_pai,


### PR DESCRIPTION
Do not save Tensorflow checkpoints on HDFS, so that we'll not be influenced by disk quota errors.