### PR TITLE
Temporarily disable CI deployment of the SQLFlow client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,19 +116,23 @@ jobs:
       -v $TRAVIS_BUILD_DIR:/work -w /work
       sqlflow:ci scripts/test/workflow.sh
   - stage: Deploy
-    env: DESC="Deploy macOS client"
-    os: osx
-    script:
-    - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
-  - env: DESC="Deploy Linux client"
-    os: linux
-    dist: bionic
-    script:
-    - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
-  - env: DESC="Deploy Windows client"
-    os: windows
-    script:
-    - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
-  - env: DESC="Deploy server Docker image"
+    env: DESC="Deploy server Docker image"
     script:
     - $TRAVIS_BUILD_DIR/scripts/travis/deploy_docker.sh
+    # We temporarily disable the deployment of client to Qiniu because the
+    # qshell upload feature is unstable and often fails the CI, c.f.,
+    # https://github.com/sql-machine-learning/sqlflow/issues/2305
+    #
+    # - env: DESC="Deploy macOS client"
+    #   os: osx
+    #   script:
+    #   - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
+    # - env: DESC="Deploy Linux client"
+    #   os: linux
+    #   dist: bionic
+    #   script:
+    #   - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh
+    # - env: DESC="Deploy Windows client"
+    #   os: windows
+    #   script:
+    #   - $TRAVIS_BUILD_DIR/scripts/travis/deploy_client.sh


### PR DESCRIPTION
This is related to but doesn't fix https://github.com/sql-machine-learning/sqlflow/issues/2305