### PR TITLE
Rename type ConstraintExpr into Constraint in *.y

### DIFF
--- a/pkg/ir/ir_generator.go
+++ b/pkg/ir/ir_generator.go
@@ -1096,8 +1096,8 @@ func GenerateOptimizeStmt(optimizeStmt *parser.SQLFlowSelectStmt) (*OptimizeStmt
 	constraints := make([]*OptimizeExpr, len(optimizeStmt.Constrants))
 	for i, c := range optimizeStmt.Constrants {
 		constraints[i] = &OptimizeExpr{
-			ExpressionTokens: c.Expression().ToTokens(),
-			GroupBy:          c.GroupBy(),
+			ExpressionTokens: c.ToTokens(),
+			GroupBy:          c.GroupBy,
 		}
 	}
 

--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -21,16 +21,8 @@ type Expr struct {
 type ExprList []*Expr
 
 type Constraint struct {
-	expr *Expr
-	groupby string
-}
-
-func (e *Constraint) Expression() *Expr {
-    return e.expr
-}
-
-func (e *Constraint) GroupBy() string {
-    return e.groupby
+	*Expr
+	GroupBy string
 }
 
 type ConstraintList []*Constraint
@@ -410,8 +402,8 @@ ExprList
 ;
 
 Constraint
-: expr { $$ = &Constraint{expr: $1, groupby: ""} }
-| expr GROUP BY IDENT { $$ = &Constraint{expr: $1, groupby: $4} }
+: expr { $$ = &Constraint{Expr: $1, GroupBy: ""} }
+| expr GROUP BY IDENT { $$ = &Constraint{Expr: $1, GroupBy: $4} }
 ;
 
 ConstraintList

--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -191,8 +191,8 @@ func attrsUnion(as1, as2 Attributes) Attributes {
 %type  <val> optional_using
 %type  <expr> expr funcall column
 %type  <expl> ExprList pythonlist columns
-%type  <ctexp> Constraint
-%type  <ctexpl> ConstraintList
+%type  <ctexp> constraint
+%type  <ctexpl> constraint_list
 %type  <atrs> attr
 %type  <atrs> attrs
 %type  <tbls> stringlist, identlist
@@ -320,7 +320,7 @@ run_clause
 ;
 
 optimize_clause
-: TO MAXIMIZE expr CONSTRAINT ConstraintList WITH attrs USING IDENT INTO IDENT {
+: TO MAXIMIZE expr CONSTRAINT constraint_list WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -328,14 +328,14 @@ optimize_clause
 	$$.Solver = $9;
 	$$.OptimizeInto = $11;
 }
-| TO MAXIMIZE expr CONSTRAINT ConstraintList WITH attrs INTO IDENT {
+| TO MAXIMIZE expr CONSTRAINT constraint_list WITH attrs INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
 	$$.OptimizeAttrs = $7;
 	$$.OptimizeInto = $9;
 }
-| TO MINIMIZE expr CONSTRAINT ConstraintList WITH attrs USING IDENT INTO IDENT {
+| TO MINIMIZE expr CONSTRAINT constraint_list WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -343,7 +343,7 @@ optimize_clause
 	$$.Solver = $9;
 	$$.OptimizeInto = $11;
 }
-| TO MINIMIZE expr CONSTRAINT ConstraintList WITH attrs INTO IDENT {
+| TO MINIMIZE expr CONSTRAINT constraint_list WITH attrs INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -401,14 +401,14 @@ ExprList
 | ExprList ',' expr { $$ = append($1, $3) }
 ;
 
-Constraint
+constraint
 : expr { $$ = &Constraint{Expr: $1, GroupBy: ""} }
 | expr GROUP BY IDENT { $$ = &Constraint{Expr: $1, GroupBy: $4} }
 ;
 
-ConstraintList
-: Constraint { $$ = ConstraintList{$1} }
-| ConstraintList ',' Constraint { $$ = append($1, $3) }
+constraint_list
+: constraint { $$ = ConstraintList{$1} }
+| constraint_list ',' constraint { $$ = append($1, $3) }
 ;
 
 pythonlist

--- a/pkg/parser/extended_syntax_parser.y
+++ b/pkg/parser/extended_syntax_parser.y
@@ -20,20 +20,20 @@ type Expr struct {
 
 type ExprList []*Expr
 
-type ConstraintExpr struct {
+type Constraint struct {
 	expr *Expr
 	groupby string
 }
 
-func (e *ConstraintExpr) Expression() *Expr {
+func (e *Constraint) Expression() *Expr {
     return e.expr
 }
 
-func (e *ConstraintExpr) GroupBy() string {
+func (e *Constraint) GroupBy() string {
     return e.groupby
 }
 
-type ConstraintExprList []*ConstraintExpr
+type ConstraintList []*Constraint
 
 /* construct an atomic expr */
 func atomic(typ int, val string) *Expr {
@@ -141,7 +141,7 @@ type OptimizeClause struct {
 	// Direction can be MAXIMIZE or MINIMIZE
 	Direction string
 	Objective *Expr
-	Constrants ConstraintExprList
+	Constrants ConstraintList
 	OptimizeAttrs Attributes
 	Solver string
 	OptimizeInto string
@@ -170,8 +170,8 @@ func attrsUnion(as1, as2 Attributes) Attributes {
   tbls []string
   expr *Expr
   expl ExprList
-  ctexp  *ConstraintExpr
-  ctexpl ConstraintExprList
+  ctexp  *Constraint
+  ctexpl ConstraintList
   atrs Attributes
   eslt SQLFlowSelectStmt
   slct StandardSelect
@@ -199,8 +199,8 @@ func attrsUnion(as1, as2 Attributes) Attributes {
 %type  <val> optional_using
 %type  <expr> expr funcall column
 %type  <expl> ExprList pythonlist columns
-%type  <ctexp> ConstraintExpr
-%type  <ctexpl> ConstraintExprList
+%type  <ctexp> Constraint
+%type  <ctexpl> ConstraintList
 %type  <atrs> attr
 %type  <atrs> attrs
 %type  <tbls> stringlist, identlist
@@ -328,7 +328,7 @@ run_clause
 ;
 
 optimize_clause
-: TO MAXIMIZE expr CONSTRAINT ConstraintExprList WITH attrs USING IDENT INTO IDENT {
+: TO MAXIMIZE expr CONSTRAINT ConstraintList WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -336,14 +336,14 @@ optimize_clause
 	$$.Solver = $9;
 	$$.OptimizeInto = $11;
 }
-| TO MAXIMIZE expr CONSTRAINT ConstraintExprList WITH attrs INTO IDENT {
+| TO MAXIMIZE expr CONSTRAINT ConstraintList WITH attrs INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
 	$$.OptimizeAttrs = $7;
 	$$.OptimizeInto = $9;
 }
-| TO MINIMIZE expr CONSTRAINT ConstraintExprList WITH attrs USING IDENT INTO IDENT {
+| TO MINIMIZE expr CONSTRAINT ConstraintList WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -351,7 +351,7 @@ optimize_clause
 	$$.Solver = $9;
 	$$.OptimizeInto = $11;
 }
-| TO MINIMIZE expr CONSTRAINT ConstraintExprList WITH attrs INTO IDENT {
+| TO MINIMIZE expr CONSTRAINT ConstraintList WITH attrs INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
 	$$.Constrants = $5;
@@ -409,14 +409,14 @@ ExprList
 | ExprList ',' expr { $$ = append($1, $3) }
 ;
 
-ConstraintExpr
-: expr { $$ = &ConstraintExpr{expr: $1, groupby: ""} }
-| expr GROUP BY IDENT { $$ = &ConstraintExpr{expr: $1, groupby: $4} }
+Constraint
+: expr { $$ = &Constraint{expr: $1, groupby: ""} }
+| expr GROUP BY IDENT { $$ = &Constraint{expr: $1, groupby: $4} }
 ;
 
-ConstraintExprList
-: ConstraintExpr { $$ = ConstraintExprList{$1} }
-| ConstraintExprList ',' ConstraintExpr { $$ = append($1, $3) }
+ConstraintList
+: Constraint { $$ = ConstraintList{$1} }
+| ConstraintList ',' Constraint { $$ = append($1, $3) }
 ;
 
 pythonlist

--- a/pkg/parser/extended_syntax_parser_test.go
+++ b/pkg/parser/extended_syntax_parser_test.go
@@ -245,7 +245,7 @@ INTO db.table;`
 	a.True(r.Optimize)
 	a.Equal("MAXIMIZE", r.Direction)
 	a.Equal("SUM((price - materials_cost - other_cost) * product)", r.Objective.String())
-	a.Equal("SUM(finishing * product) <= 100", r.Constrants[0].expr.String())
+	a.Equal("SUM(finishing * product) <= 100", r.Constrants[0].String())
 	a.Equal("db.table", r.OptimizeInto)
 	a.Equal("glpk", r.Solver)
 
@@ -260,7 +260,7 @@ INTO db.table;`
 	a.NoError(e)
 	a.Equal("MINIMIZE", r.Direction)
 	a.Equal("db.table", r.OptimizeInto)
-	a.Equal("product", r.Constrants[0].groupby)
+	a.Equal("product", r.Constrants[0].GroupBy)
 	a.Equal("", r.Solver)
 }
 


### PR DESCRIPTION
Also,

- in Go, there is nothing like hiding a data member but expose an "accessor" method.  If we want to expose it, expose it, don't hide it but expose an accessor.

- I made a wrong edit in a previous PR and renamed grammar rule `expr` into `Expr`.  This might have made a bad example that I see there are grammar rules `ConstraintExpr` and `ConstraintExprList`.  This PR follows the conversion to use `constraint` and `constraint_list`.  In future PR, I will correct other grammar rule naming.
