### PR TITLE
Fix useless error message at start

### DIFF
--- a/cmd/sqlflow/main.go
+++ b/cmd/sqlflow/main.go
@@ -39,7 +39,6 @@ import (
 
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	"sqlflow.org/sqlflow/pkg/sql"
-	"sqlflow.org/sqlflow/pkg/sql/codegen/attribute"
 	"sqlflow.org/sqlflow/pkg/tablewriter"
 )
 
@@ -347,7 +346,7 @@ func main() {
 			fmt.Println("The terminal doesn't support sixel, explanation statements will show ASCII figures.")
 		}
 		if !*noAutoCompletion {
-			attribute.ExtractDocStringsOnce()
+			// TODO(lorylin): get autocomplete dicts for sqlflow_models from sqlflow_server
 		}
 		runPrompt(func(stmt string) { runStmt(*serverAddr, stmt, true, *ds) })
 	} else {


### PR DESCRIPTION
```bash
./sqlflow --sqlflow_server=localhost:50051 --datasource='mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0'
2020/04/28 14:47:53 ExtractDocString failed:  exit status 1 Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named extract_docstring

2020/04/28 14:47:53 ExtractDocString failed: invalid character 'T' looking for beginning of value Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named extract_docstring
```