### PR TITLE
Use the same parser configuration for maxcompute and alisa.

### DIFF
--- a/pkg/parser/external/parser.go
+++ b/pkg/parser/external/parser.go
@@ -38,13 +38,11 @@ func NewParser(dialect string) (Parser, error) {
 		return newJavaParser("hive"), nil
 	case "calcite":
 		return newJavaParser("calcite"), nil
-	case "maxcompute":
+	case "maxcompute", "alisa":
 		// maxcompute is PHONY parser, java will
 		// chose odps or calcite according to which
 		// exists in classpath
 		return newJavaParser("maxcompute"), nil
-	case "alisa":
-		return newJavaParser("odps"), nil
 	default:
 		return nil, fmt.Errorf("unrecognized dialect %s", dialect)
 	}


### PR DESCRIPTION
- The data sources behind MaxCompute and Alisa are exactly the same - MaxCompute. The parser should be the same.
- While we test the SQL statement with Alisa data source in Playground, we first choose ODPS parser, if not found (that's the current situation), we will use calcite parser instead.