### PR TITLE
Fix NUMERIC shape cannot be omitted bug

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -1895,6 +1895,23 @@ INTO e2etest_dense_input;`, caseTrainTable)
 	}
 }
 
+func CasePAIMaxComputeTrainDenseColWithoutIndicatingShape(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	trainSQL := fmt.Sprintf(`SELECT class, sepal_length, sepal_width, petal_length, petal_width
+FROM %s
+TO TRAIN DNNClassifier WITH model.hidden_units=[64,32], model.n_classes=3, train.batch_size=32
+COLUMN NUMERIC(sepal_length)
+LABEL class
+INTO e2etest_dense_input_without_indicating_shape;`, caseTrainTable)
+
+	_, _, _, err := connectAndRunSQL(trainSQL)
+	if err != nil {
+		a.Fail("Run trainSQL without indicating shape error: %v", err)
+	}
+}
+
 func CasePAIMaxComputeTrainXGBoost(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
@@ -2087,6 +2104,7 @@ func TestEnd2EndMaxComputePAI(t *testing.T) {
 	t.Run("group", func(t *testing.T) {
 		t.Run("CasePAIMaxComputeDNNTrainPredictExplain", CasePAIMaxComputeDNNTrainPredictExplain)
 		t.Run("CasePAIMaxComputeTrainDenseCol", CasePAIMaxComputeTrainDenseCol)
+		t.Run("CasePAIMaxComputeTrainDenseColWithoutIndicatingShape", CasePAIMaxComputeTrainDenseColWithoutIndicatingShape)
 		t.Run("CasePAIMaxComputeTrainXGBoost", CasePAIMaxComputeTrainXGBoost)
 		t.Run("CasePAIMaxComputeTrainCustomModel", CasePAIMaxComputeTrainCustomModel)
 		t.Run("CasePAIMaxComputeTrainDistributed", CasePAIMaxComputeTrainDistributed)


### PR DESCRIPTION
In doc https://www.tensorflow.org/api_docs/python/tf/feature_column/numeric_column , shape is optional in `NUMERIC` column clause. This PR adds the default shape to be `(1, )`.