### PR TITLE
Migration to Python: encapsulating sqlflow_submitter

### DIFF
--- a/pkg/proto/ir.proto
+++ b/pkg/proto/ir.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package proto;
+
+message Statement {
+  // `select` is the query for fetching data. For example,
+  // "SELECT * FROM iris.train;"
+  string select = 2;
+  // `validation_select` is the query for fetching the validation data.
+  // For example, "SELECT * FROM iris.val;".
+  string validation_select = 3;
+  // `model_image` is the name of the model's Docker image, for example, in the
+  // statement "TO TRAIN a_data_scientist/regressors:v0.2/MyDNNRegressor", the
+  // name "a_data_scientist/regressors:v0.2" is a Docker image.
+  string model_image = 4;
+  // `estimator` specifies the estimator type. For example, after parsing
+  // "SELECT ... TRAIN DNNClassifier WITH ...", `estimator` will be
+  // "DNNClassifier".
+  string estimator = 5;
+  // `attributes` is a map of parsed attribute in the WITH Clause. For example,
+  // after parsing "SELECT ... TO TRAIN ... with train.epoch=1000,
+  // model.hidden_units = [10, 10]", the `attributes` will be
+  // {"train.epoch": "1000", "model.hidden_units": "[10, 10]"}
+  map<string, string> attributes = 6;
+  string label = 7;
+  message Columns {
+  // The COLUMN clause will be split into `column`. For example, in the COLUMN
+  // clause "COLUMN NUMERIC(sepal_length), INDICATOR(ID)" will be saved in
+  // `columns` as ["NUMERIC(sepal_length)", "INDICATOR(ID)"]
+    repeated string columns = 1;
+  }
+  // `columns` contain a map of string to `Columns` for multiple COLUMN clauses
+  // like "COLUMN ... FOR deep_feature, COLUMN ... FOR wide_feature". They will
+  // be parsed as {"deep_feature": [...], "wide_feature": [...]}. For single
+  // column clause like "COLUMN ...", "feature_columns" will be used as the
+  // default map key.
+  map<string, Columns> columns = 8;
+  // `model_save` specifies the saved model path in the INTO/USING clause.
+  string model_save = 9;
+  enum Type {
+    RUN = 0;
+    QUERY = 1;
+    TRAIN = 2;
+    PREDICT = 3;
+    EXPLAIN = 4;
+    EVALUATE = 5;
+    OPTIMIZE = 6;
+	SHOW = 7;
+  }
+  Type type = 10;
+  // `target` specifies the table/column to store predict/explain result.
+  // For example: "iris.predict.class"
+  string target = 11;
+  // `trained_model` is used in incremental training (TO TRAIN ... USING `trained_model`)
+  // and have the same format as `model_save`
+  string trained_model = 12;
+  // `original_sql` is the original statement from that this `Statement` is
+  // generated. This can be for diagnostic purpose.
+  string original_sql = 100;
+}
+
+message Program {
+  // `datasource` is the connection string to the database
+  string datasource = 1;
+  // `statements` is a list of `Statement` to be executed as a workflow
+  repeated Statement statements = 2;
+}

--- a/python/sqlflow/__init__.py
+++ b/python/sqlflow/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/sqlflow/column/__init__.py
+++ b/python/sqlflow/column/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/sqlflow/column/tensorflow.py
+++ b/python/sqlflow/column/tensorflow.py
@@ -1,0 +1,62 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from tensorflow import feature_column as tfc
+
+
+def numeric(field, dim=0):
+    return tfc.numeric_column(field["feature_name"],
+                              shape=[dim] if dim else field["shape"],
+                              dtype=eval("tf." + field["dtype"]))
+
+
+def embedding(field, dimension, combiner):
+    if isinstance(field, dict):
+        categorical = category_id(field, field["shape"][0], field["delimiter"])
+    else:
+        categorical = field
+    ret = tfc.embedding_column(categorical, dimension, combiner)
+    ret.key = categorical.key
+    return ret
+
+
+def indicator(field):
+    if isinstance(field, dict):
+        categorical = category_id(field, field["maxid"] + 1)
+    else:
+        categorical = field
+    ret = tfc.indicator_column(categorical)
+    ret.key = categorical.key
+    return ret
+
+
+def sparse(field, size, sep):
+    field["is_sparse"], field["delimiter"], field["shape"] = True, sep, [size]
+    return field
+
+
+def category_id(field, size, sep=''):
+    field = sparse(field, size, sep) if sep else field
+    return tfc.categorical_column_with_identity(field["feature_name"], size)
+
+
+def seq_category_id(field, size, sep=''):
+    field = sparse(field, size, sep) if not field["delimiter"] else field
+    ret = tfc.sequence_categorical_column_with_identity(
+        field["feature_name"], size)
+    ret.key = field["feature_name"]
+    return ret
+
+
+EVAL_GLOBALS = {'comma': ',', 'mean': 'mean', 'sum': 'sum', 'sqrtn': 'sqrtn'}

--- a/python/sqlflow/column/xgboost.py
+++ b/python/sqlflow/column/xgboost.py
@@ -1,0 +1,55 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlflow_submitter.xgboost import feature_column as xfc
+
+
+def numeric(field):
+    return xfc.numeric_column(field["feature_name"], shape=field["shape"])
+
+
+def bucket(field, boundaries):
+    if isinstance(field, dict):
+        numerical = numeric(field)
+    else:
+        numerical = field
+    ret = xfc.bucketized_column(numerical, boundaries)
+    ret.key = numerical.key
+    return ret
+
+
+def indicator(field):
+    if isinstance(field, dict):
+        categorical = category_id(field, field["maxid"] + 1)
+    else:
+        categorical = field
+    ret = xfc.indicator_column(categorical)
+    ret.key = categorical.key
+    return ret
+
+
+def category_id(field, size):
+    if field["vocab"]:
+        return xfc.categorical_column_with_vocabulary_list(
+            field["feature_name"], vocabulary_list=field["vocab"])
+    else:
+        return xfc.categorical_column_with_identity(field["feature_name"],
+                                                    size)
+
+
+def category_hash(field, size):
+    return xfc.categorical_column_with_hash_bucket(field["feature_name"], size,
+                                                   field["dtype"])
+
+
+EVAL_GLOBALS = {}

--- a/python/sqlflow/features.py
+++ b/python/sqlflow/features.py
@@ -1,0 +1,127 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import importlib
+import inspect
+import re
+
+
+def get_feature_metas(conn, select, label=None):
+    cursor = conn.cursor()
+    cursor.execute(select)
+    feature_metas = {}
+    feature_column_names = []
+    rows = list(cursor.fetchmany(1024))
+    for i, column in enumerate(cursor.description):
+        name, typ = column[0], column[1]
+        sep, shape, maxid, vocab = "", [1], 0, set()
+        if typ in (4, 5):
+            dtype = "float32"
+        elif typ in (1, 3, 8):
+            dtype = "int64"
+            vocab.update(r[i] for r in rows)
+        elif typ in (252, 253):
+            dtype = "string"
+            vocab.update(r[i] for r in rows)
+            possible_sep = set()
+            for row in rows:
+                possible_sep.update(re.sub('[0-9]', '', row[i]))
+            if len(possible_sep) in (1, 2):
+                if len(possible_sep) == 2 and '.' in possible_sep:
+                    dtype = "float32"
+                    possible_sep.remove('.')
+                    sep = possible_sep.pop()
+                elif len(possible_sep) == 1:
+                    sep = possible_sep.pop()
+                    dtype = "int64"
+                    for r in rows:
+                        maxid = max(maxid,
+                                    max(int(p) for p in r[i].split(sep)))
+                shape = [len(row[i].split(sep))]
+        else:
+            raise Exception(f"Unexpected column type {typ}: {name}")
+        feature_metas[name] = {
+            "feature_name": name,
+            "dtype": dtype,
+            "delimiter": sep,
+            "shape": shape,
+            "is_sparse": False,
+            "maxid": maxid,
+            "vocab": list(vocab)
+        }
+    label_meta = {} if not label else feature_metas.pop(label)
+    if label_meta["shape"] == [1]:
+        label_meta["shape"] = []
+    return feature_metas, label_meta
+
+
+def check_and_expand_columns(c, funcs, fields):
+    t = ast.parse(c, mode='eval')
+    body, leaf = t.body, t.body.args[0]
+    while isinstance(leaf, ast.Call):
+        body, leaf = leaf, leaf.args[0]
+    ret = []
+    if isinstance(leaf, ast.Str):
+        for f in fields:
+            if re.match(leaf.s, f):
+                body.args[0] = ast.Name(f,
+                                        ast.Load(),
+                                        lineno=1,
+                                        col_offset=leaf.col_offset)
+                ret.append((f, compile(t, '', 'eval')))
+        return ret
+    return [(leaf.id, compile(t, '', 'eval'))]
+
+
+def get_column_module(name):
+    return importlib.import_module(f"sqlflow.column.{name}")
+
+
+def get_feature_columns(feature_metas, columns, engine='tensorflow'):
+    fc = get_column_module(engine)
+    eval_globals = dict(
+        filter(lambda x: inspect.isfunction(x[1]),
+               vars(fc).items()))
+    eval_globals.update(fc.EVAL_GLOBALS)
+    ret = {k: [] for k in columns} if columns else {"feature_columns": []}
+    # undefined = []
+    for k, v in columns.items():  # k is a parameter like 'feature_columns'
+        for c in v.columns:  # v(ir_pb2.Columns) is a list of expressions
+            if c not in feature_metas:  # COLUMN sepal_length
+                for i, code_obj in check_and_expand_columns(
+                        c.lower(), eval_globals, feature_metas):
+                    ret[k].append(eval(code_obj, eval_globals, feature_metas))
+    if len(ret) == 1:
+        ret = {"feature_columns": list(ret.values())[0]}
+    specified_fields = set()
+    for k, v in ret.items():
+        specified_fields.update(map(lambda f: f.key, v))
+    features = ret[list(ret.keys())[0]]
+    for k in set(feature_metas.keys()) - specified_fields:
+        if feature_metas[k]["dtype"] in ("float32", "int64"):
+            features.append(fc.numeric(feature_metas[k]))
+    return ret
+
+
+def get_xgb_features(feature_metas, columns):
+    if not columns:
+        return None
+    from sqlflow_submitter.xgboost import feature_column as xfc
+    fc = get_feature_columns(feature_metas, columns, 'xgboost')
+    return xfc.ComposedColumnTransformer(list(feature_metas.keys()),
+                                         *fc["feature_columns"])
+
+
+def get_tf_features(feature_metas, columns):
+    return get_feature_columns(feature_metas, columns, 'tensorflow')

--- a/python/sqlflow/platform/__init__.py
+++ b/python/sqlflow/platform/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/sqlflow/platform/default.py
+++ b/python/sqlflow/platform/default.py
@@ -1,0 +1,345 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import copy
+import io
+import json
+import pickle
+import tarfile
+import tempfile
+
+import grpc
+from sqlflow_submitter import db
+from sqlflow_submitter.tensorflow import diag
+
+from .. import features
+from ..proto import ir_pb2, modelzooserver_pb2, modelzooserver_pb2_grpc
+
+
+def eval_attr(attr):
+    try:
+        return eval(attr)
+    except:
+        return attr
+
+
+def get_xgb_kwargs(attributes, select):
+    kwargs = {"model_params": {}, "train_params": {}}
+    for k, v in attributes.items():
+        if k.startswith("train."):
+            prefix, name = k.split('.')[:2]
+            if name in ("disk_cache", "epoch", "batch_size"):
+                kwargs[name] = eval_attr(v.title())
+            elif name in ("num_workers", ):
+                # TODO(shendiaomo): pass num_workers to flags
+                pass
+            else:
+                kwargs["train_params"][name] = eval_attr(v)
+        elif k.startswith("validation."):
+            kwargs[k.replace('.', '_')] = eval_attr(v)
+        else:
+            kwargs["model_params"][k.replace('.', '_')] = eval_attr(v)
+    if "validation_select" not in kwargs:
+        kwargs["validation_select"] = select
+    return kwargs
+
+
+def get_tf_kwargs(attributes, select):
+    kwargs = {"model_params": {}}
+    optimizer_args = {}
+    for k, v in attributes.items():
+        prefix, name = k.split('.')[:2]
+        if prefix == "train":
+            kwargs[name] = eval_attr(v)
+        elif prefix == "validation":
+            kwargs[k.replace('.', '_')] = eval_attr(v)
+            if name == "metrics":
+                kwargs[k.replace('.', '_')] = eval_attr(v).split(',')
+        elif prefix == "model":
+            kwargs["model_params"][name] = eval_attr(v)
+            if name.endswith("optimizer"):
+                optimizer_args.setdefault(name, {})
+        elif prefix.endswith("optimizer"):
+            optimizer_args.setdefault(prefix, {})[name] = eval_attr(v)
+    if "validation_select" not in kwargs:
+        kwargs["validation_select"] = select
+    return kwargs, optimizer_args
+
+
+def construct_tf_objects(model_params, opt_args):
+    from tensorflow.keras.losses import (
+        BinaryCrossentropy, CategoricalCrossentropy, CategoricalHinge,
+        CosineSimilarity, Hinge, Huber, KLDivergence, LogCosh,
+        MeanAbsoluteError, MeanAbsolutePercentageError, MeanSquaredError,
+        MeanSquaredLogarithmicError, Poisson, SparseCategoricalCrossentropy,
+        SquaredHinge)
+    from tensorflow.keras.optimizers import (Adadelta, Adagrad, Adam, Adamax,
+                                             Ftrl, Nadam, RMSprop, SGD)
+    for name, args in opt_args.items():
+        model_params.setdefault(name, 'Adagrad')
+        model_params[name] = eval(model_params[name])(**args)
+    if "loss" in model_params:
+        model_params["loss"] = eval(model_params["loss"])()
+
+
+def save_model(conn, table, *meta):
+    '''
+    Save the directory and specific metadata to a database table
+    '''
+    cursor = conn.cursor()
+    db_name, tbl_name = map(lambda s: s.strip(), table.split("."))
+    cursor.execute(f'CREATE DATABASE IF NOT EXISTS {db_name}')
+    cursor.execute(f'DROP TABLE IF EXISTS {table}')
+    cursor.execute(
+        f'''CREATE TABLE {table} (id INT NOT NULL AUTO_INCREMENT KEY,
+                                             block TEXT NOT NULL)''')
+    pickle.dump(meta, open("meta.pkl", "wb"))
+    f = io.BytesIO()
+    archive = tarfile.open(None, "w|gz", f)
+    archive.add(".")
+    archive.close()
+    f.seek(0)
+    for block in iter(lambda: f.read(30000), b''):
+        cursor.execute(f'INSERT INTO {table} (block) VALUES (%s)',
+                       (base64.encodebytes(block), ))
+    conn.commit()
+
+
+def load_model(conn, model):
+    '''
+    Load and restore a directory and metadata that are saved in `model`
+    '''
+    if '/' in model:
+        return load_model_from_zoo(model)
+
+    cursor = conn.cursor()
+    db_name, tbl_name = map(lambda s: s.strip(), model.split("."))
+    cursor.execute(f'SELECT block FROM {model} ORDER BY id')
+    with tempfile.TemporaryFile() as f:
+        row = cursor.fetchone()
+        while row:
+            f.write(base64.b64decode(row[0]))
+            row = cursor.fetchone()
+        f.seek(0)
+        archive = tarfile.open(None, "r|gz", f)
+        archive.extractall()
+        archive.close()
+    return pickle.load(open("meta.pkl", "rb"))
+
+
+def load_model_from_zoo(uri):
+    '''
+    Load and restore a directory and metadata that are saved in `uri`
+    '''
+    addr, name = map(lambda s: s.strip(), uri.rsplit("/", 1))
+    tag = ''
+    if ':' in name:
+        name, tag = name.split(':')
+
+    channel = grpc.insecure_channel(addr)
+    client = modelzooserver_pb2_grpc.ModelZooServerStub(channel)
+    request = modelzooserver_pb2.ReleaseModelRequest(name=name, tag=tag)
+    stream = client.DownloadModel(request)
+    with tempfile.TemporaryFile() as f:
+        for row in stream:
+            print(row)
+            f.write(row.content_tar)
+        f.seek(0)
+        archive = tarfile.open(None, "r|gz", f)
+        archive.extractall()
+        archive.close()
+    return pickle.load(open("meta.pkl", "rb"))
+
+
+def train(statement, datasource, feature_metas, label_meta, **kwargs):
+    '''Dispatch a train `statement` to appropriate engine, return metadata to be saved'''
+    if statement.estimator.lower().startswith("xgboost"):
+        from sqlflow_submitter.xgboost.train import train
+        fc = features.get_xgb_features(feature_metas, statement.columns)
+        kwargs.update(get_xgb_kwargs(statement.attributes, statement.select))
+        train(datasource=datasource,
+              select=statement.select,
+              feature_metas=feature_metas,
+              label_meta=label_meta,
+              transform_fn=fc,
+              feature_column_names=list(feature_metas.keys()),
+              **kwargs)
+        return (fc, )
+    else:
+        from sqlflow_submitter.tensorflow.train import train
+        fc = features.get_tf_features(feature_metas, statement.columns)
+        fc_names_map = {k: [f.key for f in v] for k, v in fc.items()}
+        args, opt_args = get_tf_kwargs(statement.attributes, statement.select)
+        kwargs.update(copy.deepcopy(args))
+        construct_tf_objects(kwargs["model_params"], opt_args)
+        train(datasource=datasource,
+              estimator_string=statement.estimator,
+              select=statement.select,
+              feature_metas=feature_metas,
+              label_meta=label_meta,
+              feature_column_names=list(feature_metas.keys()),
+              feature_columns=fc,
+              save='model_save',
+              **kwargs)
+        return args['model_params'], opt_args, fc, fc_names_map
+
+
+def predict(statement, datasource, feature_metas, label_meta, *meta, **kwargs):
+    tbl_name, col_name = statement.target.rsplit('.', 1)
+    if statement.estimator.lower().startswith("xgboost"):
+        from sqlflow_submitter.xgboost.predict import pred
+        fc, = meta
+        label_meta["feature_name"] = col_name
+        pred(datasource=datasource,
+             select=statement.select,
+             feature_metas=feature_metas,
+             feature_column_names=list(feature_metas.keys()),
+             label_meta=label_meta,
+             transform_fn=fc,
+             result_table=tbl_name,
+             **kwargs)
+    else:
+        from sqlflow_submitter.tensorflow.predict import pred
+        kwargs['model_params'], opt_args, feature_columns, fc_names_map = meta
+        construct_tf_objects(kwargs['model_params'], opt_args)
+        pred(datasource=datasource,
+             estimator_string=statement.estimator,
+             select=statement.select,
+             result_table=tbl_name,
+             feature_metas=feature_metas,
+             feature_column_names_map=fc_names_map,
+             result_col_name=col_name,
+             save='model_save',
+             feature_column_names=list(feature_metas.keys()),
+             feature_columns=feature_columns,
+             **kwargs)
+
+
+def create_predict_table(conn, statement, feature_metas, label_meta):
+    tbl, col = statement.target.rsplit('.', 1)
+    cursor = conn.cursor()
+    cursor.execute(statement.select)
+    col_names = [i[0] for i in cursor.description]
+    cursor.execute(f'DROP TABLE IF EXISTS {tbl}')
+    cursor.execute(f'''CREATE TABLE {tbl} AS
+                           SELECT * FROM ({statement.select}) t LIMIT 0''')
+    old_col = label_meta["feature_name"]  # Get label name
+    if old_col != col or col not in col_names:
+        t = "INT" if label_meta["dtype"].startswith("int") else "DOUBLE"
+        cursor.execute(f'ALTER TABLE {tbl} ADD COLUMN {col} {t}')
+    conn.commit()
+
+
+def create_explain_table(conn, statement, feature_metas, label_meta):
+    if statement.target:
+        if statement.estimator.startswith('BoostedTrees'):
+            columns = 'feature VARCHAR(255), dfc FLOAT, gain FLOAT'
+        else:
+            columns = ', '.join(f"{k} FLOAT" for k in feature_metas)
+        cursor = conn.cursor()
+        cursor.execute(f'DROP TABLE IF EXISTS {statement.target}')
+        cursor.execute(f'CREATE TABLE {statement.target} ({columns})')
+        conn.commit()
+
+
+def create_evaluate_table(conn, statement):
+    if statement.target:
+        cursor = conn.cursor()
+        attr = eval_attr(statement.attributes.get('validation.metrics'))
+        metrics = attr.split(',') + ['loss'] if attr else ['loss']
+        columns = ", ".join(f"{k} VARCHAR(255)" for k in metrics)
+        cursor.execute(f'DROP TABLE IF EXISTS {statement.target}')
+        cursor.execute(f'CREATE TABLE {statement.target} ({columns})')
+        conn.commit()
+
+
+def explain(statement, datasource, feature_metas, label_meta, *meta, **kwargs):
+    if statement.estimator.lower().startswith("xgboost"):
+        from sqlflow_submitter.xgboost.explain import explain
+        fc, = meta
+        explain(
+            datasource=datasource,
+            select=statement.select,
+            feature_field_meta=feature_metas,
+            feature_column_names=list(feature_metas.keys()),
+            label_spec=label_meta,
+            transform_fn=fc,
+            summary_params={},  # TODO(shendiaomo): pass summary attributes
+            result_table=statement.target,
+            **kwargs)
+    else:
+        from sqlflow_submitter.tensorflow.explain import explain
+        kwargs['model_params'], opt_args, feature_columns, _ = meta
+        construct_tf_objects(kwargs['model_params'], opt_args)
+        explain(datasource=datasource,
+                estimator_string=statement.estimator,
+                select=statement.select,
+                feature_columns=feature_columns,
+                feature_column_names=list(feature_metas.keys()),
+                feature_metas=feature_metas,
+                save='model_save',
+                label_meta=label_meta,
+                result_table=statement.target,
+                **kwargs)
+
+
+def evaluate(statement, datasource, feature_metas, label_meta, *meta,
+             **kwargs):
+    metrics = eval_attr(statement.attributes['validation.metrics']).split(',')
+    if statement.estimator.lower().startswith("xgboost"):
+        from sqlflow_submitter.xgboost.evaluate import evaluate
+        fc, = meta
+        evaluate(datasource=datasource,
+                 select=statement.select,
+                 feature_metas=feature_metas,
+                 feature_column_names=list(feature_metas.keys()),
+                 label_meta=label_meta,
+                 validation_metrics=metrics,
+                 transform_fn=fc,
+                 result_table=statement.target,
+                 **kwargs)
+    else:
+        from sqlflow_submitter.tensorflow.evaluate import evaluate
+        kwargs['model_params'], opt_args, feature_columns, _ = meta
+        construct_tf_objects(kwargs['model_params'], opt_args)
+        evaluate(datasource=datasource,
+                 estimator_string=statement.estimator,
+                 select=statement.select,
+                 feature_columns=feature_columns,
+                 feature_column_names=list(feature_metas.keys()),
+                 feature_metas=feature_metas,
+                 save='model_save',
+                 label_meta=label_meta,
+                 validation_metrics=metrics,
+                 result_table=statement.target,
+                 **kwargs)
+
+
+def show(statement, orig_sql, feature_metas, label_meta):
+    print(json.dumps(["Model", "Train Statement"]))
+    print(json.dumps([statement.model_save, orig_sql]))
+
+
+def query(conn, select):
+    cursor = conn.cursor()
+    cursor.execute(select)
+    if cursor.description:
+        print(json.dumps([c[0] for c in cursor.description]))
+        for row in cursor.fetchall():
+            print(json.dumps(row))
+
+
+def execute(program):
+    conn = db.connect_with_data_source(program.datasource)
+    # Distribute statements in `program` to `train`, `predict` ... respectively

--- a/python/sqlflow/proto/__init__.py
+++ b/python/sqlflow/proto/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
This is based on #2432 
1. `ir.proto`: `Program` and `Statement` map concept of SQLFlow to Python and Go
2. Package `python/sqlflow/column/` defines column functions for `tensorflow` and `xgboost`
3. `python/sqlflow/features.py` extracts table column statistics and maps functions in a `COLUMN` clause to Python function calls.
4. Package `python/sqlflow/platform/` defines `train`, `predict` and other functions that encapsulate `sqlflow_submitter` for each type of SQLFlow statement. The commit only supports the `default.py` for default deployment