### PR TITLE
Add Binary var type support for optimizing

### DIFF
--- a/go/cmd/sqlflowserver/e2e_common_cases.go
+++ b/go/cmd/sqlflowserver/e2e_common_cases.go
@@ -664,14 +664,6 @@ func caseXGBoostSparseKeyValueColumn(t *testing.T) {
 		a.Equal(len(rows), 1)
 	}
 
-	removeColumnNamePrefix := func(columns []string) []string {
-		for idx := range columns {
-			split := strings.Split(columns[idx], ".")
-			columns[idx] = split[len(split)-1]
-		}
-		return columns
-	}
-
 	trainedModel := "xgb_kv_column_trained_model"
 	if !isPai {
 		trainedModel = fmt.Sprintf("%s.%s", dbName, trainedModel)
@@ -759,19 +751,18 @@ func decodeAnyTypedRowData(anyData [][]*any.Any) ([][]interface{}, error) {
 	return slice, nil
 }
 
+func removeColumnNamePrefix(columns []string) []string {
+	for i, c := range columns {
+		split := strings.Split(c, ".")
+		columns[i] = split[len(split)-1]
+	}
+	return columns
+}
+
 func caseTestOptimizeClauseWithoutGroupBy(t *testing.T) {
 	a := assert.New(t)
 
-	removeColumnNamePrefix := func(columns []string) []string {
-		for i, c := range columns {
-			split := strings.Split(c, ".")
-			columns[i] = split[len(split)-1]
-		}
-		return columns
-	}
-
 	dbName := "optimize_test_db"
-
 	resultTable := fmt.Sprintf("%s.%s", dbName, "woodcarving_result")
 
 	woodcarvingOptimizeSQLTemplate := `SELECT * FROM optimize_test_db.woodcarving
@@ -820,19 +811,55 @@ INTO ` + resultTable + `;`
 	}
 }
 
+func caseTestOptimizeClauseWithBinaryVarType(t *testing.T) {
+	a := assert.New(t)
+
+	dbName := "optimize_test_db"
+	resultTable := fmt.Sprintf("%s.%s", dbName, "woodcarving_result")
+
+	binaryWoodCarvingSQL := `SELECT * FROM optimize_test_db.woodcarving
+TO MAXIMIZE SUM((price - materials_cost - other_cost) * amount)
+CONSTRAINT SUM(finishing * amount) <= 100, SUM(carpentry * amount) <= 80, amount <= max_num
+WITH 
+	variables="amount(product)",
+	var_type="Binary"
+USING glpk
+INTO ` + resultTable + `;`
+
+	_, _, _, err := connectAndRunSQL(binaryWoodCarvingSQL)
+	a.NoError(err)
+
+	queryResultSQL := fmt.Sprintf("SELECT product, amount FROM %s;", resultTable)
+
+	header, rows, _, err := connectAndRunSQL(queryResultSQL)
+	header = removeColumnNamePrefix(header)
+	a.NoError(err)
+	a.Equal(2, len(header))
+
+	a.Equal("product", header[0])
+	a.Equal("amount", header[1])
+	a.Equal(2, len(rows))
+	decodedRows, err := decodeAnyTypedRowData(rows)
+	a.NoError(err)
+	a.Equal(len(rows), len(decodedRows))
+	for i := 0; i < len(decodedRows); i++ {
+		a.Equal(2, len(decodedRows[i]))
+		a.IsType("", decodedRows[i][0])
+		a.IsType(int64(0), decodedRows[i][1])
+	}
+
+	sort.Slice(decodedRows, func(i int, j int) bool {
+		return decodedRows[i][0].(string) < decodedRows[j][0].(string)
+	})
+
+	a.True(reflect.DeepEqual(decodedRows[0], []interface{}{"soldier", int64(1)}))
+	a.True(reflect.DeepEqual(decodedRows[1], []interface{}{"train", int64(1)}))
+}
+
 func caseTestOptimizeClauseWithGroupBy(t *testing.T) {
 	a := assert.New(t)
 
-	removeColumnNamePrefix := func(columns []string) []string {
-		for i, c := range columns {
-			split := strings.Split(c, ".")
-			columns[i] = split[len(split)-1]
-		}
-		return columns
-	}
-
 	dbName := "optimize_test_db"
-
 	resultTable := fmt.Sprintf("%s.%s", dbName, "shipment_result")
 
 	shipmentOptimizeSQL := fmt.Sprintf(`SELECT 

--- a/go/cmd/sqlflowserver/e2e_mysql_test.go
+++ b/go/cmd/sqlflowserver/e2e_mysql_test.go
@@ -79,9 +79,10 @@ func TestEnd2EndMySQL(t *testing.T) {
 
 	t.Run("CaseXGBoostSparseKeyValueColumn", caseXGBoostSparseKeyValueColumn)
 
+	// Cases for optimize
 	t.Run("CaseTestOptimizeClauseWithoutGroupBy", caseTestOptimizeClauseWithoutGroupBy)
-
 	t.Run("CaseTestOptimizeClauseWithGroupBy", caseTestOptimizeClauseWithGroupBy)
+	t.Run("CaseTestOptimizeClauseWithBinaryVarType", caseTestOptimizeClauseWithBinaryVarType)
 }
 
 func CaseShouldError(t *testing.T) {

--- a/go/executor/executor.go
+++ b/go/executor/executor.go
@@ -384,9 +384,13 @@ func (s *pythonExecutor) ExecuteOptimize(stmt *ir.OptimizeStmt) error {
 		resultColumnName += "_value"
 	}
 
-	resultColumnType := "FLOAT"
-	if strings.HasSuffix(stmt.VariableType, "Integers") {
+	resultColumnType := ""
+	if stmt.VariableType == "Binary" || strings.HasSuffix(stmt.VariableType, "Integers") {
 		resultColumnType = "BIGINT"
+	} else if strings.HasSuffix(stmt.VariableType, "Reals") {
+		resultColumnType = "FLOAT"
+	} else {
+		return fmt.Errorf("unsupported variable_type = %s", stmt.VariableType)
 	}
 
 	resultColumnType, err = fieldType(driver, resultColumnType)

--- a/python/runtime/optimize/local.py
+++ b/python/runtime/optimize/local.py
@@ -19,7 +19,7 @@ import pyomo.environ as pyomo_env
 import runtime.db as db
 import runtime.verifier as verifier
 import six
-from pyomo.environ import (Integers, NegativeIntegers, NegativeReals,
+from pyomo.environ import (Binary, Integers, NegativeIntegers, NegativeReals,
                            NonNegativeIntegers, NonNegativeReals,
                            NonPositiveIntegers, NonPositiveReals,
                            PositiveIntegers, PositiveReals, Reals, maximize,


### PR DESCRIPTION
Add `Binary` variable type support for optimizing. Now, SQLFlow supports `xxxIntegers`, `xxxReals` and `Binary` variable types.