### PR TITLE
Polish sparse vector loading design doc

### DIFF
--- a/doc/design/libsvm_format_column.md
+++ b/doc/design/libsvm_format_column.md
@@ -54,7 +54,7 @@ func InferFeatureColumns() {
 In the Python code generation, we would use the data format information inferred in the feature derivation stage.
 
 - For TensorFlow models: we would convert the data in the key-value form into `tensorflow.SparseTensor` for training, prediction, evaluating, and explaining.
-- For XGBoost models: we would dump the data in the key-value form into [LibSVM format](https://xgboost.readthedocs.io/en/latest/tutorials/input_format.html) files, and then SQLFlow would load the file as `xgboost.DMatrix` for training, prediction, evaluating, and explaining.
+- For XGBoost models: we would dump the data in the key-value form into [LibSVM format](https://xgboost.readthedocs.io/en/latest/tutorials/input_format.html) files, and then SQLFlow would load the files as `xgboost.DMatrix` for training, prediction, evaluating, and explaining.
 
 ## SQL Statement Example
 


### PR DESCRIPTION
Related to the design doc in https://github.com/sql-machine-learning/sqlflow/pull/2554 .

I polish this doc using https://grammarly.com .

TODO: we need a next PR to rename the file `libsvm_format_column.md` to be `sparse_transformer.md`.