### PR TITLE
Polish attribute validate code

### DIFF
--- a/pkg/attribute/attribute.go
+++ b/pkg/attribute/attribute.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	errUnsupportedAttribute = "unsupported attribute %v"
-	errUnexpectedType       = `unexpected type on attribute %v. expect %s, received %[3]v(%[3]T)`
 )
 
 var (
@@ -270,14 +269,7 @@ func (d Dictionary) Validate(attrs map[string]interface{}) error {
 			}
 		}
 
-		if desc.typ != unknownType && desc.typ != reflect.TypeOf(v) {
-			// Allow implicit conversion from int to float to ease typing
-			if !(desc.typ == floatType && reflect.TypeOf(v) == intType) {
-				return fmt.Errorf(errUnexpectedType, k, desc.typ, v)
-			}
-		}
-
-		if desc.checker != nil {
+		if v != nil && desc.checker != nil {
 			if err := desc.checker(v); err != nil {
 				return err
 			}

--- a/pkg/attribute/attribute_test.go
+++ b/pkg/attribute/attribute_test.go
@@ -133,7 +133,7 @@ func TestDictionaryValidate(t *testing.T) {
 	a.NoError(tb.Validate(map[string]interface{}{"a": 1}))
 	a.EqualError(tb.Validate(map[string]interface{}{"a": -1}), "some error")
 	a.EqualError(tb.Validate(map[string]interface{}{"_a": -1}), fmt.Sprintf(errUnsupportedAttribute, "_a"))
-	a.EqualError(tb.Validate(map[string]interface{}{"a": 1.0}), fmt.Sprintf(errUnexpectedType, "a", "int", 1.))
+	a.EqualError(tb.Validate(map[string]interface{}{"a": 1.0}), "attribute a must be of type int, but got float64")
 	a.NoError(tb.Validate(map[string]interface{}{"b": float32(1.0)}))
 	a.NoError(tb.Validate(map[string]interface{}{"b": 1}))
 }


### PR DESCRIPTION
Remove float -> int type check in `Dictionary.Validate`, because it has been done [here](https://github.com/sql-machine-learning/sqlflow/blob/develop/pkg/attribute/attribute.go#L93).