### PR TITLE
Disable deploying Windows and Linux SQLFlow client in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,11 +106,15 @@ jobs:
     os: osx
     script:
     - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
-  - env: DESC="Deploy Linux client"
-    os: linux
-    script:
-    - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
-  - env: DESC="Deploy Windows client"
-    os: windows
-    script:
-    - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
+  # Temporarlily disable deployment the Linux and Windows client.
+  # Will soon enable them after fixing
+  # https://github.com/sql-machine-learning/sqlflow/issues/2248.
+  #
+  # - env: DESC="Deploy Linux client"
+  #   os: linux
+  #   script:
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
+  # - env: DESC="Deploy Windows client"
+  #   os: windows
+  #   script:
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh


### PR DESCRIPTION
This is a quick fix of the CI.

I will re-enable the deployment of Windows and Linux client soon after fixing https://github.com/sql-machine-learning/sqlflow/issues/2248