### PR TITLE
Enable log to /dev/null in CI

### DIFF
--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -7,6 +7,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 

--- a/cmd/sqlflowserver/main_test.go
+++ b/cmd/sqlflowserver/main_test.go
@@ -7,7 +7,6 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -37,6 +36,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"sqlflow.org/sqlflow/pkg/database"
+	sqlflowlog "sqlflow.org/sqlflow/pkg/log"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	"sqlflow.org/sqlflow/pkg/server"
 	"sqlflow.org/sqlflow/pkg/sql/testdata"
@@ -56,6 +56,10 @@ var testDatasource = os.Getenv("SQLFLOW_TEST_DATASOURCE")
 var caseInto = "sqlflow_models.my_dnn_model"
 
 const unitTestPort = 50051
+
+func init() {
+	sqlflowlog.InitLogger("/dev/null", sqlflowlog.TextFormatter)
+}
 
 func connectAndRunSQLShouldError(sql string) {
 	conn, err := createRPCConn()

--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086,SC2231,SC2002
 # Copyright 2020 The SQLFlow Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# FIXME(weiguoz): bring the shellcheck back: SC2086,SC2231,SC2002
 
 # Exit for any error.
 set -e
@@ -44,7 +47,7 @@ echo "Build parser gRPC servers in Java ..."
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
 cd $SQLFLOWPATH/java/parse-interface
-mvn clean install -B # Write to local Maven repository.
+mvn -B -q clean install # Write to local Maven repository.
 
 cd $SQLFLOWPATH/java/parser-hive
 mvn -B -q clean compile assembly:single

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -16,6 +16,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"sort"
 	"strings"
 
@@ -45,14 +46,18 @@ func InitLogger(filename string, f Formatter) {
 
 // setOutput sets log output to filename globally.
 // filename="/var/log/sqlflow.log": write the log to file
-// filename="": write the file to stdout
+// filename="": write the file to stdout or stderr
+// filename="/dev/null": ignore log message
 func setOutput(filename string) {
-	if len(strings.Trim(filename, " ")) > 0 {
+	filename = strings.Trim(filename, " ")
+	if filename == "/dev/null" {
+		logrus.SetOutput(ioutil.Discard)
+	} else if len(filename) > 0 {
 		logrus.SetOutput(&lumberjack.Logger{
 			Filename:   filename,
 			MaxSize:    32, // megabytes
 			MaxBackups: 64,
-			MaxAge:     10, // days
+			MaxAge:     30, // days
 			Compress:   true,
 		})
 	}

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -57,7 +57,7 @@ func setOutput(filename string) {
 			Filename:   filename,
 			MaxSize:    32, // megabytes
 			MaxBackups: 64,
-			MaxAge:     30, // days
+			MaxAge:     15, // days
 			Compress:   true,
 		})
 	}

--- a/pkg/workflow/argo/fetch_test.go
+++ b/pkg/workflow/argo/fetch_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
+	sqlflowlog "sqlflow.org/sqlflow/pkg/log"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	wfrsp "sqlflow.org/sqlflow/pkg/workflow/response"
 )
@@ -115,6 +116,10 @@ spec:
 
 var stepImage = "sqlflow/sqlflow"
 
+func init() {
+	sqlflowlog.InitLogger("/dev/null", sqlflowlog.TextFormatter)
+}
+
 func createAndWriteTempFile(content string) (string, error) {
 	tmpFile, err := ioutil.TempFile("/tmp", "sqlflow-")
 	if err != nil {
@@ -155,6 +160,7 @@ func parseFetchResponse(responses *pb.FetchResponse_Responses) ([]string, [][]*a
 	}
 	return columns, rows, messages, nil
 }
+
 func TestFetch(t *testing.T) {
 	a := assert.New(t)
 	if os.Getenv("SQLFLOW_TEST") != "workflow" {


### PR DESCRIPTION
As discussed in the [comment](https://github.com/sql-machine-learning/sqlflow/pull/2317#discussion_r428434587), @Yancey1989 suggested logging to `/dev/null` in CI.