### PR TITLE
config workflow spec in Couler cluster_config

### DIFF
--- a/pkg/workflow/couler/codegen_test.go
+++ b/pkg/workflow/couler/codegen_test.go
@@ -36,6 +36,10 @@ class K8s(object):
         self._with_tolerations(template)
         return template
 
+    def with_workflow_spec(self, spec):
+        spec["hostNetwork"] = True
+        return spec
+
     def _with_tolerations(self, template):
         template["tolerations"] = list()
         template["tolerations"].append({
@@ -54,6 +58,7 @@ metadata:
   generateName: sqlflow-
 spec:
   entrypoint: sqlflow
+  hostNetwork: true
   templates:
     - name: sqlflow
       steps:

--- a/python/couler/couler/argo.py
+++ b/python/couler/couler/argo.py
@@ -515,7 +515,10 @@ def yaml():
     ts = [{"name": entrypoint, "steps": list(_steps.values())}]
     ts.extend(_templates.values())
 
-    wf["spec"] = {"entrypoint": entrypoint, "templates": ts}
+    spec = {}
+    spec = _update_workflow_spec(spec)
+    spec.update({"entrypoint": entrypoint, "templates": ts})
+    wf["spec"] = spec
 
     if _workflow_ttl_cleaned is not None:
         wf["spec"]["ttlSecondsAfterFinished"] = _workflow_ttl_cleaned
@@ -720,6 +723,15 @@ def _update_pod_config(template):
         template = _cluster_config.with_pod(template)
 
     return template
+
+
+def _update_workflow_spec(spec):
+
+    if _cluster_config is not None and \
+            hasattr(_cluster_config, "with_workflow_spec"):
+        spec = _cluster_config.with_workflow_spec(spec)
+
+    return spec
 
 
 def secret(secret_data, name, dry_run):


### PR DESCRIPTION
Users can configure [Workflow Spec](https://github.com/argoproj/argo/blob/master/pkg/apis/workflow/v1alpha1/workflow_types.go#L192) `cluster_config.py` of Couler program.
