### PR TITLE
Remove exported environment variable IPYTHON_STARTUP

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -4,8 +4,6 @@ FROM sqlflow:dev
 
 # Install dependencies.
 COPY docker/ci/js /ci/js
-# Required by install-jupyter.bash
-ENV IPYTHON_STARTUP /root/.ipython/profile_default/startup/
 
 RUN apt-get -qq update
 

--- a/docker/ci/install-jupyter.bash
+++ b/docker/ci/install-jupyter.bash
@@ -23,6 +23,7 @@ pip install --quiet \
 
 # Load SQLFlow's Jupyter magic command
 # automatically. c.f. https://stackoverflow.com/a/32683001.
+IPYTHON_STARTUP="/root/.ipython/profile_default/startup/"
 mkdir -p "$IPYTHON_STARTUP"
 mkdir -p /workspace
 { echo 'get_ipython().magic(u"%reload_ext sqlflow.magic")';


### PR DESCRIPTION
It seems that this exported environment variable is not used by any program.