### PR TITLE
Add feature_columns <-> dict conversion

### DIFF
--- a/python/runtime/feature/column.py
+++ b/python/runtime/feature/column.py
@@ -169,7 +169,6 @@ class BucketColumn(CategoryColumn):
 
     def _to_dict(self):
         return {
-            "type": "BucketColumn",
             "source_column": FeatureColumn.to_dict(self.source_column),
             "boundaries": self.boundaries,
         }
@@ -240,7 +239,6 @@ class CategoryHashColumn(CategoryColumn):
 
     def _to_dict(self):
         return {
-            "type": "CategoryHashColumn",
             "field_desc": self.field_desc.to_dict(),
             "bucket_size": self.bucket_size,
         }

--- a/python/runtime/feature/column_test.py
+++ b/python/runtime/feature/column_test.py
@@ -45,7 +45,8 @@ class TestFeatureColumn(unittest.TestCase):
         self.assertEqual(json_desc["format"], desc.format)
         self.assertEqual(json_desc["shape"], desc.shape)
         self.assertEqual(json_desc["is_sparse"], desc.is_sparse)
-        self.assertEqual(json_desc["vocabulary"], desc.vocabulary)
+        vocab = set(json_desc["vocabulary"])
+        self.assertEqual(vocab, desc.vocabulary)
         self.assertEqual(json_desc["max_id"], desc.max_id)
 
     def test_feature_column_subclass(self):

--- a/python/runtime/feature/derivation_test.py
+++ b/python/runtime/feature/derivation_test.py
@@ -82,6 +82,15 @@ class TestGetMaxIndexOfKeyValueString(unittest.TestCase):
 @unittest.skipUnless(testing.get_driver() in ["mysql", "hive"],
                      "skip non MySQL and Hive tests")
 class TestFeatureDerivationWithMockedFeatures(unittest.TestCase):
+    def check_serialize(self, features, label):
+        f_dict, l_dict = fd.feature_columns_to_dict(features, label)
+        new_features, new_label = fd.dict_to_feature_columns(f_dict, l_dict)
+        new_f_dict, new_l_dict = fd.feature_columns_to_dict(
+            new_features, new_label)
+        self.assertEqual(f_dict, new_f_dict)
+        self.assertEqual(l_dict, new_l_dict)
+        return new_features, new_label
+
     def test_without_cross(self):
         features = {
             'feature_columns': [
@@ -107,6 +116,8 @@ class TestFeatureDerivationWithMockedFeatures(unittest.TestCase):
         conn = testing.get_singleton_db_connection()
         features, label = fd.infer_feature_columns(conn, select, features,
                                                    label)
+
+        features, label = self.check_serialize(features, label)
 
         self.assertEqual(len(features), 1)
         self.assertTrue("feature_columns" in features)
@@ -230,6 +241,8 @@ class TestFeatureDerivationWithMockedFeatures(unittest.TestCase):
         features, label = fd.infer_feature_columns(conn, select, features,
                                                    label)
 
+        features, label = self.check_serialize(features, label)
+
         self.assertEqual(len(features), 1)
         self.assertTrue("feature_columns" in features)
         features = features["feature_columns"]
@@ -321,6 +334,8 @@ class TestFeatureDerivationWithMockedFeatures(unittest.TestCase):
             FieldDesc(name='class', dtype=DataType.INT64, shape=[1]))
         features, label = fd.infer_feature_columns(conn, select, features,
                                                    label)
+
+        features, label = self.check_serialize(features, label)
 
         self.assertEqual(len(features), 1)
         self.assertTrue("feature_columns" in features)

--- a/python/runtime/feature/field_desc.py
+++ b/python/runtime/feature/field_desc.py
@@ -34,9 +34,9 @@ class DataType(object):
 # CSV: in the form of "1,2,4"
 # KV:  in the form of "0:3.2 1:-0.3 10:3.9"
 class DataFormat(object):
-    PLAIN = 0
-    CSV = 1
-    KV = 2
+    PLAIN = ""
+    CSV = "csv"
+    KV = "kv"
 
 
 class FieldDesc(object):
@@ -59,7 +59,6 @@ class FieldDesc(object):
     """
     def __init__(self,
                  name="",
-                 feature_name="",
                  dtype=DataType.INT64,
                  delimiter="",
                  format=DataFormat.PLAIN,
@@ -76,6 +75,8 @@ class FieldDesc(object):
         self.format = format
         self.shape = shape
         self.is_sparse = is_sparse
+        if vocabulary is not None:
+            vocabulary = set(list(vocabulary))
         self.vocabulary = vocabulary
         self.max_id = max_id
 
@@ -86,6 +87,12 @@ class FieldDesc(object):
         Returns:
             A Python dict.
         """
+        vocab = None
+        # Python set cannot be serialized as JSON, convert
+        # it to Python list first.
+        if self.vocabulary is not None:
+            vocab = list(self.vocabulary)
+            vocab.sort()
         return {
             "name": self.name,
             # FIXME(typhoonzero): this line is used to be compatible to
@@ -96,7 +103,7 @@ class FieldDesc(object):
             "format": self.format,
             "shape": self.shape,
             "is_sparse": self.is_sparse,
-            "vocabulary": self.vocabulary,
+            "vocabulary": vocab,
             "max_id": self.max_id,
         }
 
@@ -108,7 +115,14 @@ class FieldDesc(object):
         Returns:
             A FieldDesc object.
         """
-        return FieldDesc(**d)
+        return FieldDesc(name=d["name"],
+                         dtype=d["dtype"],
+                         delimiter=d["delimiter"],
+                         format=d["format"],
+                         shape=d["shape"],
+                         is_sparse=d["is_sparse"],
+                         vocabulary=d["vocabulary"],
+                         max_id=d["max_id"])
 
     def to_json(self):
         """


### PR DESCRIPTION
The conversion between `(feature_columns, label_column) <-> (feature_columns_dict, label_column_dict)` would be used to save (training) and load (prediction, evaluation, explanation) the model meta.