### PR TITLE
Remove NUMERIC column clause

### DIFF
--- a/cmd/sqlflowserver/e2e_pai_maxcompute_test.go
+++ b/cmd/sqlflowserver/e2e_pai_maxcompute_test.go
@@ -347,7 +347,7 @@ func CasePAIMaxComputeTrainDenseCol(t *testing.T) {
 FROM %s
 TO TRAIN DNNClassifier
 WITH model.hidden_units=[64,32], model.n_classes=3, train.batch_size=32
-COLUMN NUMERIC(f1, 4)
+COLUMN DENSE(f1, 4)
 LABEL class
 INTO e2etest_dense_input;`, caseTrainTable)
 	_, _, _, err := connectAndRunSQL(trainSQL)
@@ -363,7 +363,7 @@ func CasePAIMaxComputeTrainDenseColWithoutIndicatingShape(t *testing.T) {
 	trainSQL := fmt.Sprintf(`SELECT class, sepal_length, sepal_width, petal_length, petal_width
 FROM %s
 TO TRAIN DNNClassifier WITH model.hidden_units=[64,32], model.n_classes=3, train.batch_size=32
-COLUMN NUMERIC(sepal_length)
+COLUMN DENSE(sepal_length)
 LABEL class
 INTO e2etest_dense_input_without_indicating_shape;`, caseTrainTable)
 

--- a/doc/design/alps_submitter.md
+++ b/doc/design/alps_submitter.md
@@ -125,7 +125,7 @@ In SQLFlow, we use Feature Expressions to represent the feature engineering proc
 
 <b>Feature Expressions</b>
 ```
-NUMERIC(key, dtype, shape)
+DENSE(key, shape)
 
 BUCKETIZED(source_column, boundaries)
 
@@ -152,7 +152,7 @@ TO TRAIN DNNClassifier
 WITH
   ...
 COLUMN
-  CROSS([NUMERIC(c1), BUCKETIZED(NUMERIC(c2), [0, 10, 100])])
+  CROSS([DENSE(c1), BUCKETIZED(DENSE(c2), [0, 10, 100])])
 LABEL class
 
 ```
@@ -166,7 +166,7 @@ TO TRAIN DNNClassifier
 WITH
     ...
 COLUMN
-    NUMERIC(f1 * 10)
+    DENSE(f1 * 10)
 ```
 
 ### Feature Columns Code Generation
@@ -212,7 +212,7 @@ WITH
     train_spec.max_steps = 2000,
     input_fn.batch_size = 512
 COLUMN
-    CROSS([NUMERIC(c1), BUCKETIZED(NUMERIC(c2), [0, 10, 100])])
+    CROSS([DENSE(c1), BUCKETIZED(DENSE(c2), [0, 10, 100])])
 LABEL class
 ...
 ```
@@ -229,7 +229,7 @@ WITH
   dnn_feature_columns = [fc3]
   ...
 COLUMN
-  NUMERIC(f1) as fc1,
+  DENSE(f1) as fc1,
   BUCKETIZED(fc1, [0, 10, 100]) as fc2,
   CROSS([fc1, fc2, f3]) as fc3
 LABEL class

--- a/doc/design/ant_xgboost.md
+++ b/doc/design/ant_xgboost.md
@@ -52,7 +52,7 @@ WITH
   train_eval_ratio = 0.8
 COLUMN
   c1,
-  NUMERIC(c2, 10),
+  DENSE(c2, 10),
   BUCKET(c3, [0, 10, 100]),
   c4
 LABEL class

--- a/doc/design/elasticdl_on_sqlflow.md
+++ b/doc/design/elasticdl_on_sqlflow.md
@@ -20,7 +20,7 @@ WITH
   num_classes = 10
 COLUMN
   c1,
-  NUMERIC(c2, 10),
+  DENSE(c2, 10),
   BUCKET(c3, [0, 10, 100]),
   c4
 LABEL class
@@ -77,7 +77,7 @@ Steps:
 
    - In model definition function e.g. `custom_model()`, we need to configure model input and output shapes correctly in `inputs = tf.keras.layers.Input(shape=<input_shape>)` (only when the model is defined using `tf.keras` functional APIs) and `outputs = tf.keras.layers.Dense(<num_classes>)`(based on `COLUMN ... LABEL ...`). For this MVP, users can provide `<input_shape>` and `<num_classes>` using `WITH` clause which will then get passed to the model constructor `custom_model(input_shape, num_classes)` via `--params` argument in ElasticDL high-level API. In the future, this will be inferred from the ODPS table.
    - Pass additional parameters from `WITH` clause to `custom_model()`'s instantiation, such as `optimizer` and `loss`.
-   - Skip support for feature transformation functions such as `NUMERIC` or `BUCKET` in `COLUMN` clause for now as this requires additional design details and discussions on the use of feature column APIs.
+   - Skip support for feature transformation functions such as `DENSE` or `BUCKET` in `COLUMN` clause for now as this requires additional design details and discussions on the use of feature column APIs.
    - Pass column names, shapes, and types for features and labels to `dataset_fn`'s feature description that will be used in `tf.io.parse_single_example()`. For this MVP, column names can be obtained from `SELECT ... LABEL ...`. Each feature columns will be of shape `[1]` and of type `tf.float32` while label column is of shape `[1]` and of type `tf.int64` for classification problems and `tf.float32` for regression problems. In the future, this will be inferred from the ODPS table. An example `dataset_fn()` looks like the following:
 
    ```python

--- a/doc/design/train_parameters.md
+++ b/doc/design/train_parameters.md
@@ -81,7 +81,7 @@ TO TRAIN
 WITH
 	...
 COLUMN
-	NUMERIC(...) FOR linear_feature_columns
+	DENSE(...) FOR linear_feature_columns
 COLUMN
 	BUCKET(...) FOR dnn_feature_columns
 ...
@@ -113,7 +113,6 @@ represents that the `c1` field is the dense format and the `c2` field is the spa
 |------------|------------------------------------------------------------------|------------------------------------|
 | dense      | 1. field name (str) <br> 2. dense shape (list of integer) <br> 3. separator (str)  | dense(c1, [100, 200], comma)              |
 | sparse     | 1. field name (str) <br> 2. sparse shape (integer) <br> 3. separator (str) | sparse(c2, 10000, comma)           |
-| numeric    | 1. field name (str) <br> 2. shape (integer)                           | numeric(c1, 100)                   |
 | bucket     | 1. key (numeric) <br> 2. bucket size (integer)                        | bucket(numeric(c1, 100), 20)       |
 | cat_id     | 1. field name (str) <br> 2. bucket size (integer)                     | cat_id(c2, 10000)                  |
 | embedding  | 1. key (cat_id) <br> 2. dimension (integer) <br> 3. combiner (str)         | embedding(cat_id(c2, 10000), mean) |

--- a/doc/design/xgboost_feature_column.md
+++ b/doc/design/xgboost_feature_column.md
@@ -27,7 +27,7 @@ SQLFlow `COLUMN` clauses support the following listed feature columns, and they 
 
 | SQLFlow keywords | TensorFlow API                                              | Description                                                          | 
 |------------------|-------------------------------------------------------------|----------------------------------------------------------------------|
-| NUMERIC          | tf.feature_column.numeric_column                            | Raw numeric feature column without any pre-processing                | 
+| DENSE|SPARSE     | tf.feature_column.numeric_column                            | Raw numeric feature column without any pre-processing                | 
 | BUCKET           | tf.feature_column.bucketized_column                         | Transform input integer to be the bucket id divided by boundaries    |
 | CATEGORY_ID      | tf.feature_column.categorical_column_with_identity          | Identity mapping of integer feature column                           |
 | CATEGORY_HASH    | tf.feature_column.categorical_column_with_hash_bucket       | Using hash algorithm to map string or integer to category id         |

--- a/doc/design/xgboost_feature_column.md
+++ b/doc/design/xgboost_feature_column.md
@@ -27,7 +27,7 @@ SQLFlow `COLUMN` clauses support the following listed feature columns, and they 
 
 | SQLFlow keywords | TensorFlow API                                              | Description                                                          | 
 |------------------|-------------------------------------------------------------|----------------------------------------------------------------------|
-| DENSE|SPARSE     | tf.feature_column.numeric_column                            | Raw numeric feature column without any pre-processing                | 
+| DENSE            | tf.feature_column.numeric_column                            | Raw numeric feature column without any pre-processing                | 
 | BUCKET           | tf.feature_column.bucketized_column                         | Transform input integer to be the bucket id divided by boundaries    |
 | CATEGORY_ID      | tf.feature_column.categorical_column_with_identity          | Identity mapping of integer feature column                           |
 | CATEGORY_HASH    | tf.feature_column.categorical_column_with_hash_bucket       | Using hash algorithm to map string or integer to category id         |

--- a/doc/language_guide.md
+++ b/doc/language_guide.md
@@ -115,7 +115,7 @@ COLUMN column_expr [, column_expr ...]
     [COLUMN column_expr [, column_expr ...] FOR column_name ...]
 ```
 
-- *column_expr* indicates the field name and the preprocessing method on the field content. e.g. `sepal_length`, `NUMERIC(dense, 3)`. Please refer to [Feature columns](#feature-columns) for preprocessing details.
+- *column_expr* indicates the field name and the preprocessing method on the field content. e.g. `sepal_length`, `DENSE(dense, 3)`. Please refer to [Feature columns](#feature-columns) for preprocessing details.
 - *column_name* indicates the feature column names for the model inputs. Some models such as [DNNLinearCombinedClassifier](https://www.tensorflow.org/api_docs/python/tf/estimator/DNNLinearCombinedClassifier) have`linear_feature_columns` and `dnn_feature_columns` as feature column input.
 
 For example, if you want to use fields `sepal_length`, `sepal_width`, `petal_length`, and `petal_width` as the features without any pre-processing, you can write the following statement:
@@ -158,15 +158,15 @@ SQLFlow supports specifying various feature columns in the column clause and lab
  feature column type | usage | field type | example
 ---|---|---|---
  X | field | int/float/double | 3.14
- NUMERIC | NUMERIC(field, n[,delimiter]) | string/varchar[n] | "0.2,1.7,0.6"
+ DENSE | DENSE(field, n[,delimiter]) | string/varchar[n] | "0.2,1.7,0.6"
  CATEGORY_ID | CATEGORY_ID(field, n[,delimiter]) | string/varchar[n] | "66,67,42,68,48,69,70"
  SEQ_CATEGORY_ID | SEQ_CATEGORY_ID(field, n[, delimiter]) | string/varchar[n] | "20,48,80,81,82,0,0,0,0"
  EMBEDDING | EMBEDDING(category_column, dimension[, combiner]) | X | X
 
 ```text
-NUMERIC(field, n[, delimiter=comma])
+DENSE(field, n[, delimiter=comma])
 /*
-NUMERIC converts a delimiter separated string to a n dimensional Tensor
+DENSE converts a delimiter separated string to a n dimensional dense Tensor
     field:
         A string specifying the field name of the standard select result.
         e.g. dense, column1.
@@ -178,7 +178,7 @@ NUMERIC converts a delimiter separated string to a n dimensional Tensor
         default: comma.
 
 Example:
-    NUMERIC(dense, 3). "0.2,1.7,0.6" => Tensor(0.2, 1.7, 0.6)
+    DENSE(dense, 3). "0.2,1.7,0.6" => Tensor(0.2, 1.7, 0.6)
 
 Error:
     Invalid field type. field type has to be string/varchar[n]

--- a/doc/language_guide.md
+++ b/doc/language_guide.md
@@ -159,6 +159,7 @@ SQLFlow supports specifying various feature columns in the column clause and lab
 ---|---|---|---
  X | field | int/float/double | 3.14
  DENSE | DENSE(field, n[,delimiter]) | string/varchar[n] | "0.2,1.7,0.6"
+ SPARSE | SPARSE(field, n[,delimiter]) | string/varchar[n] | "3,5,7"
  CATEGORY_ID | CATEGORY_ID(field, n[,delimiter]) | string/varchar[n] | "66,67,42,68,48,69,70"
  SEQ_CATEGORY_ID | SEQ_CATEGORY_ID(field, n[, delimiter]) | string/varchar[n] | "20,48,80,81,82,0,0,0,0"
  EMBEDDING | EMBEDDING(category_column, dimension[, combiner]) | X | X
@@ -166,7 +167,7 @@ SQLFlow supports specifying various feature columns in the column clause and lab
 ```text
 DENSE(field, n[, delimiter=comma])
 /*
-DENSE converts a delimiter separated string to a n dimensional dense Tensor
+DENSE converts a delimiter separated string to a n dimensional dense tensor.
     field:
         A string specifying the field name of the standard select result.
         e.g. dense, column1.
@@ -181,14 +182,35 @@ Example:
     DENSE(dense, 3). "0.2,1.7,0.6" => Tensor(0.2, 1.7, 0.6)
 
 Error:
-    Invalid field type. field type has to be string/varchar[n]
-    Invalid dimension. e.g. convert "0.2,1.7,0.6" to dimension 2.
+    Invalid field type. Field type has to be string/varchar[n].
+    Invalid dimension. E.g. convert "0.2,1.7,0.6" to dimension 2.
 */
 
+SPARSE(field, n[, delimiter=comma])
+/*
+SPARSE converts a delimiter separated string to a n dimensional sparse tensor,
+whose values are 0 or 1. The numbers in the string are the indices where the 
+tensor values are 1.
+   field:
+       A string specifying the field name of the standard select result.
+       e.g. sparse_column, column1.
+   n:
+       An integer specifying the tensor dimension.
+       e.g. 12.
+   delimiter:
+       A string specifying the delimiter.
+       default: comma.
+
+Example:
+   SPARSE(sparse_column, 8). "3,5,7" => Tensor(0, 0, 0, 1, 0, 1, 0, 1)
+
+Error:
+   Invalid field type. Field type has to be string/varchar[n].
+*/
 
 CATEGORY_ID(field, n[, delimiter=comma])
 /*
-CATEGORY_ID splits the input field by delimiter and returns identity values
+CATEGORY_ID splits the input field by delimiter and returns identity values.
     field:
         A string specifying the field name of the standard select result.
         e.g. title, id, column1.
@@ -203,13 +225,13 @@ Example:
     CATEGORY_ID(title, 100). "1,2,3,4" => Tensor(1, 2, 3, 4)
 
 Error:
-    Invalid field type. field type has to be string/varchar[n]
+    Invalid field type. Field type has to be string/varchar[n].
 */
 
 
 SEQ_CATEGORY_ID(field, n[, delimiter=comma])
 /*
-SEQ_CATEGORY_ID splits the input field by delimiter and returns identity values
+SEQ_CATEGORY_ID splits the input field by delimiter and returns identity values.
     field:
         A string specifying the field name of the standard select result.
         e.g. title, id, column1.
@@ -224,13 +246,13 @@ Example:
     SEQ_CATEGORY_ID(title, 100). "1,2,3,4" => Tensor(1, 2, 3, 4)
 
 Error:
-    Invalid field type. field type has to be string/varchar[n]
+    Invalid field type. Field type has to be string/varchar[n].
 */
 
 
 EMBEDDING(category_column, n[, combiner])
 /*
-EMBEDDING converts a delimiter separated string to an n-dimensional Tensor
+EMBEDDING converts a delimiter separated string to an n-dimensional tensor.
     category_column:
         A category column created by CATEGORY_ID*
         e.g. CATEGORY_ID(title, 100).

--- a/pkg/ir/derivation.go
+++ b/pkg/ir/derivation.go
@@ -161,6 +161,11 @@ func fillCSVFieldDesc(cellData string, fieldDescMap FieldDescMap, fieldName stri
 		// implicit set shape if shape is not provided in SQL COLUMN clause
 		fieldDescMap[fieldName].Shape = []int{len(values)}
 	}
+
+	if fieldDescMap[fieldName].IsSparse {
+		fieldDescMap[fieldName].DType = Int // force to set sparse tensor in CSV format to be of type Int
+	}
+
 	fieldDescMap[fieldName].Delimiter = ","
 	// get dtype for csv values, use int64 and float32 only
 	for _, v := range values {

--- a/pkg/ir/derivation.go
+++ b/pkg/ir/derivation.go
@@ -162,8 +162,16 @@ func fillCSVFieldDesc(cellData string, fieldDescMap FieldDescMap, fieldName stri
 		fieldDescMap[fieldName].Shape = []int{len(values)}
 	}
 
+	// FIXME(sneaxiy): currently, we only support sparse tensor in CSV format
+	// whose values are 0 or 1. The numeric values in the cell data are the
+	// indices where the values of the sparse tensor are 1. For example, the
+	// cell value "3,5,7" indicates a sparse tensor x, and
+	// x[3] = x[5] = x[7] = 1, and the other values of x are all zeros. Since
+	// the index is always of integer type, we force to set the data type of
+	// sparse tensor in CSV format is "Int". We should remove this constraint
+	// if we will support other data formats in the future.
 	if fieldDescMap[fieldName].IsSparse {
-		fieldDescMap[fieldName].DType = Int // force to set sparse tensor in CSV format to be of type Int
+		fieldDescMap[fieldName].DType = Int
 	}
 
 	fieldDescMap[fieldName].Delimiter = ","

--- a/pkg/ir/ir_generator.go
+++ b/pkg/ir/ir_generator.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	sparse        = "SPARSE"
-	numeric       = "NUMERIC"
 	cross         = "CROSS"
 	categoryID    = "CATEGORY_ID"
 	seqCategoryID = "SEQ_CATEGORY_ID"
@@ -34,7 +33,6 @@ const (
 	embedding     = "EMBEDDING"
 	indicator     = "INDICATOR"
 	bucket        = "BUCKET"
-	square        = "SQUARE"
 	dense         = "DENSE"
 	comma         = "COMMA"
 	negative      = "-"
@@ -406,8 +404,8 @@ func generateAttributeIR(attrs *parser.Attributes) (map[string]interface{}, erro
 // 1                 ->  int(1)
 // "string"          ->  string("string")
 // [1,2,3]           ->  []int{1,2,3}
-// NUMERIC(c1)       ->  &NumericColumn{Key: "c1"...}
-// [NUMERIC(c1), c2] ->  [&NumericColumn{Key: "c1"...}, string("c2")]
+// DENSE(c1)       ->  &NumericColumn{Key: "c1"...}
+// [DENSE(c1), c2] ->  [&NumericColumn{Key: "c1"...}, string("c2")]
 //
 // parameter e could be type `*expr` or `*parser.ExprList` for recursive call.
 func parseExpression(e interface{}) (interface{}, error) {
@@ -424,7 +422,7 @@ func parseExpression(e interface{}) (interface{}, error) {
 
 	headTyp := (*el)[0].Type
 	if headTyp == parser.IDENT {
-		// expression is a function call format like `NUMERIC(c1)`
+		// expression is a function call format like `DENSE(c1)`
 		return parseFeatureColumn(el)
 	} else if headTyp == '[' {
 		// expression is a list of things
@@ -492,11 +490,11 @@ func inferStringValue(expr string) interface{} {
 func parseFeatureColumn(el *parser.ExprList) (FeatureColumn, error) {
 	head := (*el)[0].Value
 	if head == "" {
-		return nil, fmt.Errorf("column description expects format like NUMERIC(key) etc, got %v", el)
+		return nil, fmt.Errorf("column description expects format like DENSE(key) etc, got %v", el)
 	}
 
 	switch strings.ToUpper(head) {
-	case numeric:
+	case dense, sparse:
 		return parseNumericColumn(el)
 	case bucket:
 		return parseBucketColumn(el)
@@ -533,47 +531,17 @@ func parseDefaultNumericColumn(el *parser.Expr) (*NumericColumn, error) {
 }
 
 func parseNumericColumn(el *parser.ExprList) (*NumericColumn, error) {
-	help := "NUMERIC([DENSE()|SPARSE()|col_name][, SHAPE])"
-
-	// 'shape' is optional in NUMERIC, so len(*el) may be 2 or 3
-	if len(*el) != 2 && len(*el) != 3 {
-		return nil, fmt.Errorf("bad NUMERIC expression format: %s, should be like: %s", *el, help)
-	}
-
-	// 1. NUMERIC(DENSE()/SPARSE()) phrases
-	if (*el)[1].Type == 0 {
-		fieldDesc, err := parseFieldDesc(&(*el)[1].Sexp)
-		if err != nil {
-			return nil, err
-		}
-		return &NumericColumn{FieldDesc: fieldDesc}, nil
-	}
-	// 1. NUMERIC(col_name, ...) phrases
-	key, err := expression2string((*el)[1])
+	fieldDesc, err := parseFieldDesc(el)
 	if err != nil {
-		return nil, fmt.Errorf("bad NUMERIC key: %s, err: %s, should be like: %s", (*el)[1], err, help)
+		return nil, err
 	}
-
-	shape := []int{1}
-	if len(*el) == 3 {
-		shape, err = parseShape((*el)[2])
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &NumericColumn{
-		FieldDesc: &FieldDesc{
-			Name:     key,
-			DType:    Float, // default use float dtype if no DENSE()/SPARSE() provided
-			Shape:    shape,
-			IsSparse: false,
-		},
+		FieldDesc: fieldDesc,
 	}, nil
 }
 
 func parseBucketColumn(el *parser.ExprList) (*BucketColumn, error) {
-	help := "BUCKET([NUMERIC(...)|col_name], BOUNDARIES)"
+	help := "BUCKET([DENSE(...)|col_name], BOUNDARIES)"
 	if len(*el) != 3 {
 		return nil, fmt.Errorf("bad BUCKET expression format: %s, should be like: %s", *el, help)
 	}
@@ -587,15 +555,15 @@ func parseBucketColumn(el *parser.ExprList) (*BucketColumn, error) {
 	if sourceExprList.Type != 0 {
 		source, err = parseDefaultNumericColumn(sourceExprList)
 		if err != nil {
-			return nil, fmt.Errorf("key of BUCKET must be NUMERIC or column name, which is %s", sourceExprList.Value)
+			return nil, fmt.Errorf("key of BUCKET must be DENSE or column name, which is %s", sourceExprList.Value)
 		}
 	} else {
 		source, err = parseFeatureColumn(&sourceExprList.Sexp)
 		if err != nil {
-			return nil, fmt.Errorf("key of BUCKET must be NUMERIC or column name, which is %s", sourceExprList.Sexp)
+			return nil, fmt.Errorf("key of BUCKET must be DENSE or column name, which is %s", sourceExprList.Sexp)
 		}
 		if _, ok := source.(*NumericColumn); !ok {
-			return nil, fmt.Errorf("key of BUCKET must be NUMERIC or column name, which is %s", source)
+			return nil, fmt.Errorf("key of BUCKET must be DENSE or column name, which is %s", source)
 		}
 	}
 
@@ -765,19 +733,20 @@ func buildCategoryIDForEmbeddingOrIndicator(el *parser.ExprList) (CategoryColumn
 	}
 	source, err := parseFeatureColumn(&sourceExprList.Sexp)
 	if err != nil {
+		return nil, "", err
+	}
+
+	if nc, ok := source.(*NumericColumn); ok {
 		// 2. source is a FieldDesc like EMBEDDING(SPARSE(...), size)
-		fm, err := parseFieldDesc(&sourceExprList.Sexp)
-		if err != nil {
-			return nil, "", err
-		}
+		fd := nc.FieldDesc
 		// generate default CategoryIDColumn according to FieldDesc, use shape[0]
 		// as category_id_column bucket size.
-		if len(fm.Shape) < 1 {
+		if len(fd.Shape) < 1 {
 			return nil, "", fmt.Errorf("invalid FieldDesc Shape: %v", sourceExprList)
 		}
 		catColumn = &CategoryIDColumn{
-			FieldDesc:  fm,
-			BucketSize: int64(fm.Shape[0]),
+			FieldDesc:  fd,
+			BucketSize: int64(fd.Shape[0]),
 		}
 	} else {
 		// 3. source is a FeatureColumn like EMBEDDING(CATEGORY_ID(...), size)
@@ -837,74 +806,96 @@ func parseIndicatorColumn(el *parser.ExprList) (*IndicatorColumn, error) {
 }
 
 func parseFieldDesc(el *parser.ExprList) (*FieldDesc, error) {
-	help := "DENSE|SPARSE(col_name, SHAPE, DELIMITER[, DTYPE])"
-	if len(*el) != 4 && len(*el) != 5 {
-		return nil, fmt.Errorf("bad FieldDesc format: %s, should be like: %s", *el, help)
+	help := "DENSE|SPARSE(col_name[, SHAPE, DELIMITER, DTYPE])"
+
+	if len(*el) < 2 || len(*el) > 5 {
+		return nil, fmt.Errorf("bad DENSE|SPARSE format: %v, should be like: %s", *el, help)
 	}
+
 	call, err := expression2string((*el)[0])
 	if err != nil {
-		return nil, fmt.Errorf("bad FieldDesc format: %v, should be like: %s", err, help)
+		return nil, fmt.Errorf("bad DENSE|SPARSE format: %v, should be like: %s", err, help)
 	}
+
 	var isSparse bool
-	if strings.ToUpper(call) == "DENSE" {
+	head := strings.ToUpper(call)
+	if head == dense {
 		isSparse = false
-	} else if strings.ToUpper(call) == "SPARSE" {
+	} else if head == sparse {
 		isSparse = true
 	} else {
-		return nil, fmt.Errorf("bad FieldDesc: %s, should be like: %s", call, help)
+		return nil, fmt.Errorf("bad DENSE|SPARSE format: %v, should be like: %s", *el, help)
 	}
+
+	help = head + "(col_name[, SHAPE, DELIMITER, DTYPE])"
 
 	name, err := expression2string((*el)[1])
 	if err != nil {
-		return nil, fmt.Errorf("bad FieldDesc name: %s, err: %s", (*el)[1], err)
-	}
-	var shape []int
-	intShape, err := strconv.Atoi((*el)[2].Value)
-	if err != nil {
-		strShape, err := expression2string((*el)[2])
-		if err != nil {
-			return nil, fmt.Errorf("bad FieldDesc shape: %s, err: %s", (*el)[2].Value, err)
-		}
-		if strShape != "none" {
-			return nil, fmt.Errorf("bad FieldDesc shape: %s, err: %s", (*el)[2].Value, err)
-		}
-	} else {
-		shape = append(shape, intShape)
-	}
-	unresolvedDelimiter, err := expression2string((*el)[3])
-	if err != nil {
-		return nil, fmt.Errorf("bad FieldDesc delimiter: %s, err: %s", (*el)[1], err)
+		return nil, fmt.Errorf("bad %s name: %s, err: %s", head, (*el)[1], err)
 	}
 
-	delimiter, err := resolveDelimiter(unresolvedDelimiter)
-	if err != nil {
-		return nil, err
+	shape := make([]int, 0)
+	if len(*el) >= 3 {
+		shapeInterface, err := parseExpression((*el)[2])
+		if err != nil {
+			return nil, fmt.Errorf("bad %s shape: %v, err: %s", head, (*el)[2], err)
+		}
+
+		switch s := shapeInterface.(type) {
+		case int:
+			shape = append(shape, s)
+		case []interface{}:
+			for _, item := range s {
+				if intItem, ok := item.(int); ok {
+					shape = append(shape, intItem)
+				} else {
+					return nil, fmt.Errorf("bad %s shape: %v", head, (*el)[2])
+				}
+			}
+		case string:
+			if s != "none" {
+				return nil, fmt.Errorf("bad %s shape: %s", head, s)
+			}
+		default:
+			return nil, fmt.Errorf("bad %s shape: %v", head, (*el)[2])
+		}
+	}
+
+	delimiter := ""
+	if len(*el) >= 4 {
+		unresolvedDelimiter, err := expression2string((*el)[3])
+		if err != nil {
+			return nil, fmt.Errorf("bad %s delimiter: %s, err: %s", head, (*el)[1], err)
+		}
+
+		delimiter, err = resolveDelimiter(unresolvedDelimiter)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	dtype := Float
-	if isSparse {
-		dtype = Int
-	}
 	if len(*el) == 5 {
 		dtypeStr, err := expression2string((*el)[4])
 		if err != nil {
 			return nil, err
 		}
-		if dtypeStr == "float" {
+		if strings.EqualFold(dtypeStr, "float") {
 			dtype = Float
-		} else if dtypeStr == "int" {
+		} else if strings.EqualFold(dtypeStr, "int") {
 			dtype = Int
 		} else {
-			return nil, fmt.Errorf("bad FieldDesc data type %s", dtypeStr)
+			return nil, fmt.Errorf("bad %s data type %s", head, dtypeStr)
 		}
 	}
+
 	return &FieldDesc{
 		Name:      name,
 		IsSparse:  isSparse,
 		Shape:     shape,
 		DType:     dtype,
 		Delimiter: delimiter,
-		MaxID:     0}, nil
+	}, nil
 }
 
 // -------------------------- parse utilities --------------------------------------
@@ -920,10 +911,10 @@ func parseShape(e *parser.Expr) ([]int, error) {
 		if list, ok := list.([]interface{}); ok {
 			shape, err = transformToIntList(list)
 			if err != nil {
-				return nil, fmt.Errorf("bad NUMERIC shape: %s, err: %s", e.Value, err)
+				return nil, fmt.Errorf("bad shape: %s, err: %s", e.Value, err)
 			}
 		} else {
-			return nil, fmt.Errorf("bad NUMERIC shape: %s, err: %s", e.Value, err)
+			return nil, fmt.Errorf("bad shape: %s, err: %s", e.Value, err)
 		}
 	} else {
 		shape = append(shape, intVal)

--- a/pkg/ir/ir_generator_test.go
+++ b/pkg/ir/ir_generator_test.go
@@ -31,12 +31,12 @@ func TestGenerateTrainStmt(t *testing.T) {
 		train.optimizer="adam",
 		model.hidden_units=[128,64],
 		validation.select="SELECT c1, c2, c3, c4 FROM my_table LIMIT 10"
-	COLUMN c1,NUMERIC(c2, [128, 32]),CATEGORY_ID(c3, 512),
+	COLUMN c1,DENSE(c2, [128, 32]),CATEGORY_ID(c3, 512),
 		SEQ_CATEGORY_ID(c3, 512),
 		CROSS([c1,c2], 64),
-		BUCKET(NUMERIC(c1, [100]), 100),
+		BUCKET(DENSE(c1, [100]), 100),
 		EMBEDDING(CATEGORY_ID(c3, 512), 128, mean),
-		NUMERIC(DENSE(c1, 64, COMMA), [128]),
+		DENSE(c1, 64, COMMA),
 		CATEGORY_ID(SPARSE(c2, 10000, COMMA), 128),
 		SEQ_CATEGORY_ID(SPARSE(c2, 10000, COMMA), 128),
 		EMBEDDING(c1, 128, sum),
@@ -113,7 +113,7 @@ func TestGenerateTrainStmt(t *testing.T) {
 	a.Equal("c3", embInner.FieldDesc.Name)
 	a.Equal(int64(512), embInner.BucketSize)
 
-	// NUMERIC(DENSE(c1, [64], COMMA), [128])
+	// DENSE(c1, [64], COMMA), [128]
 	nc, ok = trainStmt.Features["feature_columns"][7].(*NumericColumn)
 	a.True(ok)
 	a.Equal(64, nc.FieldDesc.Shape[0])
@@ -235,15 +235,15 @@ func bucketColumnParserTestMain(bucketStr string) error {
 
 func TestBucketColumnParser(t *testing.T) {
 	a := assert.New(t)
-	a.NoError(bucketColumnParserTestMain("NUMERIC(petal_length, 1), [0, 10]"))
-	a.NoError(bucketColumnParserTestMain("NUMERIC(petal_length, 1), [-10, -5, 10]"))
+	a.NoError(bucketColumnParserTestMain("DENSE(petal_length, 1), [0, 10]"))
+	a.NoError(bucketColumnParserTestMain("DENSE(petal_length, 1), [-10, -5, 10]"))
 	a.NoError(bucketColumnParserTestMain("petal_length, [10, 20]"))
 	a.NoError(bucketColumnParserTestMain("petal_length, [-100]"))
 	a.NoError(bucketColumnParserTestMain("petal_length, [-100, -50]"))
 
-	a.Error(bucketColumnParserTestMain("NUMERIC(petal_length, 1), [10, 0]"))
-	a.Error(bucketColumnParserTestMain("NUMERIC(petal_length, 1), [-10, -10]"))
-	a.Error(bucketColumnParserTestMain("NUMERIC(petal_length, 1), [5, 5]"))
+	a.Error(bucketColumnParserTestMain("DENSE(petal_length, 1), [10, 0]"))
+	a.Error(bucketColumnParserTestMain("DENSE(petal_length, 1), [-10, -10]"))
+	a.Error(bucketColumnParserTestMain("DENSE(petal_length, 1), [5, 5]"))
 }
 
 func TestGenerateTrainStmtModelZoo(t *testing.T) {

--- a/pkg/sql/executor_ir_test.go
+++ b/pkg/sql/executor_ir_test.go
@@ -227,7 +227,7 @@ model.hidden_units = [10, 20],
 train.epoch = 200,
 train.batch_size = 10,
 train.verbose = 1
-COLUMN NUMERIC(dense, 4)
+COLUMN DENSE(dense, 4)
 LABEL class
 INTO sqlflow_models.my_dense_dnn_model;`
 		stream := RunSQLProgram(trainSQL, "", database.GetSessionFromTestingDB())


### PR DESCRIPTION
As discussed in https://github.com/sql-machine-learning/sqlflow/pull/2593 , we should remove the `NUMERIC`, and use the `DENSE/SPARSE` only.