### PR TITLE
Make verifier.fetch_samples return row_data, field_names and field_types together

### DIFF
--- a/python/runtime/maxcompute.py
+++ b/python/runtime/maxcompute.py
@@ -42,13 +42,18 @@ class MaxCompute:
                 return
 
             r = inst.open_reader(tunnel=True, compress_option=compress)
-            field_names = None if r._schema.columns is None \
-                else [col.name for col in r._schema.columns]
+
+            columns = r._schema.columns
+
+            reader.field_names = [col.name for col in columns]
+            reader.field_types = [col.type for col in columns]
+
             if label_meta:
                 try:
-                    label_idx = field_names.index(label_meta["feature_name"])
+                    label_idx = reader.field_names.index(
+                        label_meta["feature_name"])
                 except ValueError:
-                    # NOTE(typhoonzero): For clustering model, label_column_name may not in field_names when predicting.
+                    # NOTE(typhoonzero): For clustering model, label_column_name may not in reader.field_names when predicting.
                     label_idx = None
             else:
                 label_idx = None


### PR DESCRIPTION
Make the `verifier.fetch_samples` method return row data, field names, and field types together, like what the `verifier.FetchSamples` method in the Go side does (we can get field name and types by `sql.Rows.ColumnTypes()` in the Go side). To do this, we set `field_names` and `field_types` to the `db.db_generator()` when the first iteration begins.