### PR TITLE
Simplify install-*.bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -qq update
 COPY scripts/docker/install-download-tools.bash /
 RUN /install-download-tools.bash
 
-# Install it2check
+# Install shellcheck
 COPY scripts/docker/install-shell-tools.bash /
 RUN /install-shell-tools.bash
 

--- a/scripts/docker/install-shell-tools.bash
+++ b/scripts/docker/install-shell-tools.bash
@@ -14,6 +14,5 @@
 # limitations under the License.
 
 set -e
-wget -q https://iterm2.com/utilities/it2check -P /usr/local/bin/
-chmod +x  /usr/local/bin/it2check
+
 apt-get install -y shellcheck


### PR DESCRIPTION
This is a preparation of https://github.com/sql-machine-learning/sqlflow/issues/2196.  In order to distinguish install-*.bash files into development tools and runtime dependencies.

If this PR merges, I will move /scripts/docker/install-*.bash into /docker/dev/