### PR TITLE
Split setup_minikube.sh into multiple scripts reusable by desktop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,56 +34,56 @@ install:
 - echo "skip install"
 jobs:
   include:
-  # - stage: BuildAndTest
-  #   script:
-  #   - set -e
-  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-  #   - docker run --rm -it -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:dev
-  #     pre-commit run -a --show-diff-on-failure
-  # - env: SQLFLOW_TEST_DB=mysql
-  #   script:
-  #   - set -e
-  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-  #   - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
-  #     scripts/test/units.sh
-  #   - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
-  #     scripts/travis/upload_coveralls.sh
-  # - env: SQLFLOW_TEST_DB=hive # run more parallel tests in the same stage:
-  #   script:
-  #   - set -e
-  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-  #   - docker pull sqlflow/gohive:dev
-  #   - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
-  #   - docker run --rm -it --net=container:hive
-  #     -v $TRAVIS_BUILD_DIR:/work -w /work
-  #     -v $GOPATH:/root/go
-  #     sqlflow:ci scripts/test/hive.sh
-  # - env: SQLFLOW_TEST_DB=maxcompute
-  #   script:
-  #   - set -e
-  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-  #   - $TRAVIS_BUILD_DIR/scripts/travis/setup_minikube.sh
-  #   - docker run --rm --net=host
-  #     -v /var/run/docker.sock:/var/run/docker.sock
-  #     -v $HOME/.kube:/root/.kube
-  #     -v /home/$USER/.minikube/:/home/$USER/.minikube/
-  #     -v $TRAVIS_BUILD_DIR:/work -w /work
-  #     sqlflow:ci scripts/test/ipython.sh
-  #   - docker run --rm --net=host
-  #     -e SQLFLOW_TEST_DB_MAXCOMPUTE_AK=$MAXCOMPUTE_AK
-  #     -e SQLFLOW_TEST_DB_MAXCOMPUTE_SK=$MAXCOMPUTE_SK
-  #     -v /var/run/docker.sock:/var/run/docker.sock
-  #     -v $HOME/.kube:/root/.kube
-  #     -v /home/$USER/.minikube/:/home/$USER/.minikube/
-  #     -v $TRAVIS_BUILD_DIR:/work -w /work
-  #     sqlflow:ci scripts/test/maxcompute.sh
-  # - env: SQLFLOW_TEST=java
-  #   script:
-  #   - set -e
-  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-  #   - docker run --rm
-  #     -v $TRAVIS_BUILD_DIR:/work -w /work
-  #     sqlflow:ci scripts/test/java.sh
+  - stage: BuildAndTest
+    script:
+    - set -e
+    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+    - docker run --rm -it -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:dev
+      pre-commit run -a --show-diff-on-failure
+  - env: SQLFLOW_TEST_DB=mysql
+    script:
+    - set -e
+    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+    - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
+      scripts/test/units.sh
+    - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
+      scripts/travis/upload_coveralls.sh
+  - env: SQLFLOW_TEST_DB=hive # run more parallel tests in the same stage:
+    script:
+    - set -e
+    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+    - docker pull sqlflow/gohive:dev
+    - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
+    - docker run --rm -it --net=container:hive
+      -v $TRAVIS_BUILD_DIR:/work -w /work
+      -v $GOPATH:/root/go
+      sqlflow:ci scripts/test/hive.sh
+  - env: SQLFLOW_TEST_DB=maxcompute
+    script:
+    - set -e
+    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+    - $TRAVIS_BUILD_DIR/scripts/travis/setup_minikube.sh
+    - docker run --rm --net=host
+      -v /var/run/docker.sock:/var/run/docker.sock
+      -v $HOME/.kube:/root/.kube
+      -v /home/$USER/.minikube/:/home/$USER/.minikube/
+      -v $TRAVIS_BUILD_DIR:/work -w /work
+      sqlflow:ci scripts/test/ipython.sh
+    - docker run --rm --net=host
+      -e SQLFLOW_TEST_DB_MAXCOMPUTE_AK=$MAXCOMPUTE_AK
+      -e SQLFLOW_TEST_DB_MAXCOMPUTE_SK=$MAXCOMPUTE_SK
+      -v /var/run/docker.sock:/var/run/docker.sock
+      -v $HOME/.kube:/root/.kube
+      -v /home/$USER/.minikube/:/home/$USER/.minikube/
+      -v $TRAVIS_BUILD_DIR:/work -w /work
+      sqlflow:ci scripts/test/maxcompute.sh
+  - env: SQLFLOW_TEST=java
+    script:
+    - set -e
+    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+    - docker run --rm
+      -v $TRAVIS_BUILD_DIR:/work -w /work
+      sqlflow:ci scripts/test/java.sh
   - env: SQLFLOW_TEST=workflow
     script:
     - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,56 +34,56 @@ install:
 - echo "skip install"
 jobs:
   include:
-  - stage: BuildAndTest
-    script:
-    - set -e
-    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-    - docker run --rm -it -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:dev
-      pre-commit run -a --show-diff-on-failure
-  - env: SQLFLOW_TEST_DB=mysql
-    script:
-    - set -e
-    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-    - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
-      scripts/test/units.sh
-    - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
-      scripts/travis/upload_coveralls.sh
-  - env: SQLFLOW_TEST_DB=hive # run more parallel tests in the same stage:
-    script:
-    - set -e
-    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-    - docker pull sqlflow/gohive:dev
-    - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
-    - docker run --rm -it --net=container:hive
-      -v $TRAVIS_BUILD_DIR:/work -w /work
-      -v $GOPATH:/root/go
-      sqlflow:ci scripts/test/hive.sh
-  - env: SQLFLOW_TEST_DB=maxcompute
-    script:
-    - set -e
-    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-    - $TRAVIS_BUILD_DIR/scripts/travis/setup_minikube.sh
-    - docker run --rm --net=host
-      -v /var/run/docker.sock:/var/run/docker.sock
-      -v $HOME/.kube:/root/.kube
-      -v /home/$USER/.minikube/:/home/$USER/.minikube/
-      -v $TRAVIS_BUILD_DIR:/work -w /work
-      sqlflow:ci scripts/test/ipython.sh
-    - docker run --rm --net=host
-      -e SQLFLOW_TEST_DB_MAXCOMPUTE_AK=$MAXCOMPUTE_AK
-      -e SQLFLOW_TEST_DB_MAXCOMPUTE_SK=$MAXCOMPUTE_SK
-      -v /var/run/docker.sock:/var/run/docker.sock
-      -v $HOME/.kube:/root/.kube
-      -v /home/$USER/.minikube/:/home/$USER/.minikube/
-      -v $TRAVIS_BUILD_DIR:/work -w /work
-      sqlflow:ci scripts/test/maxcompute.sh
-  - env: SQLFLOW_TEST=java
-    script:
-    - set -e
-    - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-    - docker run --rm
-      -v $TRAVIS_BUILD_DIR:/work -w /work
-      sqlflow:ci scripts/test/java.sh
+  # - stage: BuildAndTest
+  #   script:
+  #   - set -e
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+  #   - docker run --rm -it -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:dev
+  #     pre-commit run -a --show-diff-on-failure
+  # - env: SQLFLOW_TEST_DB=mysql
+  #   script:
+  #   - set -e
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+  #   - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
+  #     scripts/test/units.sh
+  #   - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
+  #     scripts/travis/upload_coveralls.sh
+  # - env: SQLFLOW_TEST_DB=hive # run more parallel tests in the same stage:
+  #   script:
+  #   - set -e
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+  #   - docker pull sqlflow/gohive:dev
+  #   - docker run -d --name=hive sqlflow/gohive:dev python3 -m http.server 8899
+  #   - docker run --rm -it --net=container:hive
+  #     -v $TRAVIS_BUILD_DIR:/work -w /work
+  #     -v $GOPATH:/root/go
+  #     sqlflow:ci scripts/test/hive.sh
+  # - env: SQLFLOW_TEST_DB=maxcompute
+  #   script:
+  #   - set -e
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/setup_minikube.sh
+  #   - docker run --rm --net=host
+  #     -v /var/run/docker.sock:/var/run/docker.sock
+  #     -v $HOME/.kube:/root/.kube
+  #     -v /home/$USER/.minikube/:/home/$USER/.minikube/
+  #     -v $TRAVIS_BUILD_DIR:/work -w /work
+  #     sqlflow:ci scripts/test/ipython.sh
+  #   - docker run --rm --net=host
+  #     -e SQLFLOW_TEST_DB_MAXCOMPUTE_AK=$MAXCOMPUTE_AK
+  #     -e SQLFLOW_TEST_DB_MAXCOMPUTE_SK=$MAXCOMPUTE_SK
+  #     -v /var/run/docker.sock:/var/run/docker.sock
+  #     -v $HOME/.kube:/root/.kube
+  #     -v /home/$USER/.minikube/:/home/$USER/.minikube/
+  #     -v $TRAVIS_BUILD_DIR:/work -w /work
+  #     sqlflow:ci scripts/test/maxcompute.sh
+  # - env: SQLFLOW_TEST=java
+  #   script:
+  #   - set -e
+  #   - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
+  #   - docker run --rm
+  #     -v $TRAVIS_BUILD_DIR:/work -w /work
+  #     sqlflow:ci scripts/test/java.sh
   - env: SQLFLOW_TEST=workflow
     script:
     - set -e

--- a/scripts/travis/export_k8s_vars.sh
+++ b/scripts/travis/export_k8s_vars.sh
@@ -14,28 +14,10 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
-
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+export KUBECONFIG=$HOME/.kube/config
+export K8S_VERSION=1.18.2
+export MINIKUBE_VERSION=1.10.1

--- a/scripts/travis/install_axel.sh
+++ b/scripts/travis/install_axel.sh
@@ -14,28 +14,5 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
-
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+sudo apt-get -qq update > /dev/null
+sudo apt-get -qq install -y axel > /dev/null

--- a/scripts/travis/install_kubectl.sh
+++ b/scripts/travis/install_kubectl.sh
@@ -14,28 +14,9 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
-
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+# Travis CI VMs and Vagrant provisioning allow sudo without password.
+K8S_RELEASE_SITE="https://storage.googleapis.com/kubernetes-release/release"
+axel --quiet --output kubectl \
+     $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
+chmod a+x kubectl
+sudo mv kubectl /usr/local/bin/kubectl

--- a/scripts/travis/install_kubectl.sh
+++ b/scripts/travis/install_kubectl.sh
@@ -16,7 +16,9 @@ set -e
 
 # Travis CI VMs and Vagrant provisioning allow sudo without password.
 K8S_RELEASE_SITE="https://storage.googleapis.com/kubernetes-release/release"
-axel --quiet --output kubectl \
+
+# DEBUG: add --quiet back
+axel --output kubectl \
      $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
 chmod a+x kubectl
 sudo mv kubectl /usr/local/bin/kubectl

--- a/scripts/travis/install_kubectl.sh
+++ b/scripts/travis/install_kubectl.sh
@@ -18,6 +18,8 @@ set -e
 K8S_RELEASE_SITE="https://storage.googleapis.com/kubernetes-release/release"
 
 # DEBUG: add --quiet back
+echo axel --output kubectl \
+     $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
 axel --output kubectl \
      $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
 chmod a+x kubectl

--- a/scripts/travis/install_kubectl.sh
+++ b/scripts/travis/install_kubectl.sh
@@ -17,10 +17,7 @@ set -e
 # Travis CI VMs and Vagrant provisioning allow sudo without password.
 K8S_RELEASE_SITE="https://storage.googleapis.com/kubernetes-release/release"
 
-# DEBUG: add --quiet back
-echo axel --output kubectl \
-     $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
-axel --output kubectl \
+axel --quiet --output kubectl \
      $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
 chmod a+x kubectl
 sudo mv kubectl /usr/local/bin/kubectl

--- a/scripts/travis/install_minikube.sh
+++ b/scripts/travis/install_minikube.sh
@@ -14,28 +14,12 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
+# c.f. https://kubernetes.io/docs/tasks/tools/install-minikube/
+MINIKUBE_RELEASE_SITE="https://storage.googleapis.com/minikube/releases"
+axel --quiet --output minikube \
+     $MINIKUBE_RELEASE_SITE/v$MINIKUBE_VERSION/minikube-linux-amd64
+chmod a+x minikube
+sudo mv minikube /usr/local/bin/minikube
 
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+# Kubernetes 1.18.2 requires conntrack.
+sudo apt-get -qq install -y conntrack

--- a/scripts/travis/setup_minikube.sh
+++ b/scripts/travis/setup_minikube.sh
@@ -23,7 +23,9 @@ echo "Install axel on Travis CI VM ..."
 $(dirname $0)/install_axel.sh
 
 echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
+# NOTE: According to https://stackoverflow.com/a/16619261/724872,
+# source is very necessary here.
+source $(dirname $0)/export_k8s_vars.sh
 
 echo "Install kubectl ..."
 $(dirname $0)/install_kubectl.sh

--- a/scripts/travis/start_argo.sh
+++ b/scripts/travis/start_argo.sh
@@ -14,28 +14,10 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
-
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+echo "Install Argo on minikube cluster ..."
+kubectl create namespace argo
+kubectl apply -n argo -f \
+  https://raw.githubusercontent.com/argoproj/argo/v2.7.7/manifests/install.yaml
+kubectl create rolebinding default-admin \
+  --clusterrole=admin \
+  --serviceaccount=default:default

--- a/scripts/travis/start_minikube.sh
+++ b/scripts/travis/start_minikube.sh
@@ -14,28 +14,11 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
+echo "Start minikube cluster ..."
 
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+sudo minikube start \
+     --vm-driver=none \
+     --kubernetes-version=v$K8S_VERSION \
+     --cpus 2 \
+     --memory 6144
+kubectl cluster-info

--- a/scripts/travis/start_tekton.sh
+++ b/scripts/travis/start_tekton.sh
@@ -14,28 +14,6 @@
 
 set -e
 
-if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
-    echo "$0 can run on Linux host only"
-    exit 1
-fi
-
-echo "Install axel on Travis CI VM ..."
-$(dirname $0)/install_axel.sh
-
-echo "Export Kubernetes environment variables ..."
-$(dirname $0)/export_k8s_vars.sh
-
-echo "Install kubectl ..."
-$(dirname $0)/install_kubectl.sh
-
-echo "Install minikube ..."
-$(dirname $0)/install_minikube.sh
-
-echo "Configure minikube ..."
-mkdir -p $HOME/.kube $HOME/.minikube
-touch $KUBECONFIG
-
-$(dirname $0)/start_minikube.sh
-sudo chown -R travis: $HOME/.minikube/
-
-$(dirname $0)/start_argo.sh
+echo "Install Tekton on minikube cluster ..."
+TEKTON_RELEASE_SITE="https://storage.googleapis.com/tekton-releases/pipeline"
+kubectl apply --filename $TEKTON_RELEASE_SITE/previous/v0.10.1/release.yaml


### PR DESCRIPTION
This PR splits `scripts/travis/setup_minikube.sh` into multiple scripts named `install_*.sh` and `start_*.sh`.  So, the sqflow.org/desktop project can call `install_*.sh` from Vagrant provision shell script and call `start_*.sh` from inside the running VM.