### PR TITLE
Optimize syntax support group by

### DIFF
--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -20,6 +20,13 @@ type Expr struct {
 
 type ExprList []*Expr
 
+type ConstraintExpr struct {
+	expr *Expr
+	groupby string
+}
+
+type ConstraintExprList []*ConstraintExpr
+
 /* construct an atomic expr */
 func atomic(typ int, val string) *Expr {
 	return &Expr{
@@ -118,7 +125,7 @@ type OptimizeClause struct {
 	// Direction can be MAXIMIZE or MINIMIZE
 	Direction string
 	Objective *Expr
-	Constrants ExprList
+	Constrants ConstraintExprList
 	OptimizeAttrs Attributes
 	Solver string
 	OptimizeInto string
@@ -147,6 +154,8 @@ func attrsUnion(as1, as2 Attributes) Attributes {
   tbls []string
   expr *Expr
   expl ExprList
+  ctexp  *ConstraintExpr
+  ctexpl ConstraintExprList
   atrs Attributes
   eslt SQLFlowSelectStmt
   slct StandardSelect
@@ -172,10 +181,12 @@ func attrsUnion(as1, as2 Attributes) Attributes {
 %type  <val> optional_using
 %type  <expr> expr funcall column
 %type  <expl> ExprList pythonlist columns
+%type  <ctexp> ConstraintExpr
+%type  <ctexpl> ConstraintExprList
 %type  <atrs> attr
 %type  <atrs> attrs
 
-%token <val> SELECT FROM WHERE LIMIT TRAIN PREDICT EXPLAIN EVALUATE MAXIMIZE MINIMIZE CONSTRAINT WITH COLUMN LABEL USING INTO FOR AS TO SHOW
+%token <val> SELECT FROM WHERE LIMIT TRAIN PREDICT EXPLAIN EVALUATE MAXIMIZE MINIMIZE CONSTRAINT WITH COLUMN LABEL USING INTO FOR AS TO SHOW GROUP BY
 %token <val> IDENT NUMBER STRING
 
 %left <val> AND OR
@@ -286,7 +297,7 @@ evaluate_clause
 ;
 
 optimize_clause
-: TO MAXIMIZE expr CONSTRAINT ExprList WITH attrs USING IDENT INTO IDENT {
+: TO MAXIMIZE expr CONSTRAINT ConstraintExprList WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -294,14 +305,14 @@ optimize_clause
 	$$.Solver = $9;
 	$$.OptimizeInto = $11;
 }
-| TO MAXIMIZE expr CONSTRAINT ExprList WITH attrs INTO IDENT {
+| TO MAXIMIZE expr CONSTRAINT ConstraintExprList WITH attrs INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
 	$$.OptimizeAttrs = $7;
 	$$.OptimizeInto = $9;
 }
-| TO MINIMIZE expr CONSTRAINT ExprList WITH attrs USING IDENT INTO IDENT {
+| TO MINIMIZE expr CONSTRAINT ConstraintExprList WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -309,7 +320,7 @@ optimize_clause
 	$$.Solver = $9;
 	$$.OptimizeInto = $11;
 }
-| TO MINIMIZE expr CONSTRAINT ExprList WITH attrs INTO IDENT {
+| TO MINIMIZE expr CONSTRAINT ConstraintExprList WITH attrs INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -365,6 +376,16 @@ funcall
 ExprList
 : expr              { $$ = ExprList{$1}     }
 | ExprList ',' expr { $$ = append($1, $3) }
+;
+
+ConstraintExpr
+: expr { $$ = &ConstraintExpr{expr: $1, groupby: ""} }
+| expr GROUP BY IDENT { $$ = &ConstraintExpr{expr: $1, groupby: $4} }
+;
+
+ConstraintExprList
+: ConstraintExpr { $$ = ConstraintExprList{$1} }
+| ConstraintExprList ',' ConstraintExpr { $$ = append($1, $3) }
 ;
 
 pythonlist

--- a/pkg/parser/extended_syntax_parser_test.go
+++ b/pkg/parser/extended_syntax_parser_test.go
@@ -215,7 +215,7 @@ func TestExtendedSyntaxParseUnmatchedQuotation(t *testing.T) {
 
 }
 
-func TestExtendedSyntaxMathProg(t *testing.T) {
+func TestExtendedSyntaxOptimize(t *testing.T) {
 	a := assert.New(t)
 	s := `TO MAXIMIZE SUM((price - materials_cost - other_cost) * product)
 CONSTRAINT SUM(finishing * product) <= 100,
@@ -226,18 +226,20 @@ WITH variables="product",
 USING glpk
 INTO db.table;`
 	r, idx, e := parseSQLFlowStmt(s)
-	a.NoError(e)
+	if e != nil {
+		a.FailNow("%v", e)
+	}
 	a.Equal(len(s), idx)
 	a.True(r.Extended)
 	a.True(r.Optimize)
 	a.Equal("MAXIMIZE", r.Direction)
 	a.Equal("SUM((price - materials_cost - other_cost) * product)", r.Objective.String())
-	a.Equal("SUM(finishing * product) <= 100", r.Constrants.Strings()[0])
+	a.Equal("SUM(finishing * product) <= 100", r.Constrants[0].expr.String())
 	a.Equal("db.table", r.OptimizeInto)
 	a.Equal("glpk", r.Solver)
 
 	s = `TO MINIMIZE SUM((price - materials_cost - other_cost) * product)
-CONSTRAINT SUM(finishing * product) <= 100,
+CONSTRAINT SUM(finishing * product) <= 100 GROUP BY product,
            SUM(carpentry * product) <= 80,
 		   product <= max_num
 WITH variables="product",
@@ -247,6 +249,7 @@ INTO db.table;`
 	a.NoError(e)
 	a.Equal("MINIMIZE", r.Direction)
 	a.Equal("db.table", r.OptimizeInto)
+	a.Equal("product", r.Constrants[0].groupby)
 	a.Equal("", r.Solver)
 }
 

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -148,6 +148,8 @@ func (l *lexer) emitIdentOrKeyword(lval *extendedSyntaxSymType) int {
 		"AS":         AS,
 		"TO":         TO,
 		"SHOW":       SHOW,
+		"GROUP":      GROUP,
+		"BY":         BY,
 	}
 	if typ, ok := keywds[strings.ToUpper(l.input[l.start:l.pos])]; ok {
 		return l.emit(lval, typ)


### PR DESCRIPTION
To support syntax like:

```sql
SELECT src.plants, src.markets, src.distance, plants.capacity, markets.demand FROM transportation AS src
LEFT JOIN plants ON src.plants = plants.plants
LEFT JOIN markets ON src.markets = markets.markets
TO MINIMIZE SUM(distance * 90 / 1000)
CONSTRAINT SUM(markets) <= capacity GROUP BY plants,
           SUM(plants) >= demand GROUP BY markets
WITH variables="plants,markets",
     plants="Integers",
     markets="Integers"
[USING glpk]
INTO result_table;
```

ref: https://github.com/sql-machine-learning/sqlflow/blob/develop/doc/design/programming_solver.md