### PR TITLE
Log connection error of CLI to sqlflowserver

### DIFF
--- a/cmd/sqlflow/main.go
+++ b/cmd/sqlflow/main.go
@@ -249,17 +249,24 @@ func runStmt(serverAddr string, stmt string, isTerminal bool, ds string) error {
 }
 
 func runStmtOnServer(serverAddr string, stmt string, isTerminal bool, ds string) error {
+	// render output according to environment
+	logFlags := log.Flags()
+	log.SetFlags(0)
+	defer log.SetFlags(logFlags)
+
 	if !isTerminal {
 		fmt.Println("sqlflow>", stmt)
 	}
 
 	table, err := tablewriter.Create("ascii", tablePageSize, os.Stdout)
 	if err != nil {
+		log.Println(err)
 		return err
 	}
 	// connect to sqlflow server and run sql program
 	conn, err := createRPCConn(serverAddr)
 	if err != nil {
+		log.Println(err)
 		return err
 	}
 	defer conn.Close()
@@ -269,12 +276,10 @@ func runStmtOnServer(serverAddr string, stmt string, isTerminal bool, ds string)
 	req := sqlRequest(stmt, ds)
 	stream, err := client.Run(ctx, req)
 	if err != nil {
+		log.Println(err) // log the connection failure
 		return err
 	}
-	// render output according to environment
-	logFlags := log.Flags()
-	log.SetFlags(0)
-	defer log.SetFlags(logFlags)
+
 	renderCtx := &renderContext{
 		client:     client,
 		ctx:        ctx,

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -39,7 +39,7 @@ func FetchSamples(db *database.DB, query string) (*sql.Rows, error) {
 	} else {
 		// TODO(typhoonzero): there may be complex SQL statements that contain multiple
 		// LIMIT clause, using regex replace will replace them all.
-		re.ReplaceAllStringFunc(query, func(limitClause string) string {
+		query = re.ReplaceAllStringFunc(query, func(limitClause string) string {
 			splitted := strings.SplitN(limitClause, " ", 2)
 			limitNum, _ := strconv.Atoi(splitted[1])
 			if limitNum > numSamples {

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -45,7 +45,7 @@ func FetchSamples(db *database.DB, query string) (*sql.Rows, error) {
 			if limitNum > numSamples {
 				limitNum = numSamples
 			}
-			return fmt.Sprintf("LIMIT %d", numSamples)
+			return fmt.Sprintf("LIMIT %d", limitNum)
 		})
 	}
 	return db.Query(query)


### PR DESCRIPTION
If `sqlflowserver` is crashed after CLI has been started, there would be no error printed in CLI.

Before this PR:
```
sqlflow> SELECT * xxx; // sqlflowserver is disconnected, there would be no error printed out.
sqlflow>
```

After this PR:
```
sqlflow> SELECT * xxx;
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:50051: connect: connection refused"
sqlflow>
```