### PR TITLE
Reduce Jupyter image size

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,8 +1,10 @@
 # This Dockerfile containers Jupyter Notebook server with many
 # SQLFlow tutorials and SQLFlow magic command.
 
-FROM ubuntu:18.04
+FROM jupyter/base-notebook
 
+# using root user to avoid permission deni
+USER root
 # Choose fastest mirrors for apt-get and pip
 COPY docker/dev/find_fastest_resources.sh /usr/local/bin/find_fastest_resources.sh
 RUN /bin/bash -c 'source find_fastest_resources.sh \
@@ -16,14 +18,11 @@ COPY docker/jupyter/js /jupyter/js
 
 RUN apt-get -qq update
 
-COPY /docker/ci/install-python.bash /jupyter
-RUN /jupyter/install-python.bash
-
-COPY docker/ci/install-pips.bash /jupyter/
-RUN /jupyter/install-pips.bash
-
 COPY docker/jupyter/install-jupyter.bash /jupyter
 RUN /jupyter/install-jupyter.bash
+
+# back to the default user
+USER jovyan
 
 # Install IPythono Notebook tutorials
 COPY build/tutorial /workspace
@@ -45,4 +44,4 @@ ENV SQLFLOW_DATASOURCE=${SQLFLOW_DATASOURCE}
 WORKDIR /workspace
 EXPOSE 8888
 
-CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--allow-root", "-NotebookApp.token=''"] 
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--allow-root", "--NotebookApp.token=''"] 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get -qq update
 COPY docker/jupyter/install-jupyter.bash /jupyter
 RUN /jupyter/install-jupyter.bash
 
-# back to the default user
-USER jovyan
+# switch back to the default user to avoid accidental container runs as root,
+# this env comes from base Dockerfile:  https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile#L13
+USER $NB_UID
 
 # Install IPythono Notebook tutorials
 COPY build/tutorial /workspace

--- a/docker/jupyter/install-jupyter.bash
+++ b/docker/jupyter/install-jupyter.bash
@@ -19,6 +19,7 @@ set -e
 pip install --quiet \
     jupyter==1.0.0 \
     notebook==6.0.0 \
+    jupyterhub==1.1.0 \
     sqlflow==0.10.0 # sqlflow is the Python client of SQLFlow server.
 
 # Load SQLFlow's Jupyter magic command

--- a/docker/jupyter/install-jupyter.bash
+++ b/docker/jupyter/install-jupyter.bash
@@ -16,6 +16,8 @@
 set -e
 
 # This file depends on install-python.bash.
+# install jupyterhub Python package so that this image can be used as jupyterhub
+# singleuser notebook server, ref: https://github.com/jupyterhub/jupyterhub/tree/master/singleuser
 pip install --quiet \
     jupyter==1.0.0 \
     notebook==6.0.0 \

--- a/docker/jupyter/install-jupyter.bash
+++ b/docker/jupyter/install-jupyter.bash
@@ -19,8 +19,6 @@ set -e
 # install jupyterhub Python package so that this image can be used as jupyterhub
 # singleuser notebook server, ref: https://github.com/jupyterhub/jupyterhub/tree/master/singleuser
 pip install --quiet \
-    jupyter==1.0.0 \
-    notebook==6.0.0 \
     jupyterhub==1.1.0 \
     sqlflow==0.10.0 # sqlflow is the Python client of SQLFlow server.
 


### PR DESCRIPTION
Remove some unused dependencies, reduce the image size from 2.14GB to 894MB.