### PR TITLE
Disable JupyterNotebook's token validation for playground

### DIFF
--- a/doc/run/k8s/install-sqlflow.yaml
+++ b/doc/run/k8s/install-sqlflow.yaml
@@ -26,7 +26,7 @@ spec:
     command:
     - bash
     - -c
-    - 'export SQLFLOW_DATASOURCE=mysql://root:root@tcp\(${MY_POD_IP}:3306\)/?maxAllowedPacket=0 && jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root'
+    - 'export SQLFLOW_DATASOURCE=mysql://root:root@tcp\(${MY_POD_IP}:3306\)/?maxAllowedPacket=0 && jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root --NotebookApp.token=""'
     env:
     # Tell the Jupyter Notebook magic command the SQLFlow gRPC server address.
     - name: SQLFLOW_SERVER

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -45,4 +45,4 @@ ENV SQLFLOW_DATASOURCE=${SQLFLOW_DATASOURCE}
 WORKDIR /workspace
 EXPOSE 8888
 
-CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--allow-root", "-NotebookApp.token=''"] 
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--allow-root", "--NotebookApp.token=''"] 


### PR DESCRIPTION
Current single node playground mainly focus on single user, so,  it seems that we do not need to add a password for Jupyter Notebook.