### PR TITLE
modify readMe bug

### DIFF
--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -7,10 +7,10 @@ code of SQLFlow.
 
 ## Build the DevBox Image
 
-In this directory, run the following command.
+In the root directory of this project, run the following command. 
 
 ```bash
-docker build -t sqlflow:dev .
+docker build -t sqlflow:dev -f docker/dev/Dockerfile .
 ```
 
 ## Build SQLFlow from Source Code

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -7,7 +7,7 @@ code of SQLFlow.
 
 ## Build the DevBox Image
 
-In the root directory of this project, run the following command. 
+In the root directory of this project, run the following command.
 
 ```bash
 docker build -t sqlflow:dev -f docker/dev/Dockerfile .


### PR DESCRIPTION
**First pull request test.**

>docker build -t sqlflow:dev . -> docker build -t sqlflow:dev -f docker/dev/Dockerfile .
[https://github.com/sql-machine-learning/sqlflow/blob/develop/docker/dev/README.md](url)

The documentation is imperfect. 
You need to tell the user to execute the command in the root directory and specify the location of the dockerfile.