### PR TITLE
Disable unit test about distributed training on XGBoost temporarily

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -2091,8 +2091,9 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 		t.Run("CasePAIMaxComputeTrainPredictCategoricalFeature", CasePAIMaxComputeTrainPredictCategoricalFeature)
 		t.Run("CasePAIMaxComputeTrainTFBTDistributed", CasePAIMaxComputeTrainTFBTDistributed)
 		t.Run("CasePAIMaxComputeTrainDistributedKeras", CasePAIMaxComputeTrainDistributedKeras)
-		t.Run("CasePAIMaxComputeTrainXGBDistributed", CasePAIMaxComputeTrainXGBDistributed)
-
+		// FIXME(weiguoz): The dataset is too small for all reader to read
+		// Let's bring up this test case if we have a big dataset.
+		// t.Run("CasePAIMaxComputeTrainXGBDistributed", CasePAIMaxComputeTrainXGBDistributed)
 		// FIXME(typhoonzero): Add this test back when we solve error: model already exist issue on the CI.
 		// t.Run("CaseTrainPAIRandomForests", CaseTrainPAIRandomForests)
 	})


### PR DESCRIPTION
Because the dataset is too small for all workers to read.