### PR TITLE
Polish Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-
+dist: bionic
 
 # SQLFlow uses sqlflow.org/sqlflow as vanity import path. TravisCI
 # supports it via go_import_path.  Ref:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
   - "/release-*/"
   - "/^v\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"
 services:
-- docker
+  - docker
 
 
 # Note(tony): Update to newer version of Docker to allow
@@ -23,15 +23,16 @@ services:
 addons:
   apt:
     packages:
-    - docker-ce
-install:
+      - docker-ce
 
 # Note(tony): TravisCI's native `go get ${gobuild_args} ./...` failed with
 # `/usr/bin/ld: final link failed: Bad value`, the cause is the system linker
 # being not up to date: https://github.com/golang/go/issues/15038
 # So I decided to skip install, and go get inside SQLFlow devbox Docker image
 # Ref build: https://travis-ci.com/sql-machine-learning/sqlflow/builds/107870583
-- echo "skip install"
+install:
+  - echo "skip install"
+
 jobs:
   include:
   - stage: BuildAndTest

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.17.0 // indirect
 	sqlflow.org/goalisa v0.0.0-20200426073517-e08494be06fc

--- a/scripts/travis/install_kubectl.sh
+++ b/scripts/travis/install_kubectl.sh
@@ -16,7 +16,6 @@ set -e
 
 # Travis CI VMs and Vagrant provisioning allow sudo without password.
 K8S_RELEASE_SITE="https://storage.googleapis.com/kubernetes-release/release"
-
 axel --quiet --output kubectl \
      $K8S_RELEASE_SITE/v$K8S_VERSION/bin/linux/amd64/kubectl
 chmod a+x kubectl

--- a/scripts/travis/start_minikube.sh
+++ b/scripts/travis/start_minikube.sh
@@ -15,10 +15,6 @@
 set -e
 
 echo "Start minikube cluster ..."
-
 sudo minikube start \
      --vm-driver=none \
-     --kubernetes-version=v$K8S_VERSION \
-     --cpus 2 \
-     --memory 6144
-kubectl cluster-info
+     --kubernetes-version=v$K8S_VERSION


### PR DESCRIPTION
- Use Ubuntu Bionic other than Xeniel in Travis CI.  This is not necessary to keep CI running, but reasonable because our dev and ci Docker images all base on Bionic.  Another potential benefit is that we try to keep using recent versions of minikube and kubectl in Travic CI VMs.  It is good to keep up with recent Linux versions in the VM.

- Remove `--cpu` and `--memory` when starting minikube with `--driver=none`, because minikube prompts that `--cpu` and `--memory` options do not matter when `--driver=none`.