### PR TITLE
Unify python datasource codes

### DIFF
--- a/python/runtime/alps/train_test.py
+++ b/python/runtime/alps/train_test.py
@@ -16,13 +16,15 @@ import subprocess
 import unittest
 from unittest import TestCase
 
+import runtime.testing as testing
+
 
 class TestALPSTrain(TestCase):
     '''NOTE: we must test tensorflow training and predicting in separated processes, or
     TensorFlow will raise error "Graph is finalized.'''
+    @unittest.skipUnless(testing.get_submitter() == "alps",
+                         "skip non alps tests")
     def test_train(self):
-        if os.getenv("SQLFLOW_submitter") != "alps":
-            return
         try:
             # should run this test under directory $GOPATH/sqlflow.org/sqlflow
             ret = subprocess.run([

--- a/python/runtime/db_test.py
+++ b/python/runtime/db_test.py
@@ -16,28 +16,13 @@ import unittest
 from unittest import TestCase
 
 import numpy as np
-import tensorflow as tf
+import runtime.testing as testing
 from odps import ODPS, tunnel
 from runtime.db import (MYSQL_FIELD_TYPE_DICT, buffered_db_writer, connect,
                         connect_with_data_source, db_generator,
                         get_table_schema, limit_select, parseHiveDSN,
                         parseMaxComputeDSN, parseMySQLDSN, read_feature,
                         read_features_from_row, selected_columns_and_types)
-
-
-def testing_mysql_cfg():
-    user = os.environ.get('SQLFLOW_TEST_DB_MYSQL_USER') or "root"
-    password = os.environ.get('SQLFLOW_TEST_DB_MYSQL_PASSWD') or "root"
-    addr = os.environ.get('SQLFLOW_TEST_DB_MYSQL_ADDR') or "127.0.0.1:3306"
-    host, port = addr.split(":")
-    database = "iris"
-    return (user, password, host, port, database)
-
-
-def testing_mysql_db_url():
-    user, password, host, port, database = testing_mysql_cfg()
-    return "mysql://{0}:{1}@tcp({2}:{3})/{4}?maxAllowedPacket=0".format(
-        user, password, host, port, database)
 
 
 def _execute_maxcompute(conn, statement):
@@ -81,47 +66,47 @@ class TestDB(TestCase):
     select_statement = "select * from test_db"
     drop_statement = "drop table if exists test_db"
 
+    @unittest.skipUnless(testing.get_driver() == "mysql",
+                         "skip non mysql tests")
     def test_mysql(self):
-        driver = os.environ.get('SQLFLOW_TEST_DB')
-        if driver == "mysql":
-            user, password, host, port, database = testing_mysql_cfg()
-            conn = connect(driver,
-                           database,
-                           user=user,
-                           password=password,
-                           host=host,
-                           port=port)
-            self._do_test(driver, conn)
+        driver = testing.get_driver()
+        user, password, host, port, database, _ = parseMySQLDSN(
+            testing.get_mysql_dsn())
+        conn = connect(driver,
+                       database,
+                       user=user,
+                       password=password,
+                       host=host,
+                       port=port)
+        self._do_test(driver, conn)
+        conn.close()
 
-            conn = connect_with_data_source(testing_mysql_db_url())
-            self._do_test(driver, conn)
+        conn = testing.get_singleton_db_connection()
+        self._do_test(driver, conn)
 
+    @unittest.skipUnless(testing.get_driver() == "hive", "skip non hive tests")
     def test_hive(self):
-        driver = os.environ.get('SQLFLOW_TEST_DB')
-        if driver == "hive":
-            host = "127.0.0.1"
-            port = "10000"
-            conn = connect(driver,
-                           "iris",
-                           user="root",
-                           password="root",
-                           host=host,
-                           port=port)
-            self._do_test(driver,
-                          conn,
-                          hdfs_namenode_addr="127.0.0.1:8020",
-                          hive_location="/sqlflow")
-            conn.close()
+        driver = testing.get_driver()
+        user, password, host, port, database, _ = parseMySQLDSN(
+            testing.get_hive_dsn())
+        conn = connect(driver,
+                       database,
+                       user=user,
+                       password=password,
+                       host=host,
+                       port=port)
+        self._do_test(driver,
+                      conn,
+                      hdfs_namenode_addr="127.0.0.1:8020",
+                      hive_location="/sqlflow")
+        conn.close()
 
-            conn = connect_with_data_source(
-                "hive://root:root@127.0.0.1:10000/iris")
-            self._do_test(driver, conn)
-            self._do_test_hive_specified_db(
-                driver,
-                conn,
-                hdfs_namenode_addr="127.0.0.1:8020",
-                hive_location="/sqlflow")
-            conn.close()
+        conn = testing.get_singleton_db_connection()
+        self._do_test(driver, conn)
+        self._do_test_hive_specified_db(driver,
+                                        conn,
+                                        hdfs_namenode_addr="127.0.0.1:8020",
+                                        hive_location="/sqlflow")
 
     def _do_test_hive_specified_db(self,
                                    driver,
@@ -192,80 +177,56 @@ class TestGenerator(TestCase):
     drop_statement = "drop table if exists test_table_float_fea"
     insert_statement = "insert into test_table_float_fea (features,label) values(1.0, 0), (2.0, 1)"
 
+    @unittest.skipUnless(testing.get_driver() == "mysql",
+                         "skip non mysql tests")
     def test_generator(self):
-        driver = os.environ.get('SQLFLOW_TEST_DB')
-        if driver == "mysql":
-            database = "iris"
-            user, password, host, port, database = testing_mysql_cfg()
-            conn = connect(driver,
-                           database,
-                           user=user,
-                           password=password,
-                           host=host,
-                           port=int(port))
-            # prepare test data
-            execute(driver, conn, self.drop_statement)
-            execute(driver, conn, self.create_statement)
-            execute(driver, conn, self.insert_statement)
+        driver = testing.get_driver()
+        user, password, host, port, database, _ = parseMySQLDSN(
+            testing.get_mysql_dsn())
+        conn = connect(driver,
+                       database,
+                       user=user,
+                       password=password,
+                       host=host,
+                       port=int(port))
+        # prepare test data
+        execute(driver, conn, self.drop_statement)
+        execute(driver, conn, self.create_statement)
+        execute(driver, conn, self.insert_statement)
 
-            column_name_to_type = {
-                "features": {
-                    "feature_name": "features",
-                    "delimiter": "",
-                    "dtype": "float32",
-                    "is_sparse": False,
-                    "shape": []
-                }
+        column_name_to_type = {
+            "features": {
+                "feature_name": "features",
+                "delimiter": "",
+                "dtype": "float32",
+                "is_sparse": False,
+                "shape": []
             }
-            label_meta = {
-                "feature_name": "label",
-                "shape": [],
-                "delimiter": ""
-            }
-            gen = db_generator(conn, "SELECT * FROM test_table_float_fea",
-                               label_meta)
-            idx = 0
-            for row, label in gen():
-                features = read_features_from_row(row, ["features"],
-                                                  ["features"],
-                                                  column_name_to_type)
-                d = (features, label)
-                if idx == 0:
-                    self.assertEqual(d, (((1.0, ), ), 0))
-                elif idx == 1:
-                    self.assertEqual(d, (((2.0, ), ), 1))
-                idx += 1
-            self.assertEqual(idx, 2)
+        }
+        label_meta = {"feature_name": "label", "shape": [], "delimiter": ""}
+        gen = db_generator(conn, "SELECT * FROM test_table_float_fea",
+                           label_meta)
+        idx = 0
+        for row, label in gen():
+            features = read_features_from_row(row, ["features"], ["features"],
+                                              column_name_to_type)
+            d = (features, label)
+            if idx == 0:
+                self.assertEqual(d, (((1.0, ), ), 0))
+            elif idx == 1:
+                self.assertEqual(d, (((2.0, ), ), 1))
+            idx += 1
+        self.assertEqual(idx, 2)
 
+    @unittest.skipUnless(testing.get_driver() == "mysql",
+                         "skip non mysql tests")
     def test_generate_fetch_size(self):
-        driver = os.environ.get('SQLFLOW_TEST_DB')
-        if driver == "mysql":
-            user, password, host, port, database = testing_mysql_cfg()
-            conn = connect(driver,
-                           database,
-                           user=user,
-                           password=password,
-                           host=host,
-                           port=port)
-            column_name_to_type = {
-                "sepal_length": {
-                    "feature_name": "sepal_length",
-                    "delimiter": "",
-                    "dtype": "float32",
-                    "is_sparse": False,
-                    "shape": []
-                }
-            }
-            label_meta = {
-                "feature_name": "label",
-                "shape": [],
-                "delimiter": ""
-            }
-            gen = db_generator(conn,
-                               'SELECT * FROM iris.train limit 10',
-                               label_meta,
-                               fetch_size=4)
-            self.assertEqual(len([g for g in gen()]), 10)
+        label_meta = {"feature_name": "label", "shape": [], "delimiter": ""}
+        gen = db_generator(testing.get_singleton_db_connection(),
+                           'SELECT * FROM iris.train limit 10',
+                           label_meta,
+                           fetch_size=4)
+        self.assertEqual(len([g for g in gen()]), 10)
 
 
 class TestConnectWithDataSource(TestCase):
@@ -324,10 +285,9 @@ class TestConnectWithDataSource(TestCase):
 
 class TestGetTableSchema(TestCase):
     def test_get_table_schema(self):
-        if os.getenv("SQLFLOW_TEST_DB") == "mysql":
-            addr = os.getenv("SQLFLOW_TEST_DB_MYSQL_ADDR", "localhost:3306")
-            conn = connect_with_data_source(
-                "mysql://root:root@tcp(%s)/?maxAllowedPacket=0" % addr)
+        driver = testing.get_driver()
+        conn = testing.get_singleton_db_connection()
+        if driver == "mysql":
             schema = get_table_schema(conn, "iris.train")
             expect = (
                 ('sepal_length', 'FLOAT'),
@@ -348,10 +308,7 @@ class TestGetTableSchema(TestCase):
                 ("class", "INT"),
             ]
             self.assertTrue(np.array_equal(expect, schema))
-            conn.close()
-        elif os.getenv("SQLFLOW_TEST_DB") == "hive":
-            addr = "hive://root:root@127.0.0.1:10000/iris?auth=NOSASL"
-            conn = connect_with_data_source(addr)
+        elif driver == "hive":
             schema = get_table_schema(conn, "iris.train")
             expect = (
                 ('sepal_length', 'FLOAT'),
@@ -372,14 +329,8 @@ class TestGetTableSchema(TestCase):
                 ("class", "INT"),
             ]
             self.assertTrue(np.array_equal(expect, schema))
-            conn.close()
-        elif os.getenv("SQLFLOW_TEST_DB") == "maxcompute":
-            AK = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_AK")
-            SK = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_SK")
-            endpoint = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_ENDPOINT")
-            addr = "maxcompute://%s:%s@%s" % (AK, SK, endpoint)
+        elif driver == "maxcompute":
             case_db = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_PROJECT")
-            conn = connect_with_data_source(addr)
             table = "%s.sqlflow_test_iris_train" % case_db
             schema = get_table_schema(conn, table)
             expect = [

--- a/python/runtime/db_test.py
+++ b/python/runtime/db_test.py
@@ -87,7 +87,7 @@ class TestDB(TestCase):
     @unittest.skipUnless(testing.get_driver() == "hive", "skip non hive tests")
     def test_hive(self):
         driver = testing.get_driver()
-        user, password, host, port, database, _ = parseMySQLDSN(
+        user, password, host, port, database, _, _ = parseHiveDSN(
             testing.get_hive_dsn())
         conn = connect(driver,
                        database,

--- a/python/runtime/local/xgboost/train_test.py
+++ b/python/runtime/local/xgboost/train_test.py
@@ -16,7 +16,7 @@ import tempfile
 import unittest
 from unittest import TestCase
 
-from runtime.db_test import testing_mysql_db_url
+import runtime.testing as testing
 from runtime.local.xgboost import train
 from runtime.xgboost.dataset import xgb_dataset
 
@@ -64,13 +64,10 @@ label_meta = {
 
 
 class TestXGBoostTrain(TestCase):
+    @unittest.skipUnless(testing.get_driver() == "mysql",
+                         "skip non mysql tests")
     def test_train(self):
-        driver = os.environ.get('SQLFLOW_TEST_DB')
-        if driver != "mysql":
-            print("Skipping mysql tests")
-            return
-
-        ds = testing_mysql_db_url()
+        ds = testing.get_datasource()
         select = "SELECT * FROM iris.train"
         val_select = "SELECT * FROM iris.test"
         feature_column_names = [

--- a/python/runtime/pai/submitter_test.py
+++ b/python/runtime/pai/submitter_test.py
@@ -11,12 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import os
 import unittest
 from unittest import TestCase
 
-import tensorflow as tf
+import runtime.testing as testing
 from runtime.pai import submitter
 from runtime.pai.cluster_conf import get_cluster_config
 
@@ -71,20 +70,9 @@ class SubmitterTestCase(TestCase):
 
 
 class SubmitPAITrainTask(TestCase):
-    def setUp(self):
-        self.db_type = os.getenv("SQLFLOW_TEST_DB")
-        self.submitter = os.getenv("SQLFLOW_submitter")
-        self.AK = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_AK")
-        self.SK = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_SK")
-        self.endpoint = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_ENDPOINT")
-        self.datasource = "maxcompute://%s:%s@%s" % (self.AK, self.SK,
-                                                     self.endpoint)
-        if self.db_type != "maxcompute" or self.submitter != "pai":
-            self.skipTest("Not on PAI, skip.")
-        if any(i == None
-               for i in [self.AK, self.SK, self.endpoint, self.datasource]):
-            self.fail("Invalid config.")
-
+    @unittest.skipUnless(testing.get_driver() == "maxcompute"
+                         and testing.get_submitter() == "pai",
+                         "skip non PAI tests")
     def test_submit_pai_train_task(self):
 
         feature_column_names = [
@@ -160,7 +148,7 @@ class SubmitPAITrainTask(TestCase):
         feature_columns = eval(feature_columns_code)
 
         submitter.submit_pai_tf_train(
-            self.datasource,
+            testing.get_datasource(),
             "DNNClassifier",
             "SELECT * FROM alifin_jtest_dev.sqlflow_iris_train",
             "",

--- a/python/runtime/tensorflow/estimator_example.py
+++ b/python/runtime/tensorflow/estimator_example.py
@@ -14,13 +14,12 @@
 # NOTE: this file is used by train_predict_test.py, do **NOT** delete!
 import shutil
 
-import runtime
+import runtime.testing as testing
 import tensorflow as tf
-from runtime.db_test import testing_mysql_db_url
 from runtime.tensorflow.predict import pred
 from runtime.tensorflow.train import train
 
-datasource = testing_mysql_db_url()
+datasource = testing.get_datasource()
 select = "SELECT * FROM iris.train;"
 validate_select = "SELECT * FROM iris.test;"
 select_binary = "SELECT * FROM iris.train WHERE class!=2;"

--- a/python/runtime/testing.py
+++ b/python/runtime/testing.py
@@ -1,0 +1,108 @@
+# Copyright 2020 The SQLFlow Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import runtime.db as db
+
+
+def get_driver():
+    return os.getenv("SQLFLOW_TEST_DB")
+
+
+def get_submitter():
+    return os.getenv("SQLFLOW_submitter")
+
+
+def get_mysql_dsn():
+    usr = os.getenv("SQLFLOW_TEST_DB_MYSQL_USER", "root")
+    pwd = os.getenv("SQLFLOW_TEST_DB_MYSQL_PASSWD", "root")
+    net = os.getenv("SQLFLOW_TEST_DB_MYSQL_NET", "tcp")
+    addr = os.getenv("SQLFLOW_TEST_DB_MYSQL_ADDR", "127.0.0.1:3306")
+    return "%s:%s@%s(%s)/iris?maxAllowedPacket=0" % (usr, pwd, net, addr)
+
+
+def get_hive_dsn():
+    return "root:root@localhost:10000/iris"
+
+
+def get_maxcompute_dsn():
+    ak = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_AK")
+    if not ak:
+        raise ValueError("SQLFLOW_TEST_DB_MAXCOMPUTE_AK must be set")
+
+    sk = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_SK")
+    if not sk:
+        raise ValueError("SQLFLOW_TEST_DB_MAXCOMPUTE_SK must be set")
+
+    project = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_PROJECT")
+    if not project:
+        raise ValueError("SQLFLOW_TEST_DB_MAXCOMPUTE_PROJECT must be set")
+
+    endpoint = os.getenv("SQLFLOW_TEST_DB_MAXCOMPUTE_ENDPOINT",
+                         "http://service-maxcompute.com/api")
+
+    scheme = None
+    if endpoint.startswith("http://"):
+        scheme = "http"
+        endpoint = endpoint[len(scheme) + 2]
+    elif endpoint.startswith("https://"):
+        scheme = "https"
+
+    if scheme:
+        endpoint = endpoint[len(scheme) + 2:]
+
+    params = {}
+    idx = endpoint.find("?")
+    if idx >= 0:
+        for item in endpoint[idx + 1:].split("&"):
+            k, v = item.split("=")
+            params[k] = v
+
+        endpoint = endpoint[0:idx]
+
+    if scheme and 'scheme' not in params:
+        params['scheme'] = scheme
+
+    params["curr_project"] = project
+    params_str = ""
+    if params:
+        params_str = "&".join(["%s=%s" % (k, v) for k, v in params.items()])
+        params_str = "?" + params_str
+
+    return "%s:%s@%s%s" % (ak, sk, endpoint, params_str)
+
+
+def get_datasource():
+    driver = get_driver()
+    if driver == "mysql":
+        dsn = get_mysql_dsn()
+    elif driver == "hive":
+        dsn = get_hive_dsn()
+    elif driver == "maxcompute":
+        dsn = get_maxcompute_dsn()
+    else:
+        raise ValueError("unsupported driver %s" % driver)
+
+    return driver + "://" + dsn
+
+
+SINGLETON_DB_CONNECTION = None
+
+
+def get_singleton_db_connection():
+    global SINGLETON_DB_CONNECTION
+    if SINGLETON_DB_CONNECTION is None:
+        SINGLETON_DB_CONNECTION = db.connect_with_data_source(get_datasource())
+
+    return SINGLETON_DB_CONNECTION

--- a/python/runtime/testing.py
+++ b/python/runtime/testing.py
@@ -55,12 +55,11 @@ def get_maxcompute_dsn():
     scheme = None
     if endpoint.startswith("http://"):
         scheme = "http"
-        endpoint = endpoint[len(scheme) + 2]
     elif endpoint.startswith("https://"):
         scheme = "https"
 
     if scheme:
-        endpoint = endpoint[len(scheme) + 2:]
+        endpoint = endpoint[len(scheme) + 3:]
 
     params = {}
     idx = endpoint.find("?")

--- a/python/runtime/xgboost/explain_test.py
+++ b/python/runtime/xgboost/explain_test.py
@@ -16,12 +16,11 @@ import unittest
 from unittest import TestCase
 
 import numpy as np
-from runtime.db_test import testing_mysql_db_url
-from runtime.xgboost.explain import explain as xgb_explain
+import runtime.testing as testing
 from runtime.xgboost.explain import xgb_shap_dataset, xgb_shap_values
 from runtime.xgboost.train import train as xgb_train
 
-datasource = testing_mysql_db_url()
+datasource = testing.get_datasource()
 
 select = "SELECT * FROM boston.train;"
 


### PR DESCRIPTION
Add a new file `runtime/testing.py` to unify the datasource settings used in the Python side (like `GetTestingDBSingleton` in the Go side). All Python codes should use the `runtime/testing.py` settings instead of hard-coding the datasources in each test. 