### PR TITLE
Remove unused pkg dependence for parser-hive

### DIFF
--- a/java/parser-hive/pom.xml
+++ b/java/parser-hive/pom.xml
@@ -51,6 +51,64 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
             <version>3.1.1</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-llap-tez</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-shims</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-vector-code-gen</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-upgrade-acid</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-registry</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libfb303</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.calcite</groupId>
+                <artifactId>calcite-druid</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.calcite</groupId>
+                <artifactId>calcite-core</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.ivy</groupId>
+                <artifactId>ivy</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
To accelerate the build of java parser building, we remove some dependencies from parser-hive.