### PR TITLE
Add selected_columns_and_types method

### DIFF
--- a/python/runtime/db.py
+++ b/python/runtime/db.py
@@ -192,29 +192,102 @@ def read_feature(raw_val, feature_spec, feature_name):
         return raw_val,
 
 
-def selected_cols(conn, select):
+INT64_TYPE = long if six.PY2 else int
+LIMIT_PATTERN = re.compile("LIMIT\\s+[0-9]+", flags=re.I)
+BLANK_PATTERN = re.compile("\\s+")
+
+
+def limit_select(select, n):
+    """Make the select SQL statement with limited row number to query.
+
+    Args:
+        select (str): the select SQL statement.
+        n (int): the limited row number to query.
+
+    Returns:
+        If n >= 0, return a new SQL statement which would query n row(s) at most.
+        If n < 0, return the original SQL statement.
+    """
+    if n < 0:
+        return select
+
+    def replace_limit_num(limit_str):
+        num = INT64_TYPE(BLANK_PATTERN.split(limit_str)[1])
+        if num > n:
+            return "LIMIT {}".format(n)
+        else:
+            return limit_str
+
+    if LIMIT_PATTERN.match(select) is None:
+        return select + " LIMIT {}".format(n)
+    else:
+        return LIMIT_PATTERN.sub(repl=replace_limit_num, string=select)
+
+
+MYSQL_DATA_TYPE_DICT = {
+    1: "TINYINT",
+    3: "INT",
+    4: "FLOAT",
+    5: "DOUBLE",
+    8: "BIGINT",
+    246: "DECIMAL",
+    252: "TEXT",
+    253: "VARCHAR",
+    254: "CHAR",
+}
+
+
+def selected_columns_and_types(conn, select):
+    """Get the columns and types returned by the select statement.
+
+    Args:
+        conn: the connection object.
+        select (str): the select SQL statement.
+
+    Returns:
+        A tuple whose each element is (column_name, column_type).
+    """
     select = select.strip().rstrip(";")
-    limited = re.findall("LIMIT [0-9]*$", select.upper())
-    if not limited:
-        select += " LIMIT 1"
+    select = limit_select(select, 1)
 
     driver = conn.driver
+    if driver == "mysql":
+        cursor = conn.cursor()
+        cursor.execute(select)
+        try:
+            name_and_type = []
+            for desc in cursor.description:
+                # NOTE: MySQL returns an integer number instead of a string
+                # to represent the data type.
+                typ = MYSQL_DATA_TYPE_DICT.get(desc[1])
+                if typ is None:
+                    raise ValueError(
+                        "unsupported data type of column {}".format(desc[0]))
+                name_and_type.append((desc[0], typ))
+            return name_and_type
+        finally:
+            cursor.close()
+
     if driver == "hive":
         cursor = conn.cursor(configuration=conn.session_cfg)
         cursor.execute(select)
-        field_names = None if cursor.description is None \
-            else [i[0][i[0].find('.') + 1:] for i in cursor.description]
+        name_and_type = []
+        for desc in cursor.description:
+            name = desc[0].split('.')[-1]
+            name_and_type.append((name, desc[1]))
         cursor.close()
-    elif driver == "maxcompute":
+        return name_and_type
+
+    if driver == "maxcompute":
         from runtime.maxcompute import MaxCompute
-        field_names = MaxCompute.selected_cols(conn, select)
-    else:
-        cursor = conn.cursor()
-        cursor.execute(select)
-        field_names = None if cursor.description is None \
-            else [i[0] for i in cursor.description]
-        cursor.close()
-    return field_names
+        return MaxCompute.selected_columns_and_types(conn, select)
+
+    raise NotImplementedError("unsupported driver {}".format(driver))
+
+
+def selected_cols(conn, select):
+    name_and_type = selected_columns_and_types(conn, select)
+    return [item[0] for item in name_and_type]
 
 
 def pai_selected_cols(table):
@@ -381,24 +454,19 @@ def get_table_schema(conn, table):
     Returns:
         Tuple of (field_name, field_type) tuples
     """
-    statement = "describe %s" % table
     if conn.driver == "maxcompute":
-        compress = tunnel.CompressOption.CompressAlgorithm.ODPS_ZLIB
-        inst = conn.execute_sql(statement)
-        if not inst.is_successful():
-            return None
-        fields = []
-        with inst.open_reader(tunnel=True, compress_option=compress) as reader:
-            for row in reader[0:reader.count]:
-                fields.append((row[0], row[1]))
-        return fields
+        schema = conn.get_table(table).schema
+        names_and_types = [(c.name, str(c.type).upper())
+                           for c in schema.columns]
+        return names_and_types
     else:
+        statement = "describe %s" % table
         cursor = conn.cursor()
         cursor.execute(statement)
         fields = []
         for field in cursor:
             # add field name and type
-            fields.append((field[0], field[1]))
+            fields.append((field[0], field[1].upper()))
         cursor.close()
     return fields
 

--- a/python/runtime/db.py
+++ b/python/runtime/db.py
@@ -192,9 +192,7 @@ def read_feature(raw_val, feature_spec, feature_name):
         return raw_val,
 
 
-INT64_TYPE = long if six.PY2 else int
-LIMIT_PATTERN = re.compile("LIMIT\\s+[0-9]+", flags=re.I)
-BLANK_PATTERN = re.compile("\\s+")
+LIMIT_PATTERN = re.compile("LIMIT\\s+([0-9]+)", flags=re.I)
 
 
 def limit_select(select, n):
@@ -211,14 +209,11 @@ def limit_select(select, n):
     if n < 0:
         return select
 
-    def replace_limit_num(limit_str):
-        num = INT64_TYPE(BLANK_PATTERN.split(limit_str)[1])
-        if num > n:
-            return "LIMIT {}".format(n)
-        else:
-            return limit_str
+    def replace_limit_num(matched_limit):
+        num = int(matched_limit.group(1))
+        return "LIMIT {}".format(min(num, n))
 
-    if LIMIT_PATTERN.match(select) is None:
+    if LIMIT_PATTERN.search(select) is None:
         return select + " LIMIT {}".format(n)
     else:
         return LIMIT_PATTERN.sub(repl=replace_limit_num, string=select)

--- a/python/runtime/db_test.py
+++ b/python/runtime/db_test.py
@@ -363,7 +363,7 @@ class TestGetTableSchema(TestCase):
 
             schema = selected_columns_and_types(
                 conn,
-                "SELECT sepal_length, petal_width * 2.3 new_petal_width, class FROM iris.train"
+                "SELECT sepal_length, petal_width * 2.3 AS new_petal_width, class FROM iris.train"
             )
             expect = [
                 ("sepal_length", "FLOAT"),

--- a/python/runtime/db_test.py
+++ b/python/runtime/db_test.py
@@ -357,7 +357,7 @@ class TestGetTableSchema(TestCase):
                 ('sepal_width', 'FLOAT'),
                 ('petal_length', 'FLOAT'),
                 ('petal_width', 'FLOAT'),
-                ('class', 'INT(11)'),
+                ('class', 'INT'),
             )
             self.assertTrue(np.array_equal(expect, schema))
 
@@ -367,7 +367,7 @@ class TestGetTableSchema(TestCase):
             )
             expect = [
                 ("sepal_length", "FLOAT"),
-                ("new_petal_width", "DOUBLE"),
+                ("new_petal_width", "FLOAT"),
                 ("class", "INT"),
             ]
             self.assertTrue(np.array_equal(expect, schema))

--- a/python/runtime/db_test.py
+++ b/python/runtime/db_test.py
@@ -379,7 +379,7 @@ class TestGetTableSchema(TestCase):
             addr = "maxcompute://%s:%s@%s" % (AK, SK, endpoint)
             case_db = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_PROJECT")
             conn = connect_with_data_source(addr)
-            table = "%s.sqlflow_test_iris_train_2" % case_db
+            table = "%s.sqlflow_test_iris_train" % case_db
             schema = get_table_schema(conn, table)
             expect = [
                 ('sepal_length', 'DOUBLE'),

--- a/scripts/test/maxcompute.sh
+++ b/scripts/test/maxcompute.sh
@@ -52,6 +52,8 @@ if [ -f profile.out ]; then
     rm profile.out
 fi
 
+python -m unittest discover -v python "db_test.py"
+
 # TODO(shendiaomo): fix CI after the PAI service initiated in the MaxCompute
 # project.
 # export SQLFLOW_submitter=pai


### PR DESCRIPTION
The method `selected_columns_and_types` would be used by the `verifier` module in the Python side after refactory.