### PR TITLE
A python module for contracts based verification

### DIFF
--- a/python/contracts.py
+++ b/python/contracts.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import inspect
-from functools import wraps, reduce
+from functools import reduce, wraps
 
 
 class Requirement(object):
@@ -24,11 +24,11 @@ class Requirement(object):
     """
     def __init__(self, f, desc="", isor=False, issubj=False, typeset=None):
         self.func = f
-        self._desc= desc
+        self._desc = desc
         self._or = isor
         self._dnf = [[self]]
         self._typeset = typeset
-        self._issubj=issubj
+        self._issubj = issubj
         self._custom_diag = False
 
     def __or__(self, other):
@@ -46,7 +46,8 @@ class Requirement(object):
             typeset = self._typeset & other._typeset
             if not typeset:
                 raise TypeError(
-                    f"type can not be both in {self._typeset} and {other._typeset}")
+                    f"type can not be both in {self._typeset} and {other._typeset}"
+                )
         ret = Requirement(lambda v: self(v) and other(v))
         ret._dnf = []
         for i in self._dnf:
@@ -75,7 +76,7 @@ class Requirement(object):
         if self._custom_diag:
             return self._desc
         messages = []
-        uniq_cnfs  = []
+        uniq_cnfs = []
         for ands in sorted(self._dnf, key=lambda a: len(a)):
             ands.sort(key=lambda r: r._issubj, reverse=True)
             r = ands[0]
@@ -95,7 +96,6 @@ class Requirement(object):
                 uniq_cnfs.append(uniq_ands)
                 messages.append(desc)
         return ", or ".join(messages)
-
 
     def desc(self, desc):
         self._desc = desc
@@ -127,7 +127,10 @@ class Type(Requirement):
             typename = "`list of {}`".format(val[0])
         else:
             typename = type(val).__name__
-        super().__init__(deepcheck, "{}".format(typename), issubj=True, typeset={type(val)})
+        super().__init__(deepcheck,
+                         "{}".format(typename),
+                         issubj=True,
+                         typeset={type(val)})
 
 
 class Between(Requirement):
@@ -138,7 +141,8 @@ class Between(Requirement):
         assert upper >= lower
         assert isinstance(upper, (int, float))
         super().__init__(lambda v: upper >= v >= lower,
-                         "BETWEEN ({},{})".format(lower, upper), typeset={int, float})
+                         "BETWEEN ({},{})".format(lower, upper),
+                         typeset={int, float})
 
 
 class Greater(Requirement):
@@ -147,7 +151,9 @@ class Greater(Requirement):
     """
     def __init__(self, val):
         assert isinstance(val, (int, float))
-        super().__init__(lambda v: v > val, "> {}".format(val), typeset={int, float})
+        super().__init__(lambda v: v > val,
+                         "> {}".format(val),
+                         typeset={int, float})
 
 
 class GreaterEqual(Requirement):
@@ -155,7 +161,9 @@ class GreaterEqual(Requirement):
     GreaterEqual: a `Requirement` to the lower bound of an argument. Synonym of the operator `>=`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v >= val, ">= {}".format(val), typeset={int, float})
+        super().__init__(lambda v: v >= val,
+                         ">= {}".format(val),
+                         typeset={int, float})
 
 
 class Less(Requirement):
@@ -163,7 +171,9 @@ class Less(Requirement):
     Less: a `Requirement` to the upper bound of an argument. Synonym of the operator `<`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v < val, "< {}".format(val), typeset={int, float})
+        super().__init__(lambda v: v < val,
+                         "< {}".format(val),
+                         typeset={int, float})
 
 
 class LessEqual(Requirement):
@@ -171,7 +181,9 @@ class LessEqual(Requirement):
     LessEqual: a `Requirement` to the upper bound of an argument. Synonym of the operator `<=`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v <= val, "<= {}".format(val), typset={int, float})
+        super().__init__(lambda v: v <= val,
+                         "<= {}".format(val),
+                         typset={int, float})
 
 
 class In(Requirement):
@@ -215,10 +227,10 @@ class Diagnostics(AttributeError):
         lines = ["argument(s) didn't meet parameter requirements"]
         for k, v in self._diagnostics:
             if type(v) == tuple:  # diag, arg, mandatory
-                arg_text = '"{}(string)"'.format(v[1]) if type(v[1]) == str else v[1]
-                lines.append(
-                    '{}({}) must be {}. Actual: {}'.format(
-                        k, 'required' if v[2] else 'optional', v[0], arg_text))
+                arg_text = '"{}(string)"'.format(v[1]) if type(
+                    v[1]) == str else v[1]
+                lines.append('{}({}) must be {}. Actual: {}'.format(
+                    k, 'required' if v[2] else 'optional', v[0], arg_text))
             elif v == 'UNEXPECTED':
                 lines.append('{} is {}'.format(k, v))
             else:
@@ -290,8 +302,8 @@ def check_requirements(params_args, mandatory, unexpected, contracts):
             diagnostics[param] = str(contracts[param]), arg, param in mandatory
     for param in mandatory - params_args.keys():
         # Checking missing arguments
-        diagnostics[
-            param] = str(contracts[param]) if param in contracts else ''
+        diagnostics[param] = str(
+            contracts[param]) if param in contracts else ''
     for param in unexpected:
         # Checking unexpected arguments
         diagnostics[param] = "UNEXPECTED"
@@ -362,20 +374,14 @@ if __name__ == '__main__':
         "n_classes": 0
     }
 
-    my_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
+    # my_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
     # If we enable the above code line, the error message will look like:
-
     #     Traceback (most recent call last):
-    #       File "contracts.py", line 252, in <module>
-    #         dnn_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
-    #       File "contracts.py", line 238, in check_requirements
-    #         check_requirements_for_existed(func, kwargs, **self._contracts[func])
-    #       File "contracts.py", line 225, in check_requirements_for_existed
-    #         check_requirements(*extract_params_args(func, [], kwargs), contracts)
-    #       File "contracts.py", line 211, in check_requirements
+    #         ...
     #         raise diagnostics
     #     __main__.Diagnostics: argument(s) didn't meet parameter requirements
-    #     hidden_units: Requirements: "TYPE=list[TYPE=int AND '>0'], REQUIRED", Actual: "[0, 1, 2](TYPE=list)"
-    #     n_classes: Requirements: "TYPE=int AND '>=2', OPTIONAL", Actual: "0(TYPE=int)"
-    #     feature_columns: Requirements: "TYPE=dict, REQUIRED", Actual: MISSING
-    #     feature_column: UNEXPECTED
+
+    #     hidden_units(required) must be `list of int that's > 0`. Actual: [0, 1, 2]
+    #     n_classes(optional) must be int that's >= 2. Actual: 0
+    #     feature_columns is required but is MISSING. Should be dict
+    #     feature_column is UNEXPECTED

--- a/python/contracts.py
+++ b/python/contracts.py
@@ -1,0 +1,320 @@
+# coding: utf8
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from functools import wraps
+
+
+class Requirement(object):
+    """
+    Requirement: a basic semantic primitive for contracts based verification
+                 that supports logic combinations of primitives and readable
+                 diagnostic messages.
+    """
+    def __init__(self, f, diag, isor=False):
+        self.func = f
+        self.diag = diag
+        self._or = isor
+
+    def __or__(self, other):
+        if not isinstance(other, Requirement):
+            raise TypeError()
+
+        return Requirement(lambda v: self(v) or other(v), " OR ".join(
+            (self.diag, other.diag)), True)
+
+    def __and__(self, other):
+        if not isinstance(other, Requirement):
+            raise TypeError()
+
+        return Requirement(
+            lambda v: self(v) and other(v),
+            " AND ".join('({})'.format(p.diag) if p._or else p.diag
+                         for p in [self, other]))
+
+    def __call__(self, v):
+        try:
+            return self.func(v)
+        except:
+            # An exception implies the requirement is not met
+            return False
+
+
+class Type(Requirement):
+    """
+    Type: a `Requirement` that checks argument types (maybe 1d-nested). For example:
+          Type(0) requires the argument to be an integer,
+          Type([Int&Positive]) requires the argument to be a list of positive integers.
+    """
+    def __init__(self, val):
+        def deepcheck(v):
+            # NOTE: 1. list that's more than 2d degrades to list at the moment
+            #       2. only the 1st element of `val` is respected as the requirements
+            #          to all elements of `v`
+            # TODO(shendiaomo): support checking dict like `Type({String: Int})`?
+            if type(val) in (list, tuple) and len(val) and isinstance(
+                    val[0], Requirement):
+                return (type(v) in (list, tuple)
+                        and all(map(lambda i: val[0](i), v)))
+            return isinstance(v, type(val))
+
+        if type(val) in (list, tuple) and len(val) and isinstance(
+                val[0], Requirement):
+            typename = "list[{}]".format(val[0].diag)
+        else:
+            typename = type(val).__name__
+        super().__init__(deepcheck, "TYPE={}".format(typename))
+
+
+class Between(Requirement):
+    """
+    Between: a `Requirement` to the range of an argument. Bounds are included (closed interval).
+    """
+    def __init__(self, lower, upper):
+        super().__init__(lambda v: upper >= v >= lower,
+                         "BETWEEN ({},{})".format(lower, upper))
+
+
+class Greater(Requirement):
+    """
+    Greater: a `Requirement` to the lower bound of an argument. Synonym of the operator `>`.
+    """
+    def __init__(self, val):
+        super().__init__(lambda v: v > val, "'>{}'".format(val))
+
+
+class GreaterEqual(Requirement):
+    """
+    GreaterEqual: a `Requirement` to the lower bound of an argument. Synonym of the operator `>=`.
+    """
+    def __init__(self, val):
+        super().__init__(lambda v: v >= val, "'>={}'".format(val))
+
+
+class Less(Requirement):
+    """
+    Less: a `Requirement` to the upper bound of an argument. Synonym of the operator `<`.
+    """
+    def __init__(self, val):
+        super().__init__(lambda v: v < val, "'>{}'".format(val))
+
+
+class LessEqual(Requirement):
+    """
+    LessEqual: a `Requirement` to the upper bound of an argument. Synonym of the operator `<=`.
+    """
+    def __init__(self, val):
+        super().__init__(lambda v: v <= val, "'<={}'".format(val))
+
+
+class In(Requirement):
+    """
+    In: a `Requirement` to the value of an argument. Synonym of the keyword `in`.
+    """
+    def __init__(self, *args):
+        super().__init__(lambda v: v in args,
+                         "IN ({})".format(",".join(str(i) for i in args)))
+
+
+# Shortcuts for requirements that're often used by ML models
+Int = Type(1)
+Float = Type(1.)
+Positive = Greater(0)
+Natural = Int & Positive
+
+
+class Diagnostics(AttributeError):
+    """
+    Diagnostics: summarizes diagnostic messages from a contract checking.
+    """
+    def __init__(self):
+        super().__init__()
+        self._diagnostics = []
+
+    def __setitem__(self, param, diag):
+        self._diagnostics.append((param, diag))
+
+    def __bool__(self):
+        return len(self._diagnostics) != 0
+
+    def __str__(self):
+        lines = ["argument(s) didn't meet parameter requirements"]
+        for k, v in self._diagnostics:
+            if type(v) == tuple:  # diag, arg, mandatory
+                lines.append(
+                    '{}: Requirements: "{}, {}", Actual: "{}(TYPE={})"'.format(
+                        k, v[0], 'REQUIRED' if v[2] else 'OPTIONAL', v[1],
+                        type(v[1]).__name__))
+            elif v == 'UNEXPECTED':
+                lines.append('{}: {}'.format(k, v))
+            else:
+                lines.append('{}: Requirements: "{}", Actual: MISSING'.format(
+                    k, v + ", REQUIRED" if v else "REQUIRED"))
+        return '\n'.join(lines)
+
+
+def require(**contracts):
+    """
+    Input contract decorator.
+
+    :param contracts: dict of parameter names to argument `Requirement`s.
+    :return: func, decorator function
+    """
+    def decorator(func):
+        @wraps(func)
+        def decorated(*args, **kwargs):
+            check_requirements(*extract_params_args(func, args, kwargs),
+                               contracts)
+            return func(*args, **kwargs)
+
+        return decorated
+
+    return decorator
+
+
+def extract_params_args(func, args, kwargs={}):
+    """
+    Extract the parameter names of function with its arguments and properties.
+
+    :param func: a function or callable object to be extracted
+    :param args: [arg, ...], positional arguments
+    :param kwargs: {param: arg, ...}, variadic keyword arguments
+    :return: parameters to arguments, required positional parameters and unexpected keyword parameters
+             tuple(dict{param: arg, ...}, set{param, ...}, set{param, ...})
+    """
+    func_params = inspect.signature(func).parameters
+    unexpected = kwargs.keys() - func_params.keys()
+    for s, p in func_params.items():
+        if p.kind == p.VAR_KEYWORD:
+            unexpected = {}
+    params_args = dict(zip(func_params, args))
+    params_args.update(kwargs)
+    mandatory = {
+        s
+        for s, p in func_params.items()
+        if p.kind == p.POSITIONAL_OR_KEYWORD and p.default == p.empty
+    }
+    return params_args, mandatory, unexpected
+
+
+def check_requirements(params_args, mandatory, unexpected, contracts):
+    """
+    Check whether `params_args`, `mandatory` and `unexpected` meet the requirements of contracts.
+
+    :param params_args: dict of parameters to arguments
+    :param mandatory: set of required positional parameters
+    :param unexpected: unexpected keyword parameters
+    :param contracts: dict of parameters to requirements (a `Requirement` object)
+    :return: parameters to arguments, required positional parameters and unexpected keyword parameters
+             tuple(dict{param: arg, ...}, set{param, ...}, set{param, ...})
+    :raise: raise Diagnostics if the check failed
+    """
+    diagnostics = Diagnostics()
+    for param, arg in filter(lambda t: t[0] in contracts, params_args.items()):
+        # Checking violations
+        try:
+            if not contracts[param](arg):
+                diagnostics[param] = contracts.diag, arg, param in mandatory
+        except Exception as e:
+            diagnostics[param] = contracts[param].diag, arg, param in mandatory
+
+    for param in mandatory - params_args.keys():
+        diagnostics[
+            param] = contracts[param].diag if param in contracts else ''
+    for param in unexpected:
+        diagnostics[param] = "UNEXPECTED"
+    if diagnostics:
+        raise diagnostics
+
+
+def check_requirements_for_existed(func, kwargs, **contracts):
+    """
+    Check whether `kwargs` meet the requirements of `func`'s `contracts`.
+
+    :param func: a function or callable object to be extracted
+    :param kwargs: dict of the form {param: arg, ...}, variadic keyword arguments
+    :param contracts: variadic keyword arguments of parameter names to `Requirement`s
+    :return: parameters to arguments, required positional parameters and unexpected keyword parameters
+             tuple(dict{param: arg, ...}, set{param, ...}, set{param, ...})
+    :raise: raise Diagnostics if the check failed
+    """
+    check_requirements(*extract_params_args(func, [], kwargs), contracts)
+
+
+# This is an example of using `contracts` to design a framework to
+# check various callables
+class Contracts(object):
+    def __init__(self):
+        self._contracts = {}
+
+    def add_requirements(self, func, *aliases, **contracts):
+        for alias in list(aliases) + [func]:
+            self._contracts[alias] = contracts
+
+    def check_requirements(self, func, kwargs):
+        if func in self._contracts:
+            check_requirements_for_existed(func, kwargs,
+                                           **self._contracts[func])
+
+
+if __name__ == '__main__':
+    import tensorflow as tf
+    import xgboost as xgb
+    my_contracts = Contracts()
+    my_contracts.add_requirements(tf.estimator.DNNClassifier,
+                                  hidden_units=Type([Natural]),
+                                  n_classes=Int & GreaterEqual(2),
+                                  optimizer=In('RMSprop', 'Adagrad'),
+                                  feature_columns=Type({}))
+
+    my_contracts.add_requirements(xgb.XGBModel,
+                                  xgb.XGBClassifier,
+                                  learning_rate=Float & Between(0, 1),
+                                  booster=In(
+                                      "binary:hinge",
+                                      "binary:logistic",
+                                      "binary:logitraw",
+                                      "multi:softmax",
+                                      "multi:softprob",
+                                      "rank:map",
+                                      "rank:ndcg",
+                                      "rank:pairwise",
+                                      "reg:gamma",
+                                      "reg:logistic",
+                                  ),
+                                  max_depth=Natural)
+
+    model_params = {
+        "hidden_units": [0, 1, 2],
+        "feature_column": {},
+        "n_classes": 0
+    }
+
+    # my_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
+    # If we enable the above code line, the error message will look like:
+
+    #     Traceback (most recent call last):
+    #       File "contracts.py", line 252, in <module>
+    #         dnn_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
+    #       File "contracts.py", line 238, in check_requirements
+    #         check_requirements_for_existed(func, kwargs, **self._contracts[func])
+    #       File "contracts.py", line 225, in check_requirements_for_existed
+    #         check_requirements(*extract_params_args(func, [], kwargs), contracts)
+    #       File "contracts.py", line 211, in check_requirements
+    #         raise diagnostics
+    #     __main__.Diagnostics: argument(s) didn't meet parameter requirements
+    #     hidden_units: Requirements: "TYPE=list[TYPE=int AND '>0'], REQUIRED", Actual: "[0, 1, 2](TYPE=list)"
+    #     n_classes: Requirements: "TYPE=int AND '>=2', OPTIONAL", Actual: "0(TYPE=int)"
+    #     feature_columns: Requirements: "TYPE=dict, REQUIRED", Actual: MISSING
+    #     feature_column: UNEXPECTED

--- a/python/contracts.py
+++ b/python/contracts.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import inspect
-from functools import wraps
+from functools import wraps, reduce
 
 
 class Requirement(object):
@@ -22,33 +22,86 @@ class Requirement(object):
                  that supports logic combinations of primitives and readable
                  diagnostic messages.
     """
-    def __init__(self, f, diag, isor=False):
+    def __init__(self, f, desc="", isor=False, issubj=False, typeset=None):
         self.func = f
-        self.diag = diag
+        self._desc= desc
         self._or = isor
+        self._dnf = [[self]]
+        self._typeset = typeset
+        self._issubj=issubj
+        self._custom_diag = False
 
     def __or__(self, other):
         if not isinstance(other, Requirement):
             raise TypeError()
 
-        return Requirement(lambda v: self(v) or other(v), " OR ".join(
-            (self.diag, other.diag)), True)
+        ret = Requirement(lambda v: self(v) or other(v), "", isor=True)
+        ret._dnf = self._dnf + other._dnf
+        return ret
 
     def __and__(self, other):
         if not isinstance(other, Requirement):
             raise TypeError()
-
-        return Requirement(
-            lambda v: self(v) and other(v),
-            " AND ".join('({})'.format(p.diag) if p._or else p.diag
-                         for p in [self, other]))
+        if self._typeset and other._typeset:
+            typeset = self._typeset & other._typeset
+            if not typeset:
+                raise TypeError(
+                    f"type can not be both in {self._typeset} and {other._typeset}")
+        ret = Requirement(lambda v: self(v) and other(v))
+        ret._dnf = []
+        for i in self._dnf:
+            for j in other._dnf:
+                cnf = i + j
+                type_cnf = list(filter(None, map(lambda r: r._typeset, cnf)))
+                if type_cnf:
+                    typeset = reduce(lambda l, r: l & r, type_cnf)
+                    if not typeset:
+                        # Eliminate the cnf because it's always False
+                        continue
+                ret._dnf.append(cnf)
+        return ret
 
     def __call__(self, v):
-        try:
-            return self.func(v)
-        except:
-            # An exception implies the requirement is not met
-            return False
+        for ands in self._dnf:
+            r = ands[0]
+            res = r.func(v)
+            for r in ands[1:]:
+                res = res and r.func(v)
+            if res:
+                return True
+        return False
+
+    def __str__(self):
+        if self._custom_diag:
+            return self._desc
+        messages = []
+        uniq_cnfs  = []
+        for ands in sorted(self._dnf, key=lambda a: len(a)):
+            ands.sort(key=lambda r: r._issubj, reverse=True)
+            r = ands[0]
+            desc, hastype = r._desc, r._typeset
+            uniq_ands = set([desc])
+            for r in ands[1:]:
+                if r._desc in uniq_ands:
+                    continue
+                uniq_ands.add(r._desc)
+                if hastype:
+                    hastype = False
+                    desc = desc + " that's " + r._desc
+                else:
+                    desc = desc + " and " + r._desc
+            if not any(map(lambda s: s.issubset(uniq_ands), uniq_cnfs)):
+                # Eliminate the cnf because it's redundant
+                uniq_cnfs.append(uniq_ands)
+                messages.append(desc)
+        return ", or ".join(messages)
+
+
+    def desc(self, desc):
+        self._desc = desc
+        self._dnf = [[self]]
+        self._custom_desc = True
+        return self
 
 
 class Type(Requirement):
@@ -71,10 +124,10 @@ class Type(Requirement):
 
         if type(val) in (list, tuple) and len(val) and isinstance(
                 val[0], Requirement):
-            typename = "list[{}]".format(val[0].diag)
+            typename = "`list of {}`".format(val[0])
         else:
             typename = type(val).__name__
-        super().__init__(deepcheck, "TYPE={}".format(typename))
+        super().__init__(deepcheck, "{}".format(typename), issubj=True, typeset={type(val)})
 
 
 class Between(Requirement):
@@ -82,8 +135,10 @@ class Between(Requirement):
     Between: a `Requirement` to the range of an argument. Bounds are included (closed interval).
     """
     def __init__(self, lower, upper):
+        assert upper >= lower
+        assert isinstance(upper, (int, float))
         super().__init__(lambda v: upper >= v >= lower,
-                         "BETWEEN ({},{})".format(lower, upper))
+                         "BETWEEN ({},{})".format(lower, upper), typeset={int, float})
 
 
 class Greater(Requirement):
@@ -91,7 +146,8 @@ class Greater(Requirement):
     Greater: a `Requirement` to the lower bound of an argument. Synonym of the operator `>`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v > val, "'>{}'".format(val))
+        assert isinstance(val, (int, float))
+        super().__init__(lambda v: v > val, "> {}".format(val), typeset={int, float})
 
 
 class GreaterEqual(Requirement):
@@ -99,7 +155,7 @@ class GreaterEqual(Requirement):
     GreaterEqual: a `Requirement` to the lower bound of an argument. Synonym of the operator `>=`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v >= val, "'>={}'".format(val))
+        super().__init__(lambda v: v >= val, ">= {}".format(val), typeset={int, float})
 
 
 class Less(Requirement):
@@ -107,7 +163,7 @@ class Less(Requirement):
     Less: a `Requirement` to the upper bound of an argument. Synonym of the operator `<`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v < val, "'>{}'".format(val))
+        super().__init__(lambda v: v < val, "< {}".format(val), typeset={int, float})
 
 
 class LessEqual(Requirement):
@@ -115,7 +171,7 @@ class LessEqual(Requirement):
     LessEqual: a `Requirement` to the upper bound of an argument. Synonym of the operator `<=`.
     """
     def __init__(self, val):
-        super().__init__(lambda v: v <= val, "'<={}'".format(val))
+        super().__init__(lambda v: v <= val, "<= {}".format(val), typset={int, float})
 
 
 class In(Requirement):
@@ -123,15 +179,22 @@ class In(Requirement):
     In: a `Requirement` to the value of an argument. Synonym of the keyword `in`.
     """
     def __init__(self, *args):
+        if all(map(lambda v: isinstance(v, (int, float)), args)):
+            typeset = {int, float}
+        else:
+            typeset = set(map(type, args))
+            assert len(typeset) == 1
         super().__init__(lambda v: v in args,
-                         "IN ({})".format(",".join(str(i) for i in args)))
+                         "IN ({})".format(",".join(str(i) for i in args)),
+                         typeset=typeset)
 
 
 # Shortcuts for requirements that're often used by ML models
 Int = Type(1)
 Float = Type(1.)
-Positive = Greater(0)
-Natural = Int & Positive
+String = Type('')
+Positive = Greater(0) & (Int | Float)
+PositiveInt = Int & Greater(0)
 
 
 class Diagnostics(AttributeError):
@@ -152,15 +215,15 @@ class Diagnostics(AttributeError):
         lines = ["argument(s) didn't meet parameter requirements"]
         for k, v in self._diagnostics:
             if type(v) == tuple:  # diag, arg, mandatory
+                arg_text = '"{}(string)"'.format(v[1]) if type(v[1]) == str else v[1]
                 lines.append(
-                    '{}: Requirements: "{}, {}", Actual: "{}(TYPE={})"'.format(
-                        k, v[0], 'REQUIRED' if v[2] else 'OPTIONAL', v[1],
-                        type(v[1]).__name__))
+                    '{}({}) must be {}. Actual: {}'.format(
+                        k, 'required' if v[2] else 'optional', v[0], arg_text))
             elif v == 'UNEXPECTED':
-                lines.append('{}: {}'.format(k, v))
+                lines.append('{} is {}'.format(k, v))
             else:
-                lines.append('{}: Requirements: "{}", Actual: MISSING'.format(
-                    k, v + ", REQUIRED" if v else "REQUIRED"))
+                lines.append('{} is required but is MISSING. {}'.format(
+                    k, "Should be " + v if v else ""))
         return '\n'.join(lines)
 
 
@@ -223,16 +286,14 @@ def check_requirements(params_args, mandatory, unexpected, contracts):
     diagnostics = Diagnostics()
     for param, arg in filter(lambda t: t[0] in contracts, params_args.items()):
         # Checking violations
-        try:
-            if not contracts[param](arg):
-                diagnostics[param] = contracts.diag, arg, param in mandatory
-        except Exception as e:
-            diagnostics[param] = contracts[param].diag, arg, param in mandatory
-
+        if not contracts[param](arg):
+            diagnostics[param] = str(contracts[param]), arg, param in mandatory
     for param in mandatory - params_args.keys():
+        # Checking missing arguments
         diagnostics[
-            param] = contracts[param].diag if param in contracts else ''
+            param] = str(contracts[param]) if param in contracts else ''
     for param in unexpected:
+        # Checking unexpected arguments
         diagnostics[param] = "UNEXPECTED"
     if diagnostics:
         raise diagnostics
@@ -273,7 +334,7 @@ if __name__ == '__main__':
     import xgboost as xgb
     my_contracts = Contracts()
     my_contracts.add_requirements(tf.estimator.DNNClassifier,
-                                  hidden_units=Type([Natural]),
+                                  hidden_units=Type([PositiveInt]),
                                   n_classes=Int & GreaterEqual(2),
                                   optimizer=In('RMSprop', 'Adagrad'),
                                   feature_columns=Type({}))
@@ -293,7 +354,7 @@ if __name__ == '__main__':
                                       "reg:gamma",
                                       "reg:logistic",
                                   ),
-                                  max_depth=Natural)
+                                  max_depth=PositiveInt)
 
     model_params = {
         "hidden_units": [0, 1, 2],
@@ -301,7 +362,7 @@ if __name__ == '__main__':
         "n_classes": 0
     }
 
-    # my_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
+    my_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
     # If we enable the above code line, the error message will look like:
 
     #     Traceback (most recent call last):

--- a/python/contracts_test.py
+++ b/python/contracts_test.py
@@ -28,12 +28,12 @@ class TestContracts(unittest.TestCase):
         self.assertIsNone(f(0))
         # Type violation
         self.assertRaisesRegex(
-            Diagnostics,
-            r'(?m)^x\(required\) must be int. Actual: 0.0$', f, 0.)
+            Diagnostics, r'(?m)^x\(required\) must be int. Actual: 0.0$', f,
+            0.)
         # Missing required positional argument
         self.assertRaisesRegex(
-            Diagnostics,
-            r'(?m)^x is required but is MISSING. Should be int$', f)
+            Diagnostics, r'(?m)^x is required but is MISSING. Should be int$',
+            f)
         # Unexpected keyword arguments
         self.assertRaisesRegex(Diagnostics, r'(?m)^y is UNEXPECTED$', f, y=1)
         # Contracts don't handle unexpected positional arguments
@@ -50,16 +50,15 @@ class TestContracts(unittest.TestCase):
         self.assertIsNone(require_f(kwargs={"x": 0}))
         # Type violation
         self.assertRaisesRegex(
-            Diagnostics,
-            r'(?m)^x\(required\) must be int. Actual: 0.0$', require_f,
-            {"x": 0.})
+            Diagnostics, r'(?m)^x\(required\) must be int. Actual: 0.0$',
+            require_f, {"x": 0.})
         # Missing required positional argument
         self.assertRaisesRegex(
-            Diagnostics,
-            r'(?m)^x is required but is MISSING. Should be int$', require_f, {})
+            Diagnostics, r'(?m)^x is required but is MISSING. Should be int$',
+            require_f, {})
         # Unexpected keyword arguments
-        self.assertRaisesRegex(Diagnostics, r'(?m)^y is UNEXPECTED$', require_f,
-                               {"y": 1})
+        self.assertRaisesRegex(Diagnostics, r'(?m)^y is UNEXPECTED$',
+                               require_f, {"y": 1})
 
     def test_combination(self):
         @require(x=(Int | Float | Type("")) & (Between(0, 1) | In('relu')))
@@ -104,9 +103,9 @@ class TestContracts(unittest.TestCase):
         def f(x):
             pass
 
-        self.assertRaisesRegex(
-            Diagnostics,
-            r'x\(required\) must be list. Actual: 0.0$', f, 0.)
+        self.assertRaisesRegex(Diagnostics,
+                               r'x\(required\) must be list. Actual: 0.0$', f,
+                               0.)
         # NOTE: list that's more than 2d degrades to list at the moment
         self.assertIsNone(f([0, 0.]))
         self.assertIsNone(f([0., 1]))

--- a/python/contracts_test.py
+++ b/python/contracts_test.py
@@ -27,12 +27,15 @@ class TestContracts(unittest.TestCase):
 
         self.assertIsNone(f(0))
         # Type violation
-        self.assertRaisesRegex(Diagnostics,
-                               r'(?m)^.*TYPE=int.*\(TYPE=float\)"$', f, 0.)
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'(?m)^x\(required\) must be int. Actual: 0.0$', f, 0.)
         # Missing required positional argument
-        self.assertRaisesRegex(Diagnostics, r'(?m)^.*TYPE=int.*MISSING$', f)
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'(?m)^x is required but is MISSING. Should be int$', f)
         # Unexpected keyword arguments
-        self.assertRaisesRegex(Diagnostics, r'(?m)^y: UNEXPECTED$', f, y=1)
+        self.assertRaisesRegex(Diagnostics, r'(?m)^y is UNEXPECTED$', f, y=1)
         # Contracts don't handle unexpected positional arguments
         self.assertRaises(TypeError, f, 1, 2)
 
@@ -46,14 +49,16 @@ class TestContracts(unittest.TestCase):
         # Do the same thing as the first part
         self.assertIsNone(require_f(kwargs={"x": 0}))
         # Type violation
-        self.assertRaisesRegex(Diagnostics,
-                               r'(?m)^.*TYPE=int.*\(TYPE=float\)"$', require_f,
-                               {"x": 0.})
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'(?m)^x\(required\) must be int. Actual: 0.0$', require_f,
+            {"x": 0.})
         # Missing required positional argument
-        self.assertRaisesRegex(Diagnostics, r'(?m)^.*TYPE=int.*MISSING$',
-                               require_f, {})
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'(?m)^x is required but is MISSING. Should be int$', require_f, {})
         # Unexpected keyword arguments
-        self.assertRaisesRegex(Diagnostics, r'(?m)^y: UNEXPECTED$', require_f,
+        self.assertRaisesRegex(Diagnostics, r'(?m)^y is UNEXPECTED$', require_f,
                                {"y": 1})
 
     def test_combination(self):
@@ -82,14 +87,14 @@ class TestContracts(unittest.TestCase):
 
         self.assertRaisesRegex(
             Diagnostics,
-            r'''(?m)^.*TYPE=list\[TYPE=float AND '>0'\], REQUIRED.*$''', f, 0.)
+            r"(?m)^x\(required\) must be `list of float that's > 0`.*$", f, 0.)
         self.assertRaisesRegex(
             Diagnostics,
-            r'''(?m)^.*TYPE=list\[TYPE=float AND '>0'\], REQUIRED.*$''', f,
+            r"(?m)^x\(required\) must be `list of float that's > 0`.*$", f,
             [0, 0.])
         self.assertRaisesRegex(
             Diagnostics,
-            r'''(?m)^.*TYPE=list\[TYPE=float AND '>0'\], REQUIRED.*$''', f,
+            r"(?m)^x\(required\) must be `list of float that's > 0`.*$", f,
             [0., 1])
         self.assertIsNone(f([1e-10, 1e10]))
 
@@ -99,9 +104,14 @@ class TestContracts(unittest.TestCase):
         def f(x):
             pass
 
-        self.assertRaisesRegex(Diagnostics,
-                               r'''(?m)^.*TYPE=list, REQUIRED.*$''', f, 0.)
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'x\(required\) must be list. Actual: 0.0$', f, 0.)
         # NOTE: list that's more than 2d degrades to list at the moment
         self.assertIsNone(f([0, 0.]))
         self.assertIsNone(f([0., 1]))
         self.assertIsNone(f([1e-10, 1e10]))
+
+    def test_reduction(self):
+        self.assertEqual("float", str(Float | (Float & Positive)))
+        self.assertEqual("float", str(Float & Float))

--- a/python/contracts_test.py
+++ b/python/contracts_test.py
@@ -1,0 +1,107 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import contracts
+from contracts import (Between, Diagnostics, Float, In, Int, Positive, Type,
+                       require)
+
+
+class TestContracts(unittest.TestCase):
+    def test_type(self):
+        # 1. Test the decorator way
+        @require(x=Int)
+        def f(x):
+            pass
+
+        self.assertIsNone(f(0))
+        # Type violation
+        self.assertRaisesRegex(Diagnostics,
+                               r'(?m)^.*TYPE=int.*\(TYPE=float\)"$', f, 0.)
+        # Missing required positional argument
+        self.assertRaisesRegex(Diagnostics, r'(?m)^.*TYPE=int.*MISSING$', f)
+        # Unexpected keyword arguments
+        self.assertRaisesRegex(Diagnostics, r'(?m)^y: UNEXPECTED$', f, y=1)
+        # Contracts don't handle unexpected positional arguments
+        self.assertRaises(TypeError, f, 1, 2)
+
+        # 2. Test the api way (for existed callables that cannot be modified)
+        def f(x):
+            pass
+
+        def require_f(kwargs):
+            contracts.check_requirements_for_existed(f, kwargs, x=Int)
+
+        # Do the same thing as the first part
+        self.assertIsNone(require_f(kwargs={"x": 0}))
+        # Type violation
+        self.assertRaisesRegex(Diagnostics,
+                               r'(?m)^.*TYPE=int.*\(TYPE=float\)"$', require_f,
+                               {"x": 0.})
+        # Missing required positional argument
+        self.assertRaisesRegex(Diagnostics, r'(?m)^.*TYPE=int.*MISSING$',
+                               require_f, {})
+        # Unexpected keyword arguments
+        self.assertRaisesRegex(Diagnostics, r'(?m)^y: UNEXPECTED$', require_f,
+                               {"y": 1})
+
+    def test_combination(self):
+        @require(x=(Int | Float | Type("")) & (Between(0, 1) | In('relu')))
+        def f(x):
+            '''
+            param x: 1. int or float in the closed interval [0, 1], or
+                     2. the string 'relu'
+            '''
+            pass
+
+        self.assertIsNone(f(0))
+        self.assertIsNone(f(1))
+        self.assertIsNone(f(0.))
+        self.assertIsNone(f(1.))
+        self.assertIsNone(f(0.5))
+        self.assertRaises(Diagnostics, f, 2)
+        self.assertRaises(Diagnostics, f, -1e-10)
+        self.assertRaises(Diagnostics, f, '2')
+        self.assertIsNone(f('relu'))
+
+    def test_1d_list(self):
+        @require(x=Type([Float & Positive]))  # list of positive floats
+        def f(x):
+            pass
+
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'''(?m)^.*TYPE=list\[TYPE=float AND '>0'\], REQUIRED.*$''', f, 0.)
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'''(?m)^.*TYPE=list\[TYPE=float AND '>0'\], REQUIRED.*$''', f,
+            [0, 0.])
+        self.assertRaisesRegex(
+            Diagnostics,
+            r'''(?m)^.*TYPE=list\[TYPE=float AND '>0'\], REQUIRED.*$''', f,
+            [0., 1])
+        self.assertIsNone(f([1e-10, 1e10]))
+
+    def test_2d_list(self):
+        @require(x=Type([[Float & Positive]])
+                 )  # list of list of positive floats
+        def f(x):
+            pass
+
+        self.assertRaisesRegex(Diagnostics,
+                               r'''(?m)^.*TYPE=list, REQUIRED.*$''', f, 0.)
+        # NOTE: list that's more than 2d degrades to list at the moment
+        self.assertIsNone(f([0, 0.]))
+        self.assertIsNone(f([0., 1]))
+        self.assertIsNone(f([1e-10, 1e10]))


### PR DESCRIPTION
Partially fix #2235 
This version is not compatible with python2 now.

The PR only supports a minimal subset of the idea of the contracts that I believe is enough for our scenario, the terms `contracts` and `requirements` in this implementation are mostly interchangeable.

### Examples
#### Case 1: Check Existing Callables
```python
from contracts import *
import tensorflow as tf
import xgboost as xgb
my_contracts = Contracts()
my_contracts.add_requirements(tf.estimator.DNNClassifier,
                              hidden_units=Type([Natural]),
                              n_classes=Int & GreaterEqual(2),
                              optimizer=In('RMSprop', 'Adagrad'),
                              feature_columns=Type({}))

my_contracts.add_requirements(xgb.XGBModel,
                              xgb.XGBClassifier,
                              learning_rate=Float & Between(0, 1),
                              max_depth=Natural)

model_params = {
    "hidden_units": [0, 1, 2],
    "feature_column": {},
    "n_classes": 0
}

my_contracts.check_requirements(tf.estimator.DNNClassifier, model_params)
```

The above snippet will raise an exception like:
```
Traceback (most recent call last):
    ...
    raise diagnostics
__main__.Diagnostics: argument(s) didn't meet parameter requirements

hidden_units(required) must be `list of int that's > 0`. Actual: [0, 1, 2]
n_classes(optional) must be int that's >= 2. Actual: 0
feature_columns is required but is MISSING. Should be dict
feature_column is UNEXPECTED
```
The diagnostic messages are comprehensive and precise and can be further improved to be more readable.

 #### Case 2: Use Decorator to Check New Functions.
```python
@require(hidden_units=Type([Natural]), n_classes=Greater(1))
def MyDNNClassifier(...):
    # ...
```

 #### Case 3:  Requirements in Docstrings
This is not implemented now and is an important TODO.

```python
@contract
def MyDNNClassifier(...):
    ‘’‘
    :param: hidden_units
    :type: Type([Natural])
    :param: n_classes
    :type: Greater(1)
    ’‘’
    #  ...
```
The syntax detail should be carefully designed.

### Details
#### Combination
###### operator overloading
The design overloaded two operators (`|`, `&`) to combine different requirements. This section will use `hidden_units` of `DNNClassifier` as an example:
```python
# hidden_units must be a list of positive integers
hidden_units=IsType(list[IsInt & IsPositive])
```
##### Other Options
A pitfall of this method is that its readability is not great at a first glance. A user has to get familiar with the framework to be productive.
###### lambda
To use lambda to construct the precondition, we have to specify the error messages manually.
```python
hidden_units=require(lambda v: all(map(lambda i:  type(i) is int and i > 0, v)), "hidden_units must be a list of positive integers")
```
It's harder to write and reuse but a bit easier to generate readable diagnostic messages.

###### explicit function calls rather than overloaded operators
```python
hidden_units=IsType(list[And(IsInt,  IsPositive)])
```
Obviously, it keeps the reusability but doesn't improve the readability.