### PR TITLE
Add a MySQL server Docker image and use it in MySQL CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,20 @@ jobs:
   - env: SQLFLOW_TEST_DB=mysql
     script:
     - set -e
+    # Build MySQL server image including datasets.
+    - cd $TRAVIS_BUILD_DIR
+    - docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
+    # Build sqlflow:dev, SQLFlow, and sqlflow:ci
     - $TRAVIS_BUILD_DIR/scripts/travis/build.sh
-    - docker run --rm -v $TRAVIS_BUILD_DIR:/work -w /work sqlflow:ci
-      scripts/test/units.sh
+    # Run a MySQL server container.
+    - docker run --rm -d -p 13306:3306
+      -v $TRAVIS_BUILD_DIR:/work sqlflow:mysql
+    - docker run --rm
+      -v $TRAVIS_BUILD_DIR:/work -w /work
+      --net=host
+      -e SQLFLOW_TEST_DB=mysql
+      -e SQLFLOW_TEST_DB_MYSQL_ADDR="127.0.0.1:13306"
+      sqlflow:ci scripts/test/units.sh
     - scripts/travis/upload_coveralls.sh
   - env: SQLFLOW_TEST_DB=hive # run more parallel tests in the same stage:
     script:

--- a/cmd/sqlflow/main_test.go
+++ b/cmd/sqlflow/main_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 var space = regexp.MustCompile(`\s+`)
-var dbConnStr = "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"
+var dbConnStr = database.GetTestingMySQLURL()
 var testDBDriver = os.Getenv("SQLFLOW_TEST_DB")
 var serverAddr = "localhost:50051"
 

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -272,7 +272,7 @@ func TestEnd2EndMySQL(t *testing.T) {
 	if os.Getenv("SQLFLOW_TEST_DB") != "mysql" {
 		t.Skip("Skipping mysql tests")
 	}
-	dbConnStr = "mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0"
+	dbConnStr = database.GetTestingMySQLURL()
 	modelDir := ""
 
 	tmpDir, caCrt, caKey, err := generateTempCA()

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -686,6 +686,7 @@ func CaseShowDatabases(t *testing.T) {
 		"hive":                    "", // if current mysql is also used for hive
 		"default":                 "", // if fetching default hive databases
 		"sqlflow":                 "", // to save model zoo trained models
+		"imdb":                    "",
 	}
 	for i := 0; i < len(resp); i++ {
 		AssertContainsAny(a, expectedDBs, resp[i][0])

--- a/cmd/step/step_test.go
+++ b/cmd/step/step_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"sqlflow.org/sqlflow/pkg/database"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	"sqlflow.org/sqlflow/pkg/step"
 )
@@ -33,8 +34,7 @@ func TestStepStandardSQL(t *testing.T) {
 		t.Skip("skip no mysql test.")
 	}
 	a := assert.New(t)
-	dbConnStr := "mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0"
-	session := makeTestSession(dbConnStr)
+	session := makeTestSession(database.GetTestingMySQLURL())
 	sql := `SELECT * FROM iris.train limit 5;`
 	out, e := step.GetStdout(func() error {
 		return run(sql, session)
@@ -65,8 +65,7 @@ func TestStepSQLWithComment(t *testing.T) {
 		t.Skip("skip no mysql test.")
 	}
 	a := assert.New(t)
-	dbConnStr := "mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0"
-	session := makeTestSession(dbConnStr)
+	session := makeTestSession(database.GetTestingMySQLURL())
 	sql := `-- this is comment {a.b}
 	SELECT 1, 'a';\n\t
 `

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,0 +1,44 @@
+# This Dockerfile contains MySQL server and example datasets to be
+# populated into the server.  To COPY .sql dataset files outside of
+# this directory into the image, we need to run docker build from the
+# root directory of the SQLFlow source tree.
+#
+# To build this image:
+#
+#  cd $(git rev-parse --show-toplevel)
+#  docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
+#
+# To start a container executing this image:
+#
+#  docker run --rm -d -P --name mysql_server -v $PWD:/notify sqlflow:mysql
+#
+# To start a client container that can access this image:
+#
+#  docker run --rm --net=container:mysql_server -v $PWD:/notify sqlflow:ci
+#
+# The bind mount of $PWD on the host to /notify allows the
+# sqlflow:mysql container to create a file in the directory after
+# populating datasets, and the container running sqlflow:ci can use
+# inotifywait to wait for the creation of this file before it go on
+# running tests.
+FROM ubuntu:18.04
+
+COPY docker/mysql/install-mysql-server.bash /
+RUN /install-mysql-server.bash
+
+# Install sample datasets for CI and demo.
+COPY doc/datasets/popularize_churn.sql \
+     doc/datasets/popularize_iris.sql \
+     doc/datasets/popularize_boston.sql \
+     doc/datasets/popularize_creditcardfraud.sql \
+     doc/datasets/popularize_imdb.sql \
+     doc/datasets/create_model_db.sql \
+     /datasets/
+
+VOLUME /var/lib/mysql
+
+ARG MYSQL_PORT="3306"
+ENV MYSQL_PORT=MYSQL_PORT
+EXPOSE $MYSQL_PORT
+COPY docker/mysql/start.bash /
+CMD ["/start.bash"]

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -38,7 +38,7 @@ COPY doc/datasets/popularize_churn.sql \
 VOLUME /var/lib/mysql
 
 ARG MYSQL_PORT="3306"
-ENV MYSQL_PORT=MYSQL_PORT
+ENV MYSQL_PORT=$MYSQL_PORT
 EXPOSE $MYSQL_PORT
 COPY docker/mysql/start.bash /
 CMD ["/start.bash"]

--- a/docker/mysql/start.bash
+++ b/docker/mysql/start.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "Start mysqld ..."
+# Important to make mysqld bind to 0.0.0.0 -- all IPs.  I explained
+# the reason in https://stackoverflow.com/a/61887788/724872.
+MYSQL_HOST=${MYSQL_HOST:-0.0.0.0}
+sed -i "s/.*bind-address.*/bind-address = $MYSQL_HOST/" \
+    /etc/mysql/mysql.conf.d/mysqld.cnf
+service mysql start
+
+
+echo "Sleep until MySQL server is ready ..."
+# shellcheck disable=SC2153
+until mysql -u root -proot \
+            --host "$MYSQL_HOST" \
+            --port "$MYSQL_PORT" \
+            -e ";" ; do
+    sleep 1
+    read -r -p "Can't connect, retrying..."
+done
+
+
+# Grant all privileges to all the remote hosts so that the sqlflow
+# server can be scaled to more than one replicas.
+#
+# NOTE: should notice this authorization on the production
+# environment, it's not safe.
+mysql -uroot -proot \
+      -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'' IDENTIFIED BY 'root' WITH GRANT OPTION;"
+
+
+# FIXME(typhoonzero): should let docker-entrypoint.sh do this work
+for f in /datasets/*; do
+    echo "Populate datasets $f ..."
+    mysql -uroot -proot \
+          --host "$SQLFLOW_MYSQL_HOST" --port "$SQLFLOW_MYSQL_PORT" \
+          < "$f"
+done
+
+
+# If we run the contaienr with -v host_dir:/work, then the following
+# command would create host_dir/mysql-inited file.  A bash script (on
+# the host or a container) would be able to wait the creation of this
+# file using the trick https://unix.stackexchange.com/a/185370/325629.
+touch /work/mysql-inited
+
+sleep infinity

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.17.0 // indirect
 	sqlflow.org/goalisa v0.0.0-20200426073517-e08494be06fc

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -23,13 +23,13 @@ import (
 
 func TestDatabaseParseURL(t *testing.T) {
 	a := assert.New(t)
-	driver, dataSource, e := ParseURL(testingMySQLURL())
+	driver, dataSource, e := ParseURL(GetTestingMySQLURL())
 	a.EqualValues(driver, "mysql")
 	user := getEnv("SQLFLOW_TEST_DB_MYSQL_USER", "root")
 	pass := getEnv("SQLFLOW_TEST_DB_MYSQL_PASSWD", "root")
 	net := getEnv("SQLFLOW_TEST_DB_MYSQL_NET", "tcp")
 	addr := getEnv("SQLFLOW_TEST_DB_MYSQL_ADDR", "127.0.0.1:3306")
-	a.EqualValues(dataSource, fmt.Sprintf("%s:%s@%s(%s)?maxAllowedPacket=0", user, pass, net, addr)
+	a.EqualValues(dataSource, fmt.Sprintf("%s:%s@%s(%s)/?maxAllowedPacket=0", user, pass, net, addr))
 	a.NoError(e)
 }
 

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -15,6 +15,7 @@ package database
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,11 @@ func TestDatabaseParseURL(t *testing.T) {
 	a := assert.New(t)
 	driver, dataSource, e := ParseURL(testingMySQLURL())
 	a.EqualValues(driver, "mysql")
-	a.EqualValues(dataSource, "root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0")
+	user := getEnv("SQLFLOW_TEST_DB_MYSQL_USER", "root")
+	pass := getEnv("SQLFLOW_TEST_DB_MYSQL_PASSWD", "root")
+	net := getEnv("SQLFLOW_TEST_DB_MYSQL_NET", "tcp")
+	addr := getEnv("SQLFLOW_TEST_DB_MYSQL_ADDR", "127.0.0.1:3306")
+	a.EqualValues(dataSource, fmt.Sprintf("%s:%s@%s(%s)?maxAllowedPacket=0", user, pass, net, addr)
 	a.NoError(e)
 }
 

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -25,11 +25,8 @@ func TestDatabaseParseURL(t *testing.T) {
 	a := assert.New(t)
 	driver, dataSource, e := ParseURL(GetTestingMySQLURL())
 	a.EqualValues(driver, "mysql")
-	user := getEnv("SQLFLOW_TEST_DB_MYSQL_USER", "root")
-	pass := getEnv("SQLFLOW_TEST_DB_MYSQL_PASSWD", "root")
-	net := getEnv("SQLFLOW_TEST_DB_MYSQL_NET", "tcp")
-	addr := getEnv("SQLFLOW_TEST_DB_MYSQL_ADDR", "127.0.0.1:3306")
-	a.EqualValues(dataSource, fmt.Sprintf("%s:%s@%s(%s)/?maxAllowedPacket=0", user, pass, net, addr))
+	a.EqualValues(dataSource, fmt.Sprintf("%s:%s@%s(%s)/?maxAllowedPacket=0",
+		GetTestingMySQLConfig().User, GetTestingMySQLConfig().Passwd, GetTestingMySQLConfig().Net, GetTestingMySQLConfig().Addr))
 	a.NoError(e)
 }
 

--- a/pkg/database/testing.go
+++ b/pkg/database/testing.go
@@ -83,12 +83,13 @@ func GetTestingMySQLConfig() *mysql.Config {
 	}
 }
 
-func testingMySQLURL() string {
+// GetTestingMySQLURL returns MySQL connection URL
+func GetTestingMySQLURL() string {
 	return fmt.Sprintf("mysql://%s", GetTestingMySQLConfig().FormatDSN())
 }
 
 func createTestingMySQLDB() *DB {
-	db, e := OpenAndConnectDB(testingMySQLURL())
+	db, e := OpenAndConnectDB(GetTestingMySQLURL())
 	assertNoErr(e)
 	_, e = db.Exec("CREATE DATABASE IF NOT EXISTS sqlflow_models;")
 	assertNoErr(e)

--- a/pkg/database/testing_test.go
+++ b/pkg/database/testing_test.go
@@ -25,7 +25,7 @@ func TestDatabaseGetTestingDBSingleton(t *testing.T) {
 
 	switch dbms := getEnv("SQLFLOW_TEST_DB", "mysql"); dbms {
 	case "mysql":
-		a.Equal(testingMySQLURL(), db.URL())
+		a.Equal(GetTestingMySQLURL(), db.URL())
 	case "hive":
 		a.Equal(testingHiveURL(), db.URL())
 	case "maxcompute":
@@ -37,15 +37,13 @@ func TestDatabaseGetTestingDBSingleton(t *testing.T) {
 
 func TestDatabaseTestingMySQLURL(t *testing.T) {
 	a := assert.New(t)
-	a.Equal("mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0", testingMySQLURL())
 	if db := GetTestingDBSingleton(); db.DriverName == "mysql" {
-		a.Equal(testingMySQLURL(), db.URL())
+		a.Equal(GetTestingMySQLURL(), db.URL())
 	}
 }
 
 func TestDatabaseTestingHiveURL(t *testing.T) {
 	a := assert.New(t)
-	a.Equal("hive://root:root@localhost:10000/churn", testingHiveURL())
 	if db := GetTestingDBSingleton(); db.DriverName == "hive" {
 		a.Equal(testingHiveURL(), db.URL())
 	}
@@ -53,7 +51,6 @@ func TestDatabaseTestingHiveURL(t *testing.T) {
 
 func TestDatabaseTestingMaxComputeURL(t *testing.T) {
 	a := assert.New(t)
-	a.Equal("maxcompute://test:test@service-maxcompute.com/api?curr_project=test&scheme=http", testingMaxComputeURL())
 	if db := GetTestingDBSingleton(); db.DriverName == "maxcompute" {
 		a.Equal(testingMaxComputeURL(), db.URL())
 	}

--- a/pkg/modelzooserver/modelzooserver_test.go
+++ b/pkg/modelzooserver/modelzooserver_test.go
@@ -34,7 +34,7 @@ func startServer() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	grpcServer := grpc.NewServer()
-	mysqlConn, err := database.OpenAndConnectDB("mysql://root:root@tcp(localhost:3306)/?maxAllowedPacket=0")
+	mysqlConn, err := database.OpenAndConnectDB(database.GetTestingMySQLURL())
 	if err != nil {
 		log.Fatalf("failed to connect to mysql: %v", err)
 	}

--- a/pkg/server/sqlflowserver_test.go
+++ b/pkg/server/sqlflowserver_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 
+	"sqlflow.org/sqlflow/pkg/database"
 	"sqlflow.org/sqlflow/pkg/pipe"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 )
@@ -41,10 +42,10 @@ const (
 	testExtendedSQL            = "SELECT * FROM some_table TO TRAIN SomeModel;"
 	testExtendedSQLNoSemicolon = "SELECT * FROM some_table TO TRAIN SomeModel"
 	testExtendedSQLWithSpace   = "SELECT * FROM some_table TO TRAIN SomeModel; \n\t"
-	mockDBConnStr              = "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"
 )
 
 var testServerAddress string
+var mockDBConnStr = database.GetTestingMySQLURL()
 
 func mockRun(sql string, modelDir string, session *pb.Session) *pipe.Reader {
 	rd, wr := pipe.Pipe()

--- a/pkg/sql/codegen/tensorflow/codegen_test.go
+++ b/pkg/sql/codegen/tensorflow/codegen_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sqlflow.org/sqlflow/pkg/database"
 	"sqlflow.org/sqlflow/pkg/ir"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 )
 
 func mockSession() *pb.Session {
-	return &pb.Session{DbConnStr: "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"}
+	return &pb.Session{DbConnStr: database.GetTestingMySQLURL()}
 }
 func TestTrainCodegen(t *testing.T) {
 	a := assert.New(t)

--- a/pkg/sql/codegen/xgboost/codegen_test.go
+++ b/pkg/sql/codegen/xgboost/codegen_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sqlflow.org/sqlflow/pkg/database"
 	"sqlflow.org/sqlflow/pkg/ir"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 )
@@ -37,7 +38,7 @@ func TestAttributes(t *testing.T) {
 }
 
 func mockSession() *pb.Session {
-	return &pb.Session{DbConnStr: "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"}
+	return &pb.Session{DbConnStr: database.GetTestingMySQLURL()}
 }
 
 func TestTrainAndPredict(t *testing.T) {

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -312,7 +312,7 @@ func TestGenerateExplainStmt(t *testing.T) {
 		t.Skip(fmt.Sprintf("%s: skip test", getEnv("SQLFLOW_TEST_DB", "mysql")))
 	}
 	a := assert.New(t)
-	connStr := fmt.Sprintf("mysql://%s", database.GetTestingMySQLConfig().FormatDSN())
+	connStr := database.GetTestingMySQLURL()
 
 	cwd, e := ioutil.TempDir("/tmp", "sqlflow_models")
 	a.Nil(e)

--- a/pkg/sql/ir_generator_test.go
+++ b/pkg/sql/ir_generator_test.go
@@ -312,7 +312,7 @@ func TestGenerateExplainStmt(t *testing.T) {
 		t.Skip(fmt.Sprintf("%s: skip test", getEnv("SQLFLOW_TEST_DB", "mysql")))
 	}
 	a := assert.New(t)
-	connStr := "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"
+	connStr := fmt.Sprintf("mysql://%s", database.GetTestingMySQLConfig().FormatDSN())
 
 	cwd, e := ioutil.TempDir("/tmp", "sqlflow_models")
 	a.Nil(e)

--- a/pkg/step/feature/derivation_test.go
+++ b/pkg/step/feature/derivation_test.go
@@ -14,6 +14,7 @@
 package feature
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -164,7 +165,7 @@ LABEL class INTO model_table;`,
 
 func TestFeatureDerivation(t *testing.T) {
 	a := assert.New(t)
-	dataSource := "mysql://root:root@tcp/?maxAllowedPacket=0"
+	dataSource := fmt.Sprintf("mysql://%s", database.GetTestingMySQLConfig().FormatDSN())
 	// Prepare feature derivation test table in MySQL.
 	db, err := database.OpenAndConnectDB(dataSource)
 	if err != nil {

--- a/pkg/step/feature/derivation_test.go
+++ b/pkg/step/feature/derivation_test.go
@@ -14,7 +14,6 @@
 package feature
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -165,9 +164,8 @@ LABEL class INTO model_table;`,
 
 func TestFeatureDerivation(t *testing.T) {
 	a := assert.New(t)
-	dataSource := fmt.Sprintf("mysql://%s", database.GetTestingMySQLConfig().FormatDSN())
 	// Prepare feature derivation test table in MySQL.
-	db, err := database.OpenAndConnectDB(dataSource)
+	db, err := database.OpenAndConnectDB(database.GetTestingMySQLURL())
 	if err != nil {
 		a.Fail("error connect to mysql: %v", err)
 	}
@@ -274,9 +272,8 @@ func TestFeatureDerivationNoColumnClause(t *testing.T) {
 		t.Skip("skip TestFeatureDerivationNoColumnClause for tests not using mysql")
 	}
 	a := assert.New(t)
-	dataSource := "mysql://root:root@tcp/?maxAllowedPacket=0"
 	// Prepare feature derivation test table in MySQL.
-	db, err := database.OpenAndConnectDB(dataSource)
+	db, err := database.OpenAndConnectDB(database.GetTestingMySQLURL())
 	if err != nil {
 		a.Fail("error connect to mysql: %v", err)
 	}

--- a/pkg/step/step_test.go
+++ b/pkg/step/step_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sqlflow.org/sqlflow/pkg/database"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	"sqlflow.org/sqlflow/pkg/tablewriter"
 )
@@ -34,8 +35,7 @@ func TestStepTrainSQL(t *testing.T) {
 		t.Skip("skip no mysql test.")
 	}
 	a := assert.New(t)
-	dbConnStr := "mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0"
-	session := makeTestSession(dbConnStr)
+	session := makeTestSession(database.GetTestingMySQLURL())
 
 	sql := `SELECT * FROM iris.train WHERE class!=2
 	TO TRAIN DNNClassifier

--- a/pkg/workflow/couler/codegen_test.go
+++ b/pkg/workflow/couler/codegen_test.go
@@ -14,7 +14,6 @@
 package couler
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -153,10 +152,8 @@ func TestKatibCodegen(t *testing.T) {
 	a := assert.New(t)
 	os.Setenv("SQLFLOW_submitter", "katib")
 
-	cfg := database.GetTestingMySQLConfig()
-
 	standardSQL := ir.NormalStmt("SELECT * FROM iris.train limit 10;")
-	sqlIR := MockKatibTrainStmt(fmt.Sprintf("mysql://%s", cfg.FormatDSN()))
+	sqlIR := MockKatibTrainStmt(database.GetTestingMySQLURL())
 
 	program := []ir.SQLFlowStmt{&standardSQL, &sqlIR}
 

--- a/python/sqlflow_submitter/db_test.py
+++ b/python/sqlflow_submitter/db_test.py
@@ -87,7 +87,7 @@ class TestDB(TestCase):
                            user=user,
                            password=password,
                            host=host,
-                           port=int(port))
+                           port=port)
             self._do_test(driver, conn)
 
             conn = connect_with_data_source(testing_mysql_db_url())
@@ -193,14 +193,13 @@ class TestGenerator(TestCase):
         driver = os.environ.get('SQLFLOW_TEST_DB')
         if driver == "mysql":
             database = "iris"
-            user = os.environ.get('SQLFLOW_TEST_DB_MYSQL_USER') or "root"
-            password = os.environ.get('SQLFLOW_TEST_DB_MYSQL_PASSWD') or "root"
+            user, password, host, port, database = testing_mysql_cfg()
             conn = connect(driver,
                            database,
                            user=user,
                            password=password,
-                           host="127.0.0.1",
-                           port="3306")
+                           host=host,
+                           port=int(port))
             # prepare test data
             execute(driver, conn, self.drop_statement)
             execute(driver, conn, self.create_statement)
@@ -239,15 +238,13 @@ class TestGenerator(TestCase):
     def test_generate_fetch_size(self):
         driver = os.environ.get('SQLFLOW_TEST_DB')
         if driver == "mysql":
-            database = "iris"
-            user = os.environ.get('SQLFLOW_TEST_DB_MYSQL_USER') or "root"
-            password = os.environ.get('SQLFLOW_TEST_DB_MYSQL_PASSWD') or "root"
+            user, password, host, port, database = testing_mysql_cfg()
             conn = connect(driver,
                            database,
                            user=user,
                            password=password,
-                           host="127.0.0.1",
-                           port="3306")
+                           host=host,
+                           port=port)
             column_name_to_type = {
                 "sepal_length": {
                     "feature_name": "sepal_length",

--- a/python/sqlflow_submitter/db_test.py
+++ b/python/sqlflow_submitter/db_test.py
@@ -68,8 +68,9 @@ class TestDB(TestCase):
         if driver == "mysql":
             user = os.environ.get('SQLFLOW_TEST_DB_MYSQL_USER') or "root"
             password = os.environ.get('SQLFLOW_TEST_DB_MYSQL_PASSWD') or "root"
-            host = "127.0.0.1"
-            port = "3306"
+            addr = os.environ.get(
+                'SQLFLOW_TEST_DB_MYSQL_ADDR') or "127.0.0.1:3306"
+            host, port = addr.split(",")
             database = "iris"
             conn = connect(driver,
                            database,
@@ -80,8 +81,8 @@ class TestDB(TestCase):
             self._do_test(driver, conn)
 
             conn = connect_with_data_source(
-                "mysql://root:root@tcp(127.0.0.1:3306)/iris?maxAllowedPacket=0"
-            )
+                "mysql://%s:%s@tcp(%s)/iris?maxAllowedPacket=0" % user,
+                password, addr)
             self._do_test(driver, conn)
 
     def test_hive(self):

--- a/python/sqlflow_submitter/tensorflow/estimator_example.py
+++ b/python/sqlflow_submitter/tensorflow/estimator_example.py
@@ -16,10 +16,11 @@ import shutil
 
 import sqlflow_submitter
 import tensorflow as tf
+from sqlflow_submitter.db_test import testing_mysql_db_url
 from sqlflow_submitter.tensorflow.predict import pred
 from sqlflow_submitter.tensorflow.train import train
 
-datasource = "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"
+datasource = testing_mysql_db_url()
 select = "SELECT * FROM iris.train;"
 validate_select = "SELECT * FROM iris.test;"
 select_binary = "SELECT * FROM iris.train WHERE class!=2;"

--- a/python/sqlflow_submitter/tensorflow/train_predict_test.py
+++ b/python/sqlflow_submitter/tensorflow/train_predict_test.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 import unittest
 from unittest import TestCase
@@ -26,7 +27,7 @@ class TestEstimatorModels(TestCase):
                 "/usr/local/bin/python",
                 "python/sqlflow_submitter/tensorflow/estimator_example.py"
             ],
-                                 env={"PYTHONPATH": "python"},
+                                 env=os.environ.copy(),
                                  check=True)
             self.assertEqual(ret.returncode, 0)
         except Exception as e:
@@ -39,7 +40,7 @@ class TestEstimatorModels(TestCase):
                 "/usr/local/bin/python",
                 "python/sqlflow_submitter/tensorflow/explain_example.py"
             ],
-                                 env={"PYTHONPATH": "python"},
+                                 env=os.environ.copy(),
                                  check=True)
             self.assertEqual(ret.returncode, 0)
         except Exception as e:
@@ -52,7 +53,7 @@ class TestEstimatorModels(TestCase):
                 "/usr/local/bin/python",
                 "python/sqlflow_submitter/tensorflow/keras_example.py"
             ],
-                                 env={"PYTHONPATH": "python"},
+                                 env=os.environ.copy(),
                                  check=True)
             self.assertEqual(ret.returncode, 0)
         except Exception as e:

--- a/python/sqlflow_submitter/xgboost/explain_test.py
+++ b/python/sqlflow_submitter/xgboost/explain_test.py
@@ -16,11 +16,13 @@ import unittest
 from unittest import TestCase
 
 import numpy as np
+from sqlflow_submitter.db_test import testing_mysql_db_url
 from sqlflow_submitter.xgboost.explain import explain as xgb_explain
 from sqlflow_submitter.xgboost.explain import xgb_shap_dataset, xgb_shap_values
 from sqlflow_submitter.xgboost.train import train as xgb_train
 
-datasource = "mysql://root:root@tcp(127.0.0.1:3306)/?maxAllowedPacket=0"
+datasource = testing_mysql_db_url()
+
 select = "SELECT * FROM boston.train;"
 
 feature_field_meta = [{

--- a/python/test_sql_data.py
+++ b/python/test_sql_data.py
@@ -14,12 +14,14 @@
 import unittest
 
 import sql_data
+from sqlflow_submitter.db_test import testing_mysql_cfg
 
 
 class TestSQLData(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestSQLData, self).__init__(*args, **kwargs)
-        self.db = sql_data.connect('root', 'root', 'localhost', 3306)
+        user, password, host, port, database = testing_mysql_cfg()
+        self.db = sql_data.connect(user, password, host, int(port))
         self.assertIsNotNone(self.db)
 
     def test_load(self):


### PR DESCRIPTION
This PR is a subset of https://github.com/sql-machine-learning/sqlflow/pull/2306, which is too large to verify.

The idea is to separate MySQL server out from the `sqlflow:ci` Docker image. The decomposition process helps us understand our system better and collect ideas on how to reassemble it into a better architecture.