### PR TITLE
Call scripts/travis/upload_coveralls.sh in Travis CI VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ jobs:
     - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
     - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
       scripts/test/units.sh
-    - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
-      scripts/travis/upload_coveralls.sh
+    - scripts/travis/upload_coveralls.sh
   - env: SQLFLOW_TEST_DB=hive # run more parallel tests in the same stage:
     script:
     - set -e

--- a/scripts/travis/upload_coveralls.sh
+++ b/scripts/travis/upload_coveralls.sh
@@ -40,7 +40,7 @@ if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
         docker run --rm \
                -e COVERALLS_TOKEN="$COVERALLS_TOKEN" \
                -v "$TRAVIS_BUILD_DIR":/work -w /work \
-               sqlflow:ci \
+               sqlflow:dev \
                /usr/local/bin/goveralls \
                -coverprofile=coverage.out \
                -service=travis-ci \


### PR DESCRIPTION
Currently, the `.travis.yml` run `scripts/travis/upload_coveralls.sh` in a container.  Indeed, the script starts a container and call `goveralls` to upload the `coverage.out` file to coveralls.io.  This leads to `goveralls` running in a container in a container in the Travis VM.  This change removes a nested layer of container.

Also, the container that `upload_coveralls.sh` starts executes the `sqlflow:ci` image, which derives from `sqlflow:dev`.  Actually, `upload_coveralls.sh` can run `sqlflow:dev` other than `sqlflow:ci` because the former contains `goveralls` and is smaller than the latter.