### PR TITLE
Merge the first CI stage PreCommit into the second

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,13 @@ install:
 - echo "skip install"
 jobs:
   include:
-  - stage: BuildDockerAndPreCommit
+  - stage: BuildAndTest
     script:
     - set -e
     - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
     - docker run --rm -it -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:dev
       pre-commit run -a --show-diff-on-failure
-  - stage: Unitests
-    # env is just used for displaying the job type in travis web page
-    env: SQLFLOW_TEST_DB=mysql
+  - env: SQLFLOW_TEST_DB=mysql
     script:
     - set -e
     - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
@@ -100,6 +98,6 @@ jobs:
       -v /home/$USER/.minikube/:/home/$USER/.minikube/
       -v $TRAVIS_BUILD_DIR:/work -w /work
       sqlflow:ci scripts/test/workflow.sh
-  - stage: deploy
+  - stage: Deploy
     script:
     - $TRAVIS_BUILD_DIR/scripts/travis/deploy.sh # Push only after PR merging.


### PR DESCRIPTION
The first CI stage PreCommit has only one job, which runs pre-commit to check the source code.  It seems that we can merge it into the second stage to maximize the concurrent execution of CI jobs.