### PR TITLE
Add cora dataset

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -31,6 +31,7 @@ COPY doc/datasets/popularize_churn.sql \
      doc/datasets/popularize_imdb.sql \
      doc/datasets/create_model_db.sql \
      doc/datasets/popularize_energy.sql \
+     doc/datasets/popularize_cora.sql \
      /datasets/
 
 COPY docker/dev/find_fastest_resources.sh /usr/local/bin/

--- a/go/cmd/sqlflowserver/e2e_common_cases.go
+++ b/go/cmd/sqlflowserver/e2e_common_cases.go
@@ -72,6 +72,7 @@ func caseShowDatabases(t *testing.T) {
 		"sqlflow_model_zoo":           "",
 		"sqlflow_public_models":       "",
 		"xgboost_sparse_data_test_db": "",
+		"cora":                        "",
 	}
 	for i := 0; i < len(resp); i++ {
 		AssertContainsAny(a, expectedDBs, resp[i][0])


### PR DESCRIPTION
Hi, this is a initial PR for adding the Cora dataset related to [#2714 ](https://github.com/sql-machine-learning/sqlflow/issues/2714).

The node table is created as:
```sql
CREATE TABLE cora.node (
                    id INT,
                    node_name TEXT,
                    features  TEXT,
                    label TEXT);
```
and the edge table is created as:
```sql
CREATE TABLE cora.edge (
                    id INT,
                    from_node_id INT,
                    to_node_id  INT,
                    weight FLOAT);
```

I have tested on the mysql server on my own machine, and I was able to use this [api](https://github.com/sql-machine-learning/sqlflow/blob/develop/python/runtime/db.py#L351) from SQLFlow to query and load the data.
```sql
SELECT from_node_id, to_node_id, weight, cora.node.features 
FROM cora.edge 
LEFT JOIN cora.node ON cora.edge.from_node_id = cora.node.id                                                                                                                                      
```
If there has any problem, please let me know. Thanks!