### PR TITLE
Move os.Exit(0) in runPrompt to runStmt

### DIFF
--- a/cmd/sqlflow/main.go
+++ b/cmd/sqlflow/main.go
@@ -192,6 +192,11 @@ func isExitStmt(stmt string) bool {
 }
 
 func runStmt(serverAddr string, stmt string, isTerminal bool, ds string) error {
+	if isExitStmt(stmt) {
+		fmt.Println("Goodbye!")
+		os.Exit(0)
+	}
+
 	// special case, process USE to stick SQL session
 	parts := strings.Fields(strings.ReplaceAll(stmt, ";", ""))
 	if len(parts) == 2 && strings.ToUpper(parts[0]) == "USE" {
@@ -368,9 +373,6 @@ func main() {
 			// TODO(lorylin): get autocomplete dicts for sqlflow_models from sqlflow_server
 		}
 		runPrompt(func(stmt string) {
-			if isExitStmt(stmt) {
-				os.Exit(0)
-			}
 			runStmt(*serverAddr, stmt, true, *ds)
 		})
 	} else {


### PR DESCRIPTION
Related to https://github.com/sql-machine-learning/sqlflow/pull/2217 . As discussed in https://github.com/sql-machine-learning/sqlflow/pull/2217#discussion_r422920897 , it is better to move all corner cases handling inside `runStmt` . This PR moves `os.Exit(0)` (when `exit` or `quit` command is received) to `runStmt`.

Also, add `fmt.Println("Goodbye!)"` when exiting as what `Ctrl + D` does.