### PR TITLE
Fix default java version is 11, which will cause odpscmd error

### DIFF
--- a/docker/ci/install-java.bash
+++ b/docker/ci/install-java.bash
@@ -16,3 +16,6 @@
 set -e
 
 apt-get -qq install -y openjdk-8-jre > /dev/null
+
+rm -f /usr/bin/java
+ln -s /usr/lib/jvm/java-8-openjdk-amd64/bin/java /usr/bin/java

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.17.0 // indirect
 	sqlflow.org/goalisa v0.0.0-20200426073517-e08494be06fc


### PR DESCRIPTION
The `sqlflow/sqlflow` image currently use default java version 11, which may cause `odpscmd` fail. Change to use installed jdk 8.