### PR TITLE
Refine verifier.FetchSamples method

### DIFF
--- a/go/codegen/optimize/codegen.go
+++ b/go/codegen/optimize/codegen.go
@@ -281,7 +281,7 @@ func getTableDataAndGroupByIndexRanges(stmt *ir.OptimizeStmt, columns []string, 
 	}
 
 	selectStmt := fmt.Sprintf("SELECT %s FROM %s", strings.Join(columns, ","), tableName)
-	rows, err := verifier.FetchNSamples(db, selectStmt, -1)
+	rows, err := verifier.FetchSamples(db, selectStmt, -1)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,7 +330,7 @@ func tryConvertToAggregationFunction(token string) string {
 // updateOptimizeStmtByTableColumnNames updates the OptimizeStmt by the column names
 // returned by selectStmt. This function returns the column names.
 func updateOptimizeStmtByTableColumnNames(stmt *ir.OptimizeStmt, db *database.DB, selectStmt string) ([]string, error) {
-	rows, err := verifier.FetchNSamples(db, selectStmt, 1)
+	rows, err := verifier.FetchSamples(db, selectStmt, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/go/executor/pre_exec.go
+++ b/go/executor/pre_exec.go
@@ -90,7 +90,7 @@ func createPredictionResultTable(predStmt *ir.PredictStmt, db *database.DB, sess
 // getSQLFieldType is quiet like verify but accept a SQL string as input, and returns
 // an ordered list of the field types.
 func getSQLFieldType(slct string, db *database.DB) ([]string, []string, error) {
-	rows, err := verifier.FetchSamples(db, slct)
+	rows, err := verifier.FetchSamples(db, slct, 1)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/ir/derivation.go
+++ b/go/ir/derivation.go
@@ -345,7 +345,7 @@ func InferFeatureColumns(trainStmt *TrainStmt, db *database.DB) error {
 
 	// TODO(typhoonzero): find a way to using subqueries like select * from (%s) AS a LIMIT 100
 	// q := trainStmt.Select
-	rows, err := verifier.FetchSamples(db, trainStmt.Select)
+	rows, err := verifier.FetchSamples(db, trainStmt.Select, 1000)
 	if err != nil {
 		return err
 	}

--- a/go/verifier/verifier.go
+++ b/go/verifier/verifier.go
@@ -25,11 +25,11 @@ import (
 	"sqlflow.org/sqlflow/go/parser"
 )
 
-// FetchNSamples returns Rows according to the input Query.
+// FetchSamples returns Rows according to the input Query.
 // If n == 0, return nil, err
 // If n > 0, return n sample(s) at most
 // If n < 0, return all samples
-func FetchNSamples(db *database.DB, query string, n int) (*sql.Rows, error) {
+func FetchSamples(db *database.DB, query string, n int) (*sql.Rows, error) {
 	if n == 0 {
 		return nil, fmt.Errorf("cannot fetch 0 sample")
 	}
@@ -55,11 +55,6 @@ func FetchNSamples(db *database.DB, query string, n int) (*sql.Rows, error) {
 	}
 
 	return db.Query(query)
-}
-
-// FetchSamples returns Rows according to the input Query, and return 1000 samples at most.
-func FetchSamples(db *database.DB, query string) (*sql.Rows, error) {
-	return FetchNSamples(db, query, 1000)
 }
 
 // FieldTypes type records a mapping from field name to field type name.
@@ -99,7 +94,7 @@ func Decomp(ident string) (tbl string, fld string) {
 //
 // It returns a FieldTypes describing types of fields in SELECT.
 func Verify(q string, db *database.DB) (FieldTypes, error) {
-	rows, err := FetchSamples(db, q)
+	rows, err := FetchSamples(db, q, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/go/verifier/verifier_test.go
+++ b/go/verifier/verifier_test.go
@@ -91,7 +91,7 @@ func TestDescribeEmptyTables(t *testing.T) {
 	a.EqualError(e, `query SELECT * FROM iris.iris_empty LIMIT 10; gives 0 row`)
 }
 
-func TestFetchNSamples(t *testing.T) {
+func TestFetchSamples(t *testing.T) {
 	testDBType := os.Getenv("SQLFLOW_TEST_DB")
 	if testDBType != "mysql" && testDBType != "hive" {
 		t.Skip("skip when SQLFLOW_TEST_DB is not mysql or hive")
@@ -113,23 +113,27 @@ func TestFetchNSamples(t *testing.T) {
 	totalRowNum := getRowNum(totalRows)
 	assert.Greater(t, totalRowNum, 3)
 
-	rows, err := FetchNSamples(db, selectStmt, 1)
+	rows, err := FetchSamples(db, selectStmt, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, getRowNum(rows))
 
-	rows, err = FetchNSamples(db, selectStmt, -1)
+	rows, err = FetchSamples(db, selectStmt, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, totalRowNum, getRowNum(rows))
 
-	rows, err = FetchSamples(db, selectStmt+" LIMIT 1")
+	rows, err = FetchSamples(db, selectStmt+" LIMIT 1", -1)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, getRowNum(rows))
 
-	rows, err = FetchSamples(db, selectStmt+" LIMIT  \t2")
+	rows, err = FetchSamples(db, selectStmt+" LIMIT  \t2", -1)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, getRowNum(rows))
 
-	rows, err = FetchSamples(db, selectStmt+" LIMIT  3")
+	rows, err = FetchSamples(db, selectStmt+" LIMIT  3", -1)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, getRowNum(rows))
+
+	rows, err = FetchSamples(db, selectStmt+" LIMIT  2", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, getRowNum(rows))
 }


### PR DESCRIPTION
- Remove the original `verifier.FetchSamples` method.
- Rename `verifier.FetchNSamples` to be `verifier.FetchSamples`. The fetched number `n` must be provided in the new `verifier.FetchSamples` method. 