### PR TITLE
fix copy XGBoost package failed

### DIFF
--- a/pkg/sql/alisa_submitter.go
+++ b/pkg/sql/alisa_submitter.go
@@ -14,6 +14,7 @@
 package sql
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -253,12 +254,14 @@ func (s *alisaSubmitter) ExecuteEvaluate(es *ir.EvaluateStmt) error {
 func (s *alisaSubmitter) GetTrainStmtFromModel() bool { return false }
 
 func findPyModulePath(pyModuleName string) (string, error) {
+	var b bytes.Buffer
+	wStdout := bufio.NewWriter(&b)
 	cmd := exec.Command("python", "-c", fmt.Sprintf(`import %s;print(%s.__path__[0])`, pyModuleName, pyModuleName))
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed %s, %v", cmd, err)
+	cmd.Stdout = wStdout
+	if e := cmd.Run(); e != nil {
+		return "", fmt.Errorf("failed %s, %v", cmd, e)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(b.String()), nil
 }
 
 // FIXME(typhoonzero): use the same model bucket name e.g. sqlflow-models

--- a/pkg/sql/alisa_submitter_test.go
+++ b/pkg/sql/alisa_submitter_test.go
@@ -27,6 +27,7 @@ func TestAlisaSubmitter(t *testing.T) {
 
 func TestFindPyModulePath(t *testing.T) {
 	a := assert.New(t)
-	_, err := findPyModulePath("sqlflow_submitter")
+	path, err := findPyModulePath("xgboost")
+	a.Equal(path, "/usr/local/lib/python3.6/dist-packages/xgboost")
 	a.NoError(err)
 }

--- a/pkg/sql/alisa_submitter_test.go
+++ b/pkg/sql/alisa_submitter_test.go
@@ -27,7 +27,6 @@ func TestAlisaSubmitter(t *testing.T) {
 
 func TestFindPyModulePath(t *testing.T) {
 	a := assert.New(t)
-	path, err := findPyModulePath("xgboost")
-	a.Equal(path, "/usr/local/lib/python3.6/dist-packages/xgboost")
+	_, err := findPyModulePath("sqlflow_submitter")
 	a.NoError(err)
 }

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -531,6 +531,28 @@ func createExplainResultTable(db *database.DB, ir *ir.ExplainStmt, tableName str
 	return nil
 }
 
+func copyPythonPacakge(packageName, toCwd string) error {
+	path, e := findPyModulePath(packageName)
+	if e != nil {
+		return fmt.Errorf("Can not find Python pacakge: %s", packageName)
+	}
+	cmd := exec.Command("cp", "-r", path, ".")
+	cmd.Dir = toCwd
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed %s, %v", cmd, err)
+	}
+	return nil
+}
+
+func copyCustomPacakge(estimator, toCwd string) error {
+	modelNameParts := strings.Split(estimator, ".")
+	pkgName := modelNameParts[0]
+	if len(modelNameParts) == 2 && pkgName != "sqlflow_models" && pkgName != "xgboost" {
+		return copyPythonPacakge(pkgName, toCwd)
+	}
+	return nil
+}
+
 func achieveResource(cwd, entryCode, requirements, tarball, estimator string) error {
 	if err := writeFile(filepath.Join(cwd, entryFile), entryCode); err != nil {
 		return err
@@ -538,48 +560,20 @@ func achieveResource(cwd, entryCode, requirements, tarball, estimator string) er
 	if err := writeFile(filepath.Join(cwd, "requirements.txt"), requirements); err != nil {
 		return err
 	}
-
-	// add sqlflow_submitter
-	path, err := findPyModulePath("sqlflow_submitter")
-	if err != nil {
+	// sqlflow_submitter and sqlflow_models are built-in packages.
+	if err := copyPythonPacakge("sqlflow_submitter", cwd); err != nil {
 		return err
 	}
-	cmd := exec.Command("cp", "-r", path, ".")
-	cmd.Dir = cwd
-	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed %s, %v", cmd, err)
-	}
-
-	// add sqlflow_models
-	path, err = findPyModulePath("sqlflow_models")
-	if err != nil {
+	if err := copyPythonPacakge("sqlflow_models", cwd); err != nil {
 		return err
 	}
-	cmd = exec.Command("cp", "-r", path, ".")
-	cmd.Dir = cwd
-	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed %s, %v", cmd, err)
+
+	// add custom package if needed
+	if err := copyCustomPacakge(estimator, cwd); err != nil {
+		return err
 	}
 
-	// add any other custom model packages
-	if estimator != "" {
-		modelNameParts := strings.Split(estimator, ".")
-		if len(modelNameParts) == 2 && modelNameParts[0] != "sqlflow_models" {
-			customModelPkg := modelNameParts[0]
-			fmt.Printf("adding %s\n", customModelPkg)
-			path, err = findPyModulePath(customModelPkg)
-			if err != nil {
-				return err
-			}
-			cmd = exec.Command("cp", "-r", path, ".")
-			cmd.Dir = cwd
-			if _, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("failed %s, %v", cmd, err)
-			}
-		}
-	}
-
-	cmd = exec.Command("tar", "czf", tarball, "./sqlflow_submitter", "./sqlflow_models", entryFile, "requirements.txt")
+	cmd := exec.Command("tar", "czf", tarball, "./sqlflow_submitter", "./sqlflow_models", entryFile, "requirements.txt")
 	cmd.Dir = cwd
 	if _, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed %s, %v", cmd, err)

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -531,7 +531,7 @@ func createExplainResultTable(db *database.DB, ir *ir.ExplainStmt, tableName str
 	return nil
 }
 
-func copyPythonPacakge(packageName, toCwd string) error {
+func copyPythonPackage(packageName, toCwd string) error {
 	path, e := findPyModulePath(packageName)
 	if e != nil {
 		return fmt.Errorf("Can not find Python pacakge: %s", packageName)
@@ -544,11 +544,11 @@ func copyPythonPacakge(packageName, toCwd string) error {
 	return nil
 }
 
-func copyCustomPacakge(estimator, toCwd string) error {
+func copyCustomPackage(estimator, toCwd string) error {
 	modelNameParts := strings.Split(estimator, ".")
 	pkgName := modelNameParts[0]
 	if len(modelNameParts) == 2 && pkgName != "sqlflow_models" && pkgName != "xgboost" {
-		return copyPythonPacakge(pkgName, toCwd)
+		return copyPythonPackage(pkgName, toCwd)
 	}
 	return nil
 }
@@ -561,15 +561,15 @@ func achieveResource(cwd, entryCode, requirements, tarball, estimator string) er
 		return err
 	}
 	// sqlflow_submitter and sqlflow_models are built-in packages.
-	if err := copyPythonPacakge("sqlflow_submitter", cwd); err != nil {
+	if err := copyPythonPackage("sqlflow_submitter", cwd); err != nil {
 		return err
 	}
-	if err := copyPythonPacakge("sqlflow_models", cwd); err != nil {
+	if err := copyPythonPackage("sqlflow_models", cwd); err != nil {
 		return err
 	}
 
 	// add custom package if needed
-	if err := copyCustomPacakge(estimator, cwd); err != nil {
+	if err := copyCustomPackage(estimator, cwd); err != nil {
 		return err
 	}
 

--- a/pkg/sql/pai_submitter.go
+++ b/pkg/sql/pai_submitter.go
@@ -531,24 +531,24 @@ func createExplainResultTable(db *database.DB, ir *ir.ExplainStmt, tableName str
 	return nil
 }
 
-func copyPythonPackage(packageName, toCwd string) error {
+func copyPythonPackage(packageName, dst string) error {
 	path, e := findPyModulePath(packageName)
 	if e != nil {
 		return fmt.Errorf("Can not find Python pacakge: %s", packageName)
 	}
 	cmd := exec.Command("cp", "-r", path, ".")
-	cmd.Dir = toCwd
+	cmd.Dir = dst
 	if _, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed %s, %v", cmd, err)
 	}
 	return nil
 }
 
-func copyCustomPackage(estimator, toCwd string) error {
+func copyCustomPackage(estimator, dst string) error {
 	modelNameParts := strings.Split(estimator, ".")
 	pkgName := modelNameParts[0]
 	if len(modelNameParts) == 2 && pkgName != "sqlflow_models" && pkgName != "xgboost" {
-		return copyPythonPackage(pkgName, toCwd)
+		return copyPythonPackage(pkgName, dst)
 	}
 	return nil
 }


### PR DESCRIPTION
workflow step failed on the XGBoost training SQL:

``` sql
SELECT ...
TO TRAIN xgboost.gbtree ...
```

error logs:

``` text
workflow step failed: runSQLProgram error: failed /usr/bin/cp -r /usr/local/lib64/python3.6/site-packages/sklearn/externals/joblib/externals/cloudpickle/cloudpick
le.py:47: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
 import imp
/usr/local/lib/python3.6/site-packages/xgboost ., exit status 1
```
The following code would copy xgboost package into PAI achievement as the following code:
https://github.com/sql-machine-learning/sqlflow/blob/0f7e48d2d49e2135bbb0d967579d768dbfddba29/pkg/sql/pai_submitter.go#L565-L570

`import xgboost` would output the warning message
``` text
/usr/local/lib64/python3.6/site-packages/sklearn/externals/joblib/externals/cloudpickle/cloudpick
le.py:47: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
 import imp
```

We should skip the stderr message when finding the Python module path.