### PR TITLE
Fix PyUtilib version to fix CI failure

### DIFF
--- a/docker/ci/install-pips.bash
+++ b/docker/ci/install-pips.bash
@@ -35,5 +35,6 @@ pip install --quiet \
     scikit-learn==0.21.0 \
     sklearn2pmml==0.56.0 \
     jpmml-evaluator==0.3.1 \
+    PyUtilib==5.8.0 \
     pyomo==5.6.9
 


### PR DESCRIPTION
CI failure:
```
ImportError: Failed to import test module: sqlflow_submitter.optimize
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/pyomo/environ/__init__.py", line 69, in _import_packages
    _do_import(pname)
  File "/usr/local/lib/python3.6/dist-packages/pyomo/environ/__init__.py", line 16, in _do_import
    importlib.import_module(pkg_name)
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 941, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.6/dist-packages/pyomo/core/__init__.py", line 11, in <module>
    from pyomo.core.expr import *
  File "/usr/local/lib/python3.6/dist-packages/pyomo/core/expr/__init__.py", line 36, in <module>
    from .calculus.derivatives import differentiate
  File "/usr/local/lib/python3.6/dist-packages/pyomo/core/expr/calculus/derivatives.py", line 3, in <module>
    from pyutilib.enum import Enum
  File "/usr/local/lib/python3.6/dist-packages/pyutilib/enum/__init__.py", line 18, in <module>
    package) that supersedes this library.""")
ImportError: pyutilib.enum has been removed.
```

It may be because the latest PyUtilib package (which is a required package of Pyomo) has been updated from 5.8.0 to 6.0.0 on June 20, 2020. PyUtilib 6.0.0 has this bug when using with Pyomo. Pyomo==5.6.9 requires that PyUtilib>=5.8.0(see [here](https://github.com/Pyomo/pyomo/blob/0f305f0b41c893693e3607e153e09a9c74a26548/setup.py#L41)) but not PyUtilib==5.8.0.

This PR fixes PyUtilib version to be 5.8.0 before installing Pyomo==5.6.9 to fix this bug.