### PR TITLE
Correct Argo UI port

### DIFF
--- a/doc/run/kubernetes.md
+++ b/doc/run/kubernetes.md
@@ -20,7 +20,7 @@ Before starting any sections, please [Setup Minikube and Argo](#setup-minikube-a
 1. Access the Argo UI
 
     ``` bash
-    kubectl -n argo port-forward deployment/argo-ui 2746:2746
+    kubectl -n argo port-forward deployment/argo-server 2746:2746
     ```
 
     Then visit: `http://127.0.0.1:2746`

--- a/doc/run/kubernetes.md
+++ b/doc/run/kubernetes.md
@@ -20,10 +20,10 @@ Before starting any sections, please [Setup Minikube and Argo](#setup-minikube-a
 1. Access the Argo UI
 
     ``` bash
-    kubectl -n argo port-forward deployment/argo-ui 8001:8001
+    kubectl -n argo port-forward deployment/argo-ui 2746:2746
     ```
 
-    Then visit: `http://127.0.0.1:8001`
+    Then visit: `http://127.0.0.1:2746`
 
 ## Install SQLFlow Playground with single-user Mode
 


### PR DESCRIPTION
As we use https://raw.githubusercontent.com/argoproj/argo/v2.7.7/manifests/install.yaml to deploy Argo, and this file uses port 2746 other than 8001.