### PR TITLE
Fix deleting previous model dir on OSS

### DIFF
--- a/pkg/executor/pai.go
+++ b/pkg/executor/pai.go
@@ -501,14 +501,6 @@ func getOSSSavedModelType(modelName string, project string) (modelType int, esti
 
 // deleteDirRecursive recursively delete a directory on the OSS
 func deleteDirRecursive(bucket *oss.Bucket, dir string) error {
-	exists, err := bucket.IsObjectExist(dir)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		// if directory not exist, just go on.
-		return nil
-	}
 	if !strings.HasSuffix(dir, "/") {
 		return fmt.Errorf("dir to delete must end with /")
 	}


### PR DESCRIPTION
Go OSS API `IsObjectExist` may return error information, removing this is fine since the below code can also detect objects not exist errors.