### PR TITLE
Implement runtime.sqlfs.zip APIs to compress/decompress a directory

### DIFF
--- a/python/runtime/sqlfs/__init__.py
+++ b/python/runtime/sqlfs/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from runtime.sqlfs.tar import unzip_dir, zip_dir

--- a/python/runtime/sqlfs/tar.py
+++ b/python/runtime/sqlfs/tar.py
@@ -1,0 +1,43 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" This module provides two APIs to compress and decompress a
+directory.
+"""
+import tarfile
+
+
+def zip_dir(src_dir, tarball):
+    """compress a directory into tarball
+    Args:
+        src_dir: string
+        the source directory to compress.
+
+        tarball: string
+        the output tarball name.
+    """
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(src_dir, recursive=True)
+
+
+def unzip_dir(tarball, dest_dir="./"):
+    """decompress a tarball to a directory.
+    Args:
+        tarball: string
+        the tarball to decompress.
+
+        dest_dir: string
+        the output path.
+    """
+
+    with tarfile.open(tarball, 'r:gz') as tar:
+        tar.extractall(path=dest_dir)

--- a/python/runtime/sqlfs/tar_test.py
+++ b/python/runtime/sqlfs/tar_test.py
@@ -1,0 +1,58 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from runtime.sqlfs.tar import unzip_dir, zip_dir
+
+
+class TestTarOperator(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.cur_dir = os.getcwd()
+        os.chdir(self.test_dir.name)
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+        os.chdir(self.cur_dir)
+
+    def test_tar(self):
+        # create the test file tree:
+        #
+        # |-sqlflow_tar
+        #   |-sqlflow_sub_dir
+        #     |-hello.py
+        test_dir = "sqlflow_tar"
+        test_sub_dir = "sqlflow_sub_dir"
+        test_py_file = "hello.py"
+        test_py_content = "print('hello SQLFlow!')"
+
+        fullpath = os.path.join(test_dir, test_sub_dir)
+        os.makedirs(fullpath)
+        with open(os.path.join(fullpath, test_py_file), "w") as f:
+            f.write(test_py_content)
+
+        zip_dir(fullpath, "sqlflow.tar.gz")
+        unzip_dir("sqlflow.tar.gz", "output")
+        self.assertTrue(os.path.isdir("output/sqlflow_tar/sqlflow_sub_dir"))
+        self.assertTrue(
+            os.path.isfile("output/sqlflow_tar/sqlflow_sub_dir/hello.py"))
+        with open(os.path.join(fullpath, test_py_file), "r") as f:
+            self.assertEqual(f.read(), test_py_content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/runtime/sqlfs/tar_test.py
+++ b/python/runtime/sqlfs/tar_test.py
@@ -16,7 +16,7 @@ import shutil
 import tempfile
 import unittest
 
-from runtime.sqlfs.tar import unzip_dir, zip_dir
+from runtime.sqlfs import unzip_dir, zip_dir
 
 
 class TestTarOperator(unittest.TestCase):


### PR DESCRIPTION
As the title description, implement `runtime.sqlfs.zip_dir/unzip_dir` compress directory, this feature is needed to save the model using Sqlfs.

TODO: implement sqlfs API.
 