### PR TITLE
Add parameter name to attribute checker

### DIFF
--- a/pkg/attribute/attribute.go
+++ b/pkg/attribute/attribute.go
@@ -52,60 +52,122 @@ type Description struct {
 	Type    reflect.Type
 	Default interface{}
 	Doc     string
-	Checker func(i interface{}) error
+	Checker func(i interface{}, name string) error
 }
 
 // Int declares an attribute of int-typed in Dictionary d.
-func (d Dictionary) Int(name string, value int, doc string, checker func(int) error) Dictionary {
+func (d Dictionary) Int(name string, value int, doc string, checker func(int, string) error) Dictionary {
+	if err := checker(value, name); err != nil {
+		log.Panic(err)
+	}
+
 	d[name] = &Description{
 		Type:    Int,
 		Default: value,
 		Doc:     doc,
-		Checker: func(x interface{}) error { return checker(x.(int)) },
+		Checker: func(x interface{}, attrName string) error {
+			if v, ok := x.(int); ok {
+				return checker(v, attrName)
+			}
+			return fmt.Errorf("attribute %s should be of type int, but got type %T(%v)", attrName, x, x)
+		},
 	}
 	return d
 }
 
 // Float declares an attribute of float32-typed in Dictionary d.
-func (d Dictionary) Float(name string, value float32, doc string, checker func(float32) error) Dictionary {
+func (d Dictionary) Float(name string, value float32, doc string, checker func(float32, string) error) Dictionary {
+	if err := checker(value, name); err != nil {
+		log.Panic(err)
+	}
+
 	d[name] = &Description{
 		Type:    Float,
 		Default: value,
 		Doc:     doc,
-		Checker: func(x interface{}) error { return checker(x.(float32)) },
+		Checker: func(x interface{}, attrName string) error {
+			if v, ok := x.(float32); ok {
+				return checker(v, attrName)
+			}
+			return fmt.Errorf("attribute %s should be of type float, but got type %T(%v)", attrName, x, x)
+		},
 	}
 	return d
 }
 
 // Bool declares an attribute of bool-typed in Dictionary d.
-func (d Dictionary) Bool(name string, value bool, doc string, checker func(bool) error) Dictionary {
+func (d Dictionary) Bool(name string, value bool, doc string, checker func(bool, string) error) Dictionary {
+	if err := checker(value, name); err != nil {
+		log.Panic(err)
+	}
+
 	d[name] = &Description{
 		Type:    Bool,
 		Default: value,
 		Doc:     doc,
-		Checker: func(x interface{}) error { return checker(x.(bool)) },
+		Checker: func(x interface{}, attrName string) error {
+			if v, ok := x.(bool); ok {
+				return checker(v, attrName)
+			}
+			return fmt.Errorf("attribute %s should be of type bool, but got type %T(%v)", attrName, x, x)
+		},
 	}
 	return d
 }
 
 // String declares an attribute of string-typed in Dictionary d.
-func (d Dictionary) String(name string, value string, doc string, checker func(string) error) Dictionary {
+func (d Dictionary) String(name string, value string, doc string, checker func(string, string) error) Dictionary {
+	if err := checker(value, name); err != nil {
+		log.Panic(err)
+	}
+
 	d[name] = &Description{
 		Type:    String,
 		Default: value,
 		Doc:     doc,
-		Checker: func(x interface{}) error { return checker(x.(string)) },
+		Checker: func(x interface{}, attrName string) error {
+			if v, ok := x.(string); ok {
+				return checker(v, attrName)
+			}
+			return fmt.Errorf("attribute %s should be of type string, but got type %T(%v)", attrName, x, x)
+		},
 	}
 	return d
 }
 
 // IntList declares an attribute of []int-typed in Dictionary d.
-func (d Dictionary) IntList(name string, value []int, doc string, checker func([]int) error) Dictionary {
+func (d Dictionary) IntList(name string, value []int, doc string, checker func([]int, string) error) Dictionary {
+	if err := checker(value, name); err != nil {
+		log.Panic(err)
+	}
+
 	d[name] = &Description{
 		Type:    IntList,
 		Default: value,
 		Doc:     doc,
-		Checker: func(x interface{}) error { return checker(x.([]int)) },
+		Checker: func(x interface{}, attrName string) error {
+			if v, ok := x.([]int); ok {
+				return checker(v, attrName)
+			}
+			return fmt.Errorf("attribute %s should be of type []int, but got type %T(%v)", attrName, x, x)
+		},
+	}
+	return d
+}
+
+// Unknown declares an attribute of unknown type
+func (d Dictionary) Unknown(name string, value interface{}, doc string, checker func(interface{}, string) error) Dictionary {
+	if value != nil {
+		if err := checker(value, name); err != nil {
+			log.Panic(err)
+		}
+	}
+
+	d[name] = &Description{
+		Type:    Unknown,
+		Default: value,
+		Doc:     doc,
+		Checker: checker,
 	}
 	return d
 }
@@ -159,7 +221,7 @@ func (d Dictionary) Validate(attrs map[string]interface{}) error {
 		}
 
 		if desc.Checker != nil {
-			if err := desc.Checker(v); err != nil {
+			if err := desc.Checker(v, k); err != nil {
 				return err
 			}
 		}

--- a/pkg/attribute/checker.go
+++ b/pkg/attribute/checker.go
@@ -22,135 +22,118 @@ var equalSign = map[bool]string{true: "=", false: ""}
 // Float32RangeChecker is a helper function to generate range checkers on attributes.
 // lower/upper indicates the lower bound and upper bound of the attribute value.
 // includeLower/includeUpper indicates the inclusion of the bound.
-func Float32RangeChecker(lower, upper float32, includeLower, includeUpper bool) func(interface{}) error {
-	return func(attr interface{}) error {
+// TODO(sneaxiy): change the returned value type to be func(float32, string) error
+func Float32RangeChecker(lower, upper float32, includeLower, includeUpper bool) func(interface{}, string) error {
+	return func(attr interface{}, name string) error {
 		if f, ok := attr.(float32); ok {
-			e := Float32LowerBoundChecker(lower, includeLower)(f)
+			e := Float32LowerBoundChecker(lower, includeLower)(f, name)
 			if e == nil {
-				e = Float32UpperBoundChecker(upper, includeUpper)(f)
+				e = Float32UpperBoundChecker(upper, includeUpper)(f, name)
 			}
 			return e
 		}
-		return fmt.Errorf("expected type float32, received %T", attr)
+		return fmt.Errorf("attribute %s expected type float32, received %T", name, attr)
 	}
 }
 
 // Float32LowerBoundChecker returns a range checker that only checks the lower bound.
-func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}) error {
-	return func(attr interface{}) error {
+func Float32LowerBoundChecker(lower float32, includeLower bool) func(interface{}, string) error {
+	return func(attr interface{}, name string) error {
 		if f, ok := attr.(float32); ok {
 			if (!includeLower && f > lower) || (includeLower && f >= lower) {
 				return nil
 			}
-			return fmt.Errorf("range check %v <%v %v failed", lower, equalSign[includeLower], f)
+			return fmt.Errorf("attribute %s range check %v <%v %v failed", name, lower, equalSign[includeLower], f)
 		}
-		return fmt.Errorf("expected type float32, received %T", attr)
+		return fmt.Errorf("attribute %s expected type float32, received %T", name, attr)
 	}
 }
 
 // Float32UpperBoundChecker returns a range checker that only checks the upper bound.
-func Float32UpperBoundChecker(upper float32, includeUpper bool) func(interface{}) error {
-	return func(attr interface{}) error {
+func Float32UpperBoundChecker(upper float32, includeUpper bool) func(interface{}, string) error {
+	return func(attr interface{}, name string) error {
 		if f, ok := attr.(float32); ok {
 			if (!includeUpper && f < upper) || (includeUpper && f <= upper) {
 				return nil
 			}
-			return fmt.Errorf("range check %v >%v %v failed", upper, equalSign[includeUpper], f)
+			return fmt.Errorf("attribute %s range check %v >%v %v failed", name, upper, equalSign[includeUpper], f)
 		}
-		return fmt.Errorf("expected type float32, received %T", attr)
+		return fmt.Errorf("attribute %s expected type float32, received %T", name, attr)
 	}
 }
 
 // IntRangeChecker is a helper function to generate range checkers on attributes.
 // lower/upper indicates the lower bound and upper bound of the attribute value.
 // includeLower/includeUpper indicates the inclusion of the bound.
-func IntRangeChecker(lower, upper int, includeLower, includeUpper bool) func(interface{}) error {
-	return func(attr interface{}) error {
+func IntRangeChecker(lower, upper int, includeLower, includeUpper bool) func(interface{}, string) error {
+	return func(attr interface{}, name string) error {
 		if f, ok := attr.(int); ok {
-			e := IntLowerBoundChecker(lower, includeLower)(f)
+			e := IntLowerBoundChecker(lower, includeLower)(f, name)
 			if e == nil {
-				e = IntUpperBoundChecker(upper, includeUpper)(f)
+				e = IntUpperBoundChecker(upper, includeUpper)(f, name)
 			}
 			return e
 		}
-		return fmt.Errorf("expected type int, received %T", attr)
+		return fmt.Errorf("attribute %s expected type int, received %T", name, attr)
 	}
 }
 
 // IntLowerBoundChecker returns a range checker that only checks the lower bound.
-func IntLowerBoundChecker(lower int, includeLower bool) func(interface{}) error {
-	return func(attr interface{}) error {
+func IntLowerBoundChecker(lower int, includeLower bool) func(interface{}, string) error {
+	return func(attr interface{}, name string) error {
 		if f, ok := attr.(int); ok {
 			if f > lower || includeLower && f == lower {
 				return nil
 			}
-			return fmt.Errorf("range check %v <%v %v failed", lower, equalSign[includeLower], f)
+			return fmt.Errorf("attribute %s range check %v <%v %v failed", name, lower, equalSign[includeLower], f)
 		}
-		return fmt.Errorf("expected type int, received %T", attr)
+		return fmt.Errorf("attribute %s expected type int, received %T", name, attr)
 	}
 }
 
 // IntUpperBoundChecker returns a range checker that only checks the upper bound.
-func IntUpperBoundChecker(upper int, includeUpper bool) func(interface{}) error {
-	return func(attr interface{}) error {
+func IntUpperBoundChecker(upper int, includeUpper bool) func(interface{}, string) error {
+	return func(attr interface{}, name string) error {
 		if f, ok := attr.(int); ok {
 			if f < upper || includeUpper && f == upper {
 				return nil
 			}
-			return fmt.Errorf("range check %v >%v %v failed", upper, equalSign[includeUpper], f)
+			return fmt.Errorf("attribute %s range check %v >%v %v failed", name, upper, equalSign[includeUpper], f)
 		}
-		return fmt.Errorf("expected type int, received %T", attr)
+		return fmt.Errorf("attribute %s expected type int, received %T", name, attr)
 	}
 }
 
 // IntChoicesChecker verifies the attribute value is in a list of choices.
-func IntChoicesChecker(choices ...int) func(interface{}) error {
-	checker := func(e interface{}) error {
+func IntChoicesChecker(choices ...int) func(interface{}, string) error {
+	checker := func(e interface{}, name string) error {
 		i, ok := e.(int)
 		if !ok {
-			return fmt.Errorf("expected type int, received %T", e)
+			return fmt.Errorf("attribute %s expected type int, received %T", name, e)
 		}
-		found := false
 		for _, possibleValue := range choices {
 			if i == possibleValue {
-				found = true
-				break
+				return nil
 			}
 		}
-		if found == false {
-			return fmt.Errorf("expected value in %v, actual: %v", choices, i)
-		}
-		return nil
+		return fmt.Errorf("attribute %s expected value in %v, actual: %v", name, choices, i)
 	}
 	return checker
 }
 
 // StringChoicesChecker verifies the attribute value is in a list of choices.
-func StringChoicesChecker(choices ...string) func(interface{}) error {
-	checker := func(e interface{}) error {
+func StringChoicesChecker(choices ...string) func(interface{}, string) error {
+	checker := func(e interface{}, name string) error {
 		s, ok := e.(string)
 		if !ok {
-			return fmt.Errorf("expected type string, received %T", e)
+			return fmt.Errorf("attribute %s expected type string, received %T", name, e)
 		}
-		found := false
 		for _, possibleValue := range choices {
 			if s == possibleValue {
-				found = true
-				break
+				return nil
 			}
 		}
-		if found == false {
-			return fmt.Errorf("expected value in %v, actual: %v", choices, s)
-		}
-		return nil
-	}
-	return checker
-}
-
-// EmptyChecker returns a checker function that do **not** check the input.
-func EmptyChecker() func(interface{}) error {
-	checker := func(e interface{}) error {
-		return nil
+		return fmt.Errorf("attribute %s expected value in %v, actual: %v", name, choices, s)
 	}
 	return checker
 }

--- a/pkg/attribute/checker_test.go
+++ b/pkg/attribute/checker_test.go
@@ -21,64 +21,68 @@ import (
 
 func TestFloat32RangeChecker(t *testing.T) {
 	a := assert.New(t)
+	name := "attr_name"
 
 	checker := Float32RangeChecker(0.0, 1.0, true, true)
-	a.Error(checker(1))
-	a.Error(checker(float32(-1)))
-	a.NoError(checker(float32(0)))
-	a.NoError(checker(float32(0.5)))
-	a.NoError(checker(float32(1)))
-	a.Error(checker(float32(2)))
+	a.Error(checker(1, name))
+	a.Error(checker(float32(-1), name))
+	a.NoError(checker(float32(0), name))
+	a.NoError(checker(float32(0.5), name))
+	a.NoError(checker(float32(1), name))
+	a.Error(checker(float32(2), name))
 
 	checker2 := Float32RangeChecker(0.0, 1.0, false, false)
-	a.Error(checker(1))
-	a.Error(checker2(float32(-1)))
-	a.Error(checker2(float32(0)))
-	a.NoError(checker2(float32(0.5)))
-	a.Error(checker2(float32(1)))
-	a.Error(checker2(float32(2)))
+	a.Error(checker(1, name))
+	a.Error(checker2(float32(-1), name))
+	a.Error(checker2(float32(0), name))
+	a.NoError(checker2(float32(0.5), name))
+	a.Error(checker2(float32(1), name))
+	a.Error(checker2(float32(2), name))
 }
 
 func TestIntRangeChecker(t *testing.T) {
 	a := assert.New(t)
+	name := "attr_name"
 
 	checker := IntRangeChecker(0, 2, true, true)
-	a.Error(checker(1.0))
-	a.Error(checker(int(-1)))
-	a.NoError(checker(int(0)))
-	a.NoError(checker(int(1)))
-	a.NoError(checker(int(2)))
-	a.Error(checker(int(3)))
+	a.Error(checker(1.0, name))
+	a.Error(checker(int(-1), name))
+	a.NoError(checker(int(0), name))
+	a.NoError(checker(int(1), name))
+	a.NoError(checker(int(2), name))
+	a.Error(checker(int(3), name))
 
 	checker2 := IntRangeChecker(0, 2, false, false)
-	a.Error(checker(1.0))
-	a.Error(checker2(int(-1)))
-	a.Error(checker2(int(0)))
-	a.NoError(checker2(int(1)))
-	a.Error(checker2(int(2)))
-	a.Error(checker2(int(3)))
+	a.Error(checker(1.0, name))
+	a.Error(checker2(int(-1), name))
+	a.Error(checker2(int(0), name))
+	a.NoError(checker2(int(1), name))
+	a.Error(checker2(int(2), name))
+	a.Error(checker2(int(3), name))
 }
 
 func TestIntChoicesChecker(t *testing.T) {
 	a := assert.New(t)
+	name := "attr_name"
 
 	checker := IntChoicesChecker(0, 1, 2)
-	a.Error(checker(1.0))
-	a.Error(checker(-1))
-	a.NoError(checker(0))
-	a.NoError(checker(1))
-	a.NoError(checker(2))
-	a.Error(checker(3))
+	a.Error(checker(1.0, name))
+	a.Error(checker(-1, name))
+	a.NoError(checker(0, name))
+	a.NoError(checker(1, name))
+	a.NoError(checker(2, name))
+	a.Error(checker(3, name))
 }
 
 func TestStringChoicesChecker(t *testing.T) {
 	a := assert.New(t)
+	name := "attr_name"
 
 	checker := StringChoicesChecker("0", "1", "2")
-	a.Error(checker(1.0))
-	a.Error(checker(-1))
-	a.NoError(checker("0"))
-	a.NoError(checker("1"))
-	a.NoError(checker("2"))
-	a.Error(checker("3"))
+	a.Error(checker(1.0, name))
+	a.Error(checker(-1, name))
+	a.NoError(checker("0", name))
+	a.NoError(checker("1", name))
+	a.NoError(checker("2", name))
+	a.Error(checker("3", name))
 }

--- a/pkg/codegen/optimize/codegen.go
+++ b/pkg/codegen/optimize/codegen.go
@@ -24,27 +24,14 @@ import (
 	"text/template"
 )
 
-func checkIsPositiveInteger(i interface{}, name string) error {
-	if v, ok := i.(int); !ok || v <= 0 {
-		return fmt.Errorf("%s should be positive integer", name)
-	}
-	return nil
-}
-
 // TODO(sneaxiy): polish attribute codes
 var attributeDictionary = attribute.Dictionary{
 	"data.enable_slice": {attribute.Bool, false, "Whether to enable data slicing", nil},
 	"data.batch_size":   {attribute.Int, -1, "Batch size when training", nil},
-	"worker.num": {attribute.Int, 1, "Worker number", func(i interface{}) error {
-		return checkIsPositiveInteger(i, "worker.num")
-	}},
-	"worker.core": {attribute.Int, 8, "Worker core number", func(i interface{}) error {
-		return checkIsPositiveInteger(i, "worker.core")
-	}},
-	"worker.memory": {attribute.Int, 4096, "Worker memory", func(i interface{}) error {
-		return checkIsPositiveInteger(i, "worker.memory")
-	}},
-	"solver.*": {attribute.Unknown, nil, "Solver options", nil},
+	"worker.num":        {attribute.Int, 1, "Worker number", attribute.IntLowerBoundChecker(0, false)},
+	"worker.core":       {attribute.Int, 8, "Worker core number", attribute.IntLowerBoundChecker(0, false)},
+	"worker.memory":     {attribute.Int, 4096, "Worker memory", attribute.IntLowerBoundChecker(0, false)},
+	"solver.*":          {attribute.Unknown, nil, "Solver options", nil},
 }
 
 // InitializeAttributes initialize attributes in optimize clause IR


### PR DESCRIPTION
Add parameter `name` to attribute checker for better error message.

This PR addresses part of https://github.com/sql-machine-learning/playground/issues/42#issue-640787739