### PR TITLE
Move feature column codegen to common path for XGBoost models support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.17.0 // indirect
 	sqlflow.org/goalisa v0.0.0-20200426073517-e08494be06fc

--- a/pkg/sql/codegen/codegen_feature_column.go
+++ b/pkg/sql/codegen/codegen_feature_column.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package feature
+package codegen
 
 import (
 	"fmt"

--- a/pkg/sql/codegen/feature/codegen_feature_column.go
+++ b/pkg/sql/codegen/feature/codegen_feature_column.go
@@ -118,7 +118,7 @@ func GenerateFeatureColumnCode(fc ir.FeatureColumn, module string) (string, erro
 			module, sourceCode, c.Dimension, c.Combiner), nil
 	case *ir.IndicatorColumn:
 		if isXGBoostModule(module) {
-			return "", fmt.Errorf("INDICATOR is only supported in XGBoost models")
+			return "", fmt.Errorf("INDICATOR is not supported in XGBoost models")
 		}
 
 		sourceCode, err := GenerateFeatureColumnCode(c.CategoryColumn, module)

--- a/pkg/sql/codegen/feature/codegen_feature_column.go
+++ b/pkg/sql/codegen/feature/codegen_feature_column.go
@@ -76,7 +76,7 @@ func GenerateFeatureColumnCode(fc ir.FeatureColumn, module string) (string, erro
 		return fmt.Sprintf("%s.feature_column.categorical_column_with_identity(key=\"%s\", num_buckets=%d)",
 			module, c.FieldDesc.Name, c.BucketSize), nil
 	case *ir.SeqCategoryIDColumn:
-		if !isXGBoostModule(module) {
+		if isXGBoostModule(module) {
 			return "", fmt.Errorf("SEQ_CATEGORY_ID is not supported in XGBoost models")
 		}
 		return fmt.Sprintf("%s.feature_column.sequence_categorical_column_with_identity(key=\"%s\", num_buckets=%d)",
@@ -106,7 +106,7 @@ func GenerateFeatureColumnCode(fc ir.FeatureColumn, module string) (string, erro
 			"%s.feature_column.crossed_column([%s], hash_bucket_size=%d)",
 			module, strings.Join(keysGenerated, ","), c.HashBucketSize), nil
 	case *ir.EmbeddingColumn:
-		if !isXGBoostModule(module) {
+		if isXGBoostModule(module) {
 			return "", fmt.Errorf("EMBEDDING is not supported in XGBoost models")
 		}
 
@@ -117,7 +117,7 @@ func GenerateFeatureColumnCode(fc ir.FeatureColumn, module string) (string, erro
 		return fmt.Sprintf("%s.feature_column.embedding_column(%s, dimension=%d, combiner=\"%s\")",
 			module, sourceCode, c.Dimension, c.Combiner), nil
 	case *ir.IndicatorColumn:
-		if !isXGBoostModule(module) {
+		if isXGBoostModule(module) {
 			return "", fmt.Errorf("INDICATOR is only supported in XGBoost models")
 		}
 

--- a/pkg/sql/codegen/feature/codegen_feature_column.go
+++ b/pkg/sql/codegen/feature/codegen_feature_column.go
@@ -1,0 +1,133 @@
+// Copyright 2020 The SQLFlow Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import (
+	"fmt"
+	"sqlflow.org/sqlflow/pkg/ir"
+	"strings"
+)
+
+func toModuleDataType(dtype int, module string) (string, error) {
+	switch dtype {
+	case ir.Int:
+		return fmt.Sprintf("%s.dtypes.int64", module), nil
+	case ir.Float:
+		return fmt.Sprintf("%s.dtypes.float32", module), nil
+	case ir.String:
+		return fmt.Sprintf("%s.dtypes.string", module), nil
+	default:
+		return "", fmt.Errorf("unsupport dtype: %d", dtype)
+	}
+}
+
+// TODO(sneaxiy): XGBoost does not support some feature columns, such as EMBEDDING.
+// For better error message, we should find a better way to distinguish whether the
+// module is TensorFlow or XGBoost.
+func isXGBoostModule(module string) bool {
+	return strings.HasPrefix(module, "xgboost")
+}
+
+// IntArrayToJSONString converts int array to json string
+func IntArrayToJSONString(intArray []int) string {
+	return strings.Join(strings.Split(fmt.Sprint(intArray), " "), ",")
+}
+
+// GenerateFeatureColumnCode generates feature column code for both TensorFlow and XGBoost models
+func GenerateFeatureColumnCode(fc ir.FeatureColumn, module string) (string, error) {
+	switch c := fc.(type) {
+	case *ir.NumericColumn:
+		return fmt.Sprintf("%s.feature_column.numeric_column(\"%s\", shape=%s)",
+			module,
+			c.FieldDesc.Name,
+			IntArrayToJSONString(c.FieldDesc.Shape)), nil
+	case *ir.BucketColumn:
+		sourceCode, err := GenerateFeatureColumnCode(c.SourceColumn, module)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf(
+			"%s.feature_column.bucketized_column(%s, boundaries=%s)",
+			module,
+			sourceCode,
+			IntArrayToJSONString(c.Boundaries)), nil
+	case *ir.CategoryIDColumn:
+		fm := c.GetFieldDesc()[0]
+		if len(fm.Vocabulary) > 0 {
+			vocabList := []string{}
+			for k := range fm.Vocabulary {
+				vocabList = append(vocabList, fmt.Sprintf("\"%s\"", k))
+			}
+			vocabCode := strings.Join(vocabList, ",")
+			return fmt.Sprintf("%s.feature_column.categorical_column_with_vocabulary_list(key=\"%s\", vocabulary_list=[%s])",
+				module, c.FieldDesc.Name, vocabCode), nil
+		}
+		return fmt.Sprintf("%s.feature_column.categorical_column_with_identity(key=\"%s\", num_buckets=%d)",
+			module, c.FieldDesc.Name, c.BucketSize), nil
+	case *ir.SeqCategoryIDColumn:
+		if !isXGBoostModule(module) {
+			return "", fmt.Errorf("SEQ_CATEGORY_ID is not supported in XGBoost models")
+		}
+		return fmt.Sprintf("%s.feature_column.sequence_categorical_column_with_identity(key=\"%s\", num_buckets=%d)",
+			module, c.FieldDesc.Name, c.BucketSize), nil
+	case *ir.CategoryHashColumn:
+		// FIXME(typhoonzero): do we need to support dtype other than int64?
+		dtype, err := toModuleDataType(c.FieldDesc.DType, module)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s.feature_column.categorical_column_with_hash_bucket(key=\"%s\", hash_bucket_size=%d, dtype=%s)",
+			module, c.FieldDesc.Name, c.BucketSize, dtype), nil
+	case *ir.CrossColumn:
+		var keysGenerated = make([]string, len(c.Keys))
+		for idx, key := range c.Keys {
+			if c, ok := key.(ir.FeatureColumn); ok {
+				code, err := GenerateFeatureColumnCode(c, module)
+				if err != nil {
+					return "", err
+				}
+				keysGenerated[idx] = code
+			} else {
+				return "", fmt.Errorf("field in cross column is not a FeatureColumn type: %v", key)
+			}
+		}
+		return fmt.Sprintf(
+			"%s.feature_column.crossed_column([%s], hash_bucket_size=%d)",
+			module, strings.Join(keysGenerated, ","), c.HashBucketSize), nil
+	case *ir.EmbeddingColumn:
+		if !isXGBoostModule(module) {
+			return "", fmt.Errorf("EMBEDDING is not supported in XGBoost models")
+		}
+
+		sourceCode, err := GenerateFeatureColumnCode(c.CategoryColumn, module)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s.feature_column.embedding_column(%s, dimension=%d, combiner=\"%s\")",
+			module, sourceCode, c.Dimension, c.Combiner), nil
+	case *ir.IndicatorColumn:
+		if !isXGBoostModule(module) {
+			return "", fmt.Errorf("INDICATOR is only supported in XGBoost models")
+		}
+
+		sourceCode, err := GenerateFeatureColumnCode(c.CategoryColumn, module)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s.feature_column.indicator_column(%s)", module, sourceCode), nil
+
+	default:
+		return "", fmt.Errorf("unsupported feature column type %T on %v", c, c)
+	}
+}

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -273,7 +273,7 @@ func categorizeAttributes(trainStmt *ir.TrainStmt) (trainParams, validateParams,
 	return trainParams, validateParams, modelParams
 }
 
-func deriveFeatureColumnCode(trainStmt *ir.TrainStmt) (featureColumnsCode []string, fieldDescs map[string][]*ir.FieldDesc, err error) {
+func deriveFeatureColumnCodeAndFieldDescs(trainStmt *ir.TrainStmt) (featureColumnsCode []string, fieldDescs map[string][]*ir.FieldDesc, err error) {
 	fieldDescs = make(map[string][]*ir.FieldDesc)
 	for target, fcList := range trainStmt.Features {
 		perTargetFeatureColumnsCode := []string{}
@@ -302,7 +302,7 @@ func deriveFeatureColumnCode(trainStmt *ir.TrainStmt) (featureColumnsCode []stri
 // Train generates a Python program for train a TensorFlow model.
 func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 	trainParams, validateParams, modelParams := categorizeAttributes(trainStmt)
-	featureColumnsCode, fieldDescs, err := deriveFeatureColumnCode(trainStmt)
+	featureColumnsCode, fieldDescs, err := deriveFeatureColumnCodeAndFieldDescs(trainStmt)
 	if err != nil {
 		return "", err
 	}
@@ -490,7 +490,7 @@ func restoreModel(stmt *ir.TrainStmt) (modelParams map[string]interface{}, featu
 			modelParams[strings.Replace(attrKey, "model.", "", 1)] = attr
 		}
 	}
-	featureColumnsCode, fieldDescs, err = deriveFeatureColumnCode(stmt)
+	featureColumnsCode, fieldDescs, err = deriveFeatureColumnCodeAndFieldDescs(stmt)
 	return
 }
 

--- a/pkg/sql/codegen/tensorflow/codegen.go
+++ b/pkg/sql/codegen/tensorflow/codegen.go
@@ -18,13 +18,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sqlflow.org/sqlflow/pkg/sql/codegen"
 	"strings"
 	"text/template"
 
 	"sqlflow.org/sqlflow/pkg/ir"
 	pb "sqlflow.org/sqlflow/pkg/proto"
 	"sqlflow.org/sqlflow/pkg/sql/codegen/attribute"
-	feature "sqlflow.org/sqlflow/pkg/sql/codegen/feature"
 )
 
 var commonAttributes = attribute.Dictionary{
@@ -81,7 +81,7 @@ func attrToPythonValue(attr interface{}) string {
 	case float64: // FIXME(typhoonzero): may never use
 		return fmt.Sprintf("%f", attr.(float64))
 	case []int:
-		return feature.IntArrayToJSONString(attr.([]int))
+		return codegen.IntArrayToJSONString(attr.([]int))
 		// TODO(typhoonzero): support []float etc.
 	case []interface{}:
 		tmplist := attr.([]interface{})
@@ -91,7 +91,7 @@ func attrToPythonValue(attr interface{}) string {
 				for _, v := range tmplist {
 					intlist = append(intlist, v.(int))
 				}
-				return feature.IntArrayToJSONString(intlist)
+				return codegen.IntArrayToJSONString(intlist)
 			}
 		}
 		// TODO(typhoonzero): support []float etc.
@@ -278,7 +278,7 @@ func deriveFeatureColumnCodeAndFieldDescs(trainStmt *ir.TrainStmt) (featureColum
 	for target, fcList := range trainStmt.Features {
 		perTargetFeatureColumnsCode := []string{}
 		for _, fc := range fcList {
-			fcCode, err := feature.GenerateFeatureColumnCode(fc, "tf")
+			fcCode, err := codegen.GenerateFeatureColumnCode(fc, "tf")
 			if err != nil {
 				return nil, nil, err
 			}
@@ -333,7 +333,7 @@ func Train(trainStmt *ir.TrainStmt, session *pb.Session) (string, error) {
 	}
 	var program bytes.Buffer
 	var trainTemplate = template.Must(template.New("Train").Funcs(template.FuncMap{
-		"intArrayToJSONString": feature.IntArrayToJSONString,
+		"intArrayToJSONString": codegen.IntArrayToJSONString,
 		"attrToPythonValue":    attrToPythonValue,
 		"DTypeToString":        DTypeToString,
 	}).Parse(tfTrainTemplateText))
@@ -386,7 +386,7 @@ func Pred(predStmt *ir.PredictStmt, session *pb.Session) (string, error) {
 	}
 	var program bytes.Buffer
 	var predTemplate = template.Must(template.New("Pred").Funcs(template.FuncMap{
-		"intArrayToJSONString": feature.IntArrayToJSONString,
+		"intArrayToJSONString": codegen.IntArrayToJSONString,
 		"attrToPythonValue":    attrToPythonValue,
 		"DTypeToString":        DTypeToString,
 	}).Parse(tfPredTemplateText))
@@ -430,7 +430,7 @@ func Explain(stmt *ir.ExplainStmt, session *pb.Session) (string, error) {
 	}
 	var program bytes.Buffer
 	var tmpl = template.Must(template.New("Explain").Funcs(template.FuncMap{
-		"intArrayToJSONString": feature.IntArrayToJSONString,
+		"intArrayToJSONString": codegen.IntArrayToJSONString,
 		"attrToPythonValue":    attrToPythonValue,
 		"DTypeToString":        DTypeToString,
 	}).Parse(boostedTreesExplainTemplateText))
@@ -471,7 +471,7 @@ func Evaluate(stmt *ir.EvaluateStmt, session *pb.Session) (string, error) {
 	}
 	var program bytes.Buffer
 	var tmpl = template.Must(template.New("Evaluate").Funcs(template.FuncMap{
-		"intArrayToJSONString": feature.IntArrayToJSONString,
+		"intArrayToJSONString": codegen.IntArrayToJSONString,
 		"attrToPythonValue":    attrToPythonValue,
 		"DTypeToString":        DTypeToString,
 	}).Parse(tfEvaluateTemplateText))

--- a/pkg/sql/fields.go
+++ b/pkg/sql/fields.go
@@ -111,7 +111,7 @@ func fieldType(dbms, typeName string) (string, error) {
 	} else if dbms == "hive" {
 		const hiveCTypeSuffix = "_TYPE" // Hive field type names ends with _TYPE
 		if strings.HasSuffix(typeName, hiveCTypeSuffix) {
-			return typeName[:len(typeName)-len(hiveCTypeSuffix)], nil
+			typeName = typeName[:len(typeName)-len(hiveCTypeSuffix)]
 		}
 		// In hive, capacity is also needed when define a VARCHAR field, so we replace it with STRING.
 		if typeName == "VARCHAR" {

--- a/pkg/sql/testdata/feature_derivation_case.go
+++ b/pkg/sql/testdata/feature_derivation_case.go
@@ -21,9 +21,9 @@ CREATE TABLE feature_derivation_case.train (
        c2 float,
        c3 TEXT,
        c4 TEXT,
-       c5 TEXT,
-       c6 TEXT,
-       class int);
+       c5 VARCHAR(255),
+       c6 CHAR(255),
+       class TINYINT);
 INSERT INTO feature_derivation_case.train VALUES
 (6.4,2.8, '1,4,2,3', '1,3,2,6', '3,140', 'MALE', 0),
 (5.0,2.3, '1,3,8,3', '3,2,5,3', '93,12,1,392,49,13,398', 'FEMALE', 1),

--- a/pkg/step/feature/derivation.go
+++ b/pkg/step/feature/derivation.go
@@ -133,9 +133,9 @@ func newRowValue(columnTypeList []*sql.ColumnType) ([]interface{}, error) {
 	for idx, ct := range columnTypeList {
 		typeName := ct.DatabaseTypeName()
 		switch unifyDatabaseTypeName(typeName) {
-		case "VARCHAR", "TEXT", "STRING":
+		case "CHAR", "VARCHAR", "TEXT", "STRING":
 			rowData[idx] = new(string)
-		case "INT":
+		case "INT", "TINYINT":
 			rowData[idx] = new(int32)
 		case "BIGINT", "DECIMAL":
 			rowData[idx] = new(int64)
@@ -239,13 +239,13 @@ func fillFieldDesc(columnTypeList []*sql.ColumnType, rowdata []interface{}, fiel
 		// start the feature derivation routine
 		typeName := ct.DatabaseTypeName()
 		switch unifyDatabaseTypeName(typeName) {
-		case "INT", "DECIMAL", "BIGINT":
+		case "INT", "TINYINT", "DECIMAL", "BIGINT":
 			fieldDescMap[fld].DType = ir.Int
 			fieldDescMap[fld].Shape = []int{1}
 		case "FLOAT", "DOUBLE":
 			fieldDescMap[fld].DType = ir.Float
 			fieldDescMap[fld].Shape = []int{1}
-		case "VARCHAR", "TEXT", "STRING":
+		case "CHAR", "VARCHAR", "TEXT", "STRING":
 			cellData := rowdata[idx].(*string)
 			if csvRegex.MatchString(*cellData) {
 				fillCSVFieldDesc(*cellData, fieldDescMap, fld)


### PR DESCRIPTION
Mainly move `generateFeatureColumnCode` to a new file `codegen_feature_column.go`.