### PR TITLE
Support to exit sqlflow cli by "exit" and "quit" command

### DIFF
--- a/cmd/sqlflow/main_test.go
+++ b/cmd/sqlflow/main_test.go
@@ -977,6 +977,15 @@ func TestGetServerAddrFromEnv(t *testing.T) {
 +----------------+`)
 }
 
+func TestIsExitStmt(t *testing.T) {
+	a := assert.New(t)
+	a.True(isExitStmt("exit"))
+	a.True(isExitStmt("quit"))
+	a.True(isExitStmt(" ExiT ; SELECT 1"))
+	a.False(isExitStmt("SELECT 1; EXIT"))
+	a.False(isExitStmt("QUIT SELECT 1"))
+}
+
 type testConsoleParser struct{}
 
 func (p *testConsoleParser) Read() ([]byte, error) {


### PR DESCRIPTION
Currently, sqlflow cli only supports `Ctrl + D` to exit. However, like most of the softwares, mysql supports `exit` and `quit` command to exit cli. This PR adds `exit` and `quit` command support in sqlflow cli, which may be friendly to users.