### PR TITLE
Mount Go, Python, Java cache into the devbox container

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -22,9 +22,13 @@ cd $TRAVIS_BUILD_DIR/docker/dev
 docker build --cache-from sqlflow/sqlflow:dev -t sqlflow:dev .
 
 echo "build SQLFlow from source into $TRAVIS_BUILD_DIR/build using sqlflow:dev"
-docker run --name dev -it -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:dev
-docker logs dev
-docker rm dev
+mkdir -p $TRAVIS_BUILD_DIR/build
+docker run --rm -it \
+       -v $TRAVIS_BUILD_DIR:/work -w /work \
+       -v $GOPATH:/root/go \
+       -v $HOME/.m2:/root/.m2 \
+       -v $HOME/.cache:/root/.cache \
+       sqlflow:dev
 
 echo "build sqlflow:ci byloading $TRAVIS_BUILD_DIR/build"
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
I am using `scripts/travis/build.sh` in my daily development work to build the source code into the release Docker image.  This PR mounts Go, Python, Java dependency cache into the dev container to reduce the total build time.

On my desktop, before this change, the command `time scripts/travis.build.sh` takes

```
real	2m11.089s
user	0m1.188s
sys	0m0.907s
```

After this change, the time consumption reduces to 

```
real	1m41.942s
user	0m1.114s
sys	0m0.973s
```