### PR TITLE
Fix create predict result table error

### DIFF
--- a/pkg/sql/executor_ir.go
+++ b/pkg/sql/executor_ir.go
@@ -245,7 +245,11 @@ func createPredictionTableFromIR(predStmt *ir.PredictStmt, db *database.DB, sess
 				continue
 			}
 		}
-
+		// result column have the same name, do not add as feature column
+		if fldName == resultColumnName {
+			resultColumnType = stype
+			continue
+		}
 		fmt.Fprintf(&b, "%s %s, ", fldName, stype)
 	}
 


### PR DESCRIPTION
Fix errors on PAI prediction:

```
failed executing create table predict_result (sepal_length double, sepal_width double, petal_length double, petal_width double, class bigint, class INT);: "ODPS-0130071:[1,144] Semantic analysis exception - column repeated in creation: class\n"
```