### PR TITLE
Push images on self hosted machine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,6 @@ jobs:
       run: echo "::set-env name=TRAVIS_BRANCH::${{ github.head_ref }}"
     - if: ${{ github.event_name == 'push' }}
       run: echo "::set-env name=TRAVIS_BRANCH::${GITHUB_REF##*/}"
-    - name: release latest linux client binary
     - name: push server images
       env:
         DOCKER_USERNAME: "typhoon1986"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,48 +21,48 @@ jobs:
         go generate ./...
         go install ./...
         pre-commit run -a --show-diff-on-failure
-    - name: build mysql image
-      run: docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
-    - name: mysql unit test
-      run: |
-        set -e
-        bash scripts/test/prepare.sh
-        source build/env/bin/activate
-        docker stop mysql || true
-        docker rm mysql || true
-        docker run --rm --name mysql -d -p 13306:3306 -v ${{ github.workspace }}:/work sqlflow:mysql
-        SQLFLOW_TEST_DB_MYSQL_ADDR="127.0.0.1:13306" PYTHONPATH=${{ github.workspace }}/python scripts/test/mysql.sh
-        # bash scripts/travis/upload_codecov.sh
-  test-hive-java:
-    runs-on: [self-hosted, linux]
-    env:
-      SQLFLOW_PARSER_SERVER_PORT: 12300
-      SQLFLOW_PARSER_SERVER_LOADING_PATH: "/usr/local/sqlflow/java"
-    steps:
-    - uses: actions/checkout@v1
-    - name: hive unit test
-      run: |
-        set -e
-        bash scripts/test/prepare.sh
-        source build/env/bin/activate
-        docker pull sqlflow/gohive:dev
-        docker stop hive || true
-        docker rm hive || true
-        docker run --rm -d --name=hive --net=host sqlflow/gohive:dev python3 -m http.server 8899
-        PYTHONPATH=${{ github.workspace }}/python scripts/test/hive.sh
-        # bash scripts/travis/upload_codecov.sh
-    - name: maxcompute unit test
-      run: |
-        set -e
-        source build/env/bin/activate
-        export SQLFLOW_TEST_DB_MAXCOMPUTE_AK=$MAXCOMPUTE_AK
-        export SQLFLOW_TEST_DB_MAXCOMPUTE_SK=$MAXCOMPUTE_SK
-        PYTHONPATH=${{ github.workspace }}/python bash scripts/test/maxcompute.sh
-        # bash scripts/travis/upload_codecov.sh
-    - name: java unit test
-      run: |
-        set -e
-        bash scripts/test/java.sh
+  #   - name: build mysql image
+  #     run: docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
+  #   - name: mysql unit test
+  #     run: |
+  #       set -e
+  #       bash scripts/test/prepare.sh
+  #       source build/env/bin/activate
+  #       docker stop mysql || true
+  #       docker rm mysql || true
+  #       docker run --rm --name mysql -d -p 13306:3306 -v ${{ github.workspace }}:/work sqlflow:mysql
+  #       SQLFLOW_TEST_DB_MYSQL_ADDR="127.0.0.1:13306" PYTHONPATH=${{ github.workspace }}/python scripts/test/mysql.sh
+  #       # bash scripts/travis/upload_codecov.sh
+  # test-hive-java:
+  #   runs-on: [self-hosted, linux]
+  #   env:
+  #     SQLFLOW_PARSER_SERVER_PORT: 12300
+  #     SQLFLOW_PARSER_SERVER_LOADING_PATH: "/usr/local/sqlflow/java"
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: hive unit test
+  #     run: |
+  #       set -e
+  #       bash scripts/test/prepare.sh
+  #       source build/env/bin/activate
+  #       docker pull sqlflow/gohive:dev
+  #       docker stop hive || true
+  #       docker rm hive || true
+  #       docker run --rm -d --name=hive --net=host sqlflow/gohive:dev python3 -m http.server 8899
+  #       PYTHONPATH=${{ github.workspace }}/python scripts/test/hive.sh
+  #       # bash scripts/travis/upload_codecov.sh
+  #   - name: maxcompute unit test
+  #     run: |
+  #       set -e
+  #       source build/env/bin/activate
+  #       export SQLFLOW_TEST_DB_MAXCOMPUTE_AK=$MAXCOMPUTE_AK
+  #       export SQLFLOW_TEST_DB_MAXCOMPUTE_SK=$MAXCOMPUTE_SK
+  #       PYTHONPATH=${{ github.workspace }}/python bash scripts/test/maxcompute.sh
+  #       # bash scripts/travis/upload_codecov.sh
+  #   - name: java unit test
+  #     run: |
+  #       set -e
+  #       bash scripts/test/java.sh
   test-workflow:
     runs-on: [self-hosted, linux]
     env:
@@ -81,7 +81,8 @@ jobs:
         # bash scripts/travis/upload_codecov.sh
   push-images:
     runs-on: [self-hosted, linux]
-    needs: [test-mysql, test-hive-java, test-workflow]
+    # needs: [test-mysql, test-hive-java, test-workflow]
+    needs: [test-mysql]
     steps:
     - uses: actions/checkout@v1
     - name: push server images
@@ -99,7 +100,8 @@ jobs:
         bash scripts/travis/deploy_docker.sh
   linux-client:
     runs-on: ubuntu-latest
-    needs: [test-mysql, test-hive-java, test-workflow]
+    # needs: [test-mysql, test-hive-java, test-workflow]
+    needs: [test-mysql]
     steps:
     - uses: actions/checkout@v2
     - uses: olegtarasov/get-tag@v2
@@ -125,7 +127,8 @@ jobs:
   # TODO(typhoonzero): remove travis envs when we have moved to github actions completely
   macos-client:
     runs-on: macos-latest
-    needs: [test-mysql, test-hive-java, test-workflow]
+    # needs: [test-mysql, test-hive-java, test-workflow]
+    needs: [test-mysql]
     steps:
     - uses: actions/checkout@v2
     - uses: olegtarasov/get-tag@v2
@@ -150,7 +153,8 @@ jobs:
         bash scripts/travis/deploy_client.sh
   windows-client:
     runs-on: windows-latest
-    needs: [test-mysql, test-hive-java, test-workflow]
+    # needs: [test-mysql, test-hive-java, test-workflow]
+    needs: [test-mysql]
     steps:
     - uses: actions/checkout@v2
     - uses: olegtarasov/get-tag@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,9 @@ jobs:
         bash scripts/test/workflow.sh
         # bash scripts/travis/upload_codecov.sh
   push-images:
-    - runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux]
+    needs: [test-mysql, test-hive-java, test-workflow]
+    steps:
     - uses: actions/checkout@v1
     - name: push server images
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, push_images_on_actions_self_hosted_machine ]
   pull_request:
     branches: [ develop ]
 
@@ -79,7 +79,23 @@ jobs:
         source build/env/bin/activate
         bash scripts/test/workflow.sh
         # bash scripts/travis/upload_codecov.sh
-  push:
+  push-images:
+    - runs-on: [self-hosted, linux]
+    - uses: actions/checkout@v1
+    - name: push server images
+      env:
+        DOCKER_USERNAME: "typhoon1986"
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        ALIYUN_DOCKER_USERNAME: "sqlflow@prod.trusteeship.aliyunid.com"
+        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
+      run: |
+        export TRAVIS_TAG=${{ steps.tagName.outputs.tag }}
+        export TRAVIS_PULL_REQUEST=${{ github.event.number }}
+        export TRAVIS_BUILD_DIR=${{ github.workspace }}
+        export FIND_FASTED_MIRROR=false
+        export TRAVIS_BUILD_STAGE_NAME=Deploy
+        bash scripts/travis/deploy_docker.sh
+  linux-client:
     runs-on: ubuntu-latest
     needs: [test-mysql, test-hive-java, test-workflow]
     steps:
@@ -104,19 +120,6 @@ jobs:
         export TRAVIS_TAG=${{ steps.tagName.outputs.tag }}
         export TRAVIS_PULL_REQUEST=${{ github.event.number }}
         bash scripts/travis/deploy_client.sh
-    - name: push server images
-      env:
-        DOCKER_USERNAME: "typhoon1986"
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        ALIYUN_DOCKER_USERNAME: "sqlflow@prod.trusteeship.aliyunid.com"
-        ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
-      run: |
-        export TRAVIS_TAG=${{ steps.tagName.outputs.tag }}
-        export TRAVIS_PULL_REQUEST=${{ github.event.number }}
-        export TRAVIS_BUILD_DIR=${{ github.workspace }}
-        export FIND_FASTED_MIRROR=false
-        export TRAVIS_BUILD_STAGE_NAME=Deploy
-        bash scripts/travis/deploy_docker.sh
   # TODO(typhoonzero): remove travis envs when we have moved to github actions completely
   macos-client:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,9 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ develop, push_images_on_actions_self_hosted_machine ]
-  # pull_request:
-  #   branches: [ develop ]
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
 
 jobs:
   test-mysql:
@@ -22,69 +22,68 @@ jobs:
         go generate ./...
         go install ./...
         pre-commit run -a --show-diff-on-failure
-  #   - name: build mysql image
-  #     run: docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
-  #   - name: mysql unit test
-  #     run: |
-  #       set -e
-  #       bash scripts/test/prepare.sh
-  #       source build/env/bin/activate
-  #       docker stop mysql || true
-  #       docker rm mysql || true
-  #       docker run --rm --name mysql -d -p 13306:3306 -v ${{ github.workspace }}:/work sqlflow:mysql
-  #       SQLFLOW_TEST_DB_MYSQL_ADDR="127.0.0.1:13306" PYTHONPATH=${{ github.workspace }}/python scripts/test/mysql.sh
-  #       # bash scripts/travis/upload_codecov.sh
-  # test-hive-java:
-  #   runs-on: [self-hosted, linux]
-  #   env:
-  #     SQLFLOW_PARSER_SERVER_PORT: 12300
-  #     SQLFLOW_PARSER_SERVER_LOADING_PATH: "/usr/local/sqlflow/java"
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - name: hive unit test
-  #     run: |
-  #       set -e
-  #       bash scripts/test/prepare.sh
-  #       source build/env/bin/activate
-  #       docker pull sqlflow/gohive:dev
-  #       docker stop hive || true
-  #       docker rm hive || true
-  #       docker run --rm -d --name=hive --net=host sqlflow/gohive:dev python3 -m http.server 8899
-  #       PYTHONPATH=${{ github.workspace }}/python scripts/test/hive.sh
-  #       # bash scripts/travis/upload_codecov.sh
-  #   - name: maxcompute unit test
-  #     env:
-  #       SQLFLOW_TEST_DB_MAXCOMPUTE_AK: ${{ secrets.MAXCOMPUTE_AK }}
-  #       SQLFLOW_TEST_DB_MAXCOMPUTE_SK: ${{ secrets.MAXCOMPUTE_SK }}
-  #     run: |
-  #       set -e
-  #       source build/env/bin/activate
-  #       PYTHONPATH=${{ github.workspace }}/python bash scripts/test/maxcompute.sh
-  #       # bash scripts/travis/upload_codecov.sh
-  #   - name: java unit test
-  #     run: |
-  #       set -e
-  #       bash scripts/test/java.sh
-  # test-workflow:
-  #   runs-on: [self-hosted, linux]
-  #   env:
-  #     SQLFLOW_PARSER_SERVER_PORT: 12300
-  #     SQLFLOW_PARSER_SERVER_LOADING_PATH: "/usr/local/sqlflow/java"
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - name: build mysql image
-  #     run: docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
-  #   - name: workflow mode ci
-  #     run: |
-  #       set -e
-  #       bash scripts/test/prepare.sh
-  #       source build/env/bin/activate
-  #       bash scripts/test/workflow.sh
-  #       # bash scripts/travis/upload_codecov.sh
+    - name: build mysql image
+      run: docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
+    - name: mysql unit test
+      run: |
+        set -e
+        bash scripts/test/prepare.sh
+        source build/env/bin/activate
+        docker stop mysql || true
+        docker rm mysql || true
+        docker run --rm --name mysql -d -p 13306:3306 -v ${{ github.workspace }}:/work sqlflow:mysql
+        SQLFLOW_TEST_DB_MYSQL_ADDR="127.0.0.1:13306" PYTHONPATH=${{ github.workspace }}/python scripts/test/mysql.sh
+        # bash scripts/travis/upload_codecov.sh
+  test-hive-java:
+    runs-on: [self-hosted, linux]
+    env:
+      SQLFLOW_PARSER_SERVER_PORT: 12300
+      SQLFLOW_PARSER_SERVER_LOADING_PATH: "/usr/local/sqlflow/java"
+    steps:
+    - uses: actions/checkout@v1
+    - name: hive unit test
+      run: |
+        set -e
+        bash scripts/test/prepare.sh
+        source build/env/bin/activate
+        docker pull sqlflow/gohive:dev
+        docker stop hive || true
+        docker rm hive || true
+        docker run --rm -d --name=hive --net=host sqlflow/gohive:dev python3 -m http.server 8899
+        PYTHONPATH=${{ github.workspace }}/python scripts/test/hive.sh
+        # bash scripts/travis/upload_codecov.sh
+    - name: maxcompute unit test
+      env:
+        SQLFLOW_TEST_DB_MAXCOMPUTE_AK: ${{ secrets.MAXCOMPUTE_AK }}
+        SQLFLOW_TEST_DB_MAXCOMPUTE_SK: ${{ secrets.MAXCOMPUTE_SK }}
+      run: |
+        set -e
+        source build/env/bin/activate
+        PYTHONPATH=${{ github.workspace }}/python bash scripts/test/maxcompute.sh
+        # bash scripts/travis/upload_codecov.sh
+    - name: java unit test
+      run: |
+        set -e
+        bash scripts/test/java.sh
+  test-workflow:
+    runs-on: [self-hosted, linux]
+    env:
+      SQLFLOW_PARSER_SERVER_PORT: 12300
+      SQLFLOW_PARSER_SERVER_LOADING_PATH: "/usr/local/sqlflow/java"
+    steps:
+    - uses: actions/checkout@v1
+    - name: build mysql image
+      run: docker build -t sqlflow:mysql -f docker/mysql/Dockerfile .
+    - name: workflow mode ci
+      run: |
+        set -e
+        bash scripts/test/prepare.sh
+        source build/env/bin/activate
+        bash scripts/test/workflow.sh
+        # bash scripts/travis/upload_codecov.sh
   push-images:
     runs-on: [self-hosted, linux]
-    # needs: [test-mysql, test-hive-java, test-workflow]
-    needs: [test-mysql]
+    needs: [test-mysql, test-hive-java, test-workflow]
     steps:
     - uses: actions/checkout@v1
     - uses: olegtarasov/get-tag@v2
@@ -112,8 +111,7 @@ jobs:
         bash scripts/travis/deploy_docker.sh
   linux-client:
     runs-on: ubuntu-latest
-    # needs: [test-mysql, test-hive-java, test-workflow]
-    needs: [test-mysql]
+    needs: [test-mysql, test-hive-java, test-workflow]
     steps:
     - uses: actions/checkout@v2
     - uses: olegtarasov/get-tag@v2
@@ -139,8 +137,7 @@ jobs:
   # TODO(typhoonzero): remove travis envs when we have moved to github actions completely
   macos-client:
     runs-on: macos-latest
-    # needs: [test-mysql, test-hive-java, test-workflow]
-    needs: [test-mysql]
+    needs: [test-mysql, test-hive-java, test-workflow]
     steps:
     - uses: actions/checkout@v2
     - uses: olegtarasov/get-tag@v2
@@ -165,8 +162,7 @@ jobs:
         bash scripts/travis/deploy_client.sh
   windows-client:
     runs-on: windows-latest
-    # needs: [test-mysql, test-hive-java, test-workflow]
-    needs: [test-mysql]
+    needs: [test-mysql, test-hive-java, test-workflow]
     steps:
     - uses: actions/checkout@v2
     - uses: olegtarasov/get-tag@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ name: CI
 on:
   push:
     branches: [ develop, push_images_on_actions_self_hosted_machine ]
-  pull_request:
-    branches: [ develop ]
+  # pull_request:
+  #   branches: [ develop ]
 
 jobs:
   test-mysql:
@@ -87,6 +87,17 @@ jobs:
     needs: [test-mysql]
     steps:
     - uses: actions/checkout@v1
+    - uses: olegtarasov/get-tag@v2
+      id: tagName
+    - if: ${{ github.event_name == 'schedule' }}
+      run: |
+        echo "::set-env name=TRAVIS_EVENT_TYPE::cron"
+        echo "::set-env name=TRAVIS_BRANCH::${GITHUB_REF##*/}"
+    - if: ${{ github.event_name == 'pull_request' }}
+      run: echo "::set-env name=TRAVIS_BRANCH::${{ github.head_ref }}"
+    - if: ${{ github.event_name == 'push' }}
+      run: echo "::set-env name=TRAVIS_BRANCH::${GITHUB_REF##*/}"
+    - name: release latest linux client binary
     - name: push server images
       env:
         DOCKER_USERNAME: "typhoon1986"

--- a/docker/dev/install.sh
+++ b/docker/dev/install.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
 
 if [ "$FIND_FASTED_MIRROR" == "true" ]; then
     # shellcheck disable=SC1091

--- a/docker/dev/install.sh
+++ b/docker/dev/install.sh
@@ -74,7 +74,7 @@ rm -rf "$HOME"/.cache/pip/*
 
 
 echo "Install Go compiler ..."
-GO_MIRROR_0="http://mirrors.ustc.edu.cn/golang/go1.13.4.linux-amd64.tar.gz"
+GO_MIRROR_0="https://studygolang.com/dl/golang/go1.13.4.linux-amd64.tar.gz"
 GO_MIRROR_1="https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz"
 axel --quiet --output go.tar.gz $GO_MIRROR_0 $GO_MIRROR_1
 tar -C /usr/local -xzf go.tar.gz

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -72,4 +72,4 @@ build_sqlflow_image step
 build_sqlflow_image modelzooserver
 
 echo "Clean up root permission $TRAVIS_BUILD_DIR/build ..."
-docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build
+docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -70,3 +70,6 @@ build_sqlflow_image mysql
 build_sqlflow_image jupyter
 build_sqlflow_image step
 build_sqlflow_image modelzooserver
+
+echo "Clean up root permission $TRAVIS_BUILD_DIR/build ..."
+docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build

--- a/scripts/travis/deploy_docker.sh
+++ b/scripts/travis/deploy_docker.sh
@@ -45,7 +45,7 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
 fi
 
 # Figure out the tag to push sqlflow:ci.
-if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
+if [[ "$TRAVIS_BRANCH" == "develop" || "$TRAVIS_BRANCH" == "push_images_on_actions_self_hosted_machine" ]]; then
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
         DOCKER_TAG="nightly"
     else

--- a/scripts/travis/deploy_docker.sh
+++ b/scripts/travis/deploy_docker.sh
@@ -45,7 +45,7 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
 fi
 
 # Figure out the tag to push sqlflow:ci.
-if [[ "$TRAVIS_BRANCH" == "develop" || "$TRAVIS_BRANCH" == "push_images_on_actions_self_hosted_machine" ]]; then
+if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
         DOCKER_TAG="nightly"
     else


### PR DESCRIPTION
Use shared workers to build and push docker images to aliyun registry often takes to much time, so use our self-hosted worker to publish docker images when merging PRs to develop.