### PR TITLE
Make CONSTRAINT optional in optimize clause

### DIFF
--- a/go/cmd/sqlflowserver/e2e_hive_test.go
+++ b/go/cmd/sqlflowserver/e2e_hive_test.go
@@ -62,4 +62,5 @@ func TestEnd2EndHive(t *testing.T) {
 	t.Run("CaseTestOptimizeClauseWithoutGroupBy", caseTestOptimizeClauseWithoutGroupBy)
 	t.Run("CaseTestOptimizeClauseWithGroupBy", caseTestOptimizeClauseWithGroupBy)
 	t.Run("CaseTestOptimizeClauseWithBinaryVarType", caseTestOptimizeClauseWithBinaryVarType)
+	t.Run("CaseTestOptimizeClauseWithoutConstraint", caseTestOptimizeClauseWithoutConstraint)
 }

--- a/go/cmd/sqlflowserver/e2e_mysql_test.go
+++ b/go/cmd/sqlflowserver/e2e_mysql_test.go
@@ -112,6 +112,7 @@ func TestEnd2EndMySQL(t *testing.T) {
 	t.Run("CaseTestOptimizeClauseWithoutGroupBy", caseTestOptimizeClauseWithoutGroupBy)
 	t.Run("CaseTestOptimizeClauseWithGroupBy", caseTestOptimizeClauseWithGroupBy)
 	t.Run("CaseTestOptimizeClauseWithBinaryVarType", caseTestOptimizeClauseWithBinaryVarType)
+	t.Run("CaseTestOptimizeClauseWithoutConstraint", caseTestOptimizeClauseWithoutConstraint)
 }
 
 func CaseShouldError(t *testing.T) {

--- a/go/ir/ir_generator.go
+++ b/go/ir/ir_generator.go
@@ -1081,8 +1081,8 @@ func GenerateOptimizeStmt(optimizeStmt *parser.SQLFlowSelectStmt) (*OptimizeStmt
 		ExpressionTokens: optimizeStmt.Objective.ToTokens(),
 	}
 
-	constraints := make([]*OptimizeExpr, len(optimizeStmt.Constrants))
-	for i, c := range optimizeStmt.Constrants {
+	constraints := make([]*OptimizeExpr, len(optimizeStmt.Constraints))
+	for i, c := range optimizeStmt.Constraints {
 		constraints[i] = &OptimizeExpr{
 			ExpressionTokens: c.ToTokens(),
 			GroupBy:          c.GroupBy,

--- a/go/parser/extended_syntax_parser.y
+++ b/go/parser/extended_syntax_parser.y
@@ -132,7 +132,7 @@ type OptimizeClause struct {
 	// Direction can be MAXIMIZE or MINIMIZE
 	Direction string
 	Objective *Expr
-	Constrants ConstraintList
+	Constraints ConstraintList
 	OptimizeAttrs Attributes
 	Solver string
 	OptimizeInto string
@@ -161,6 +161,7 @@ func attrsUnion(as1, as2 Attributes) Attributes {
   expl ExprList
   ctexp  *Constraint
   ctexpl ConstraintList
+  octexpl ConstraintList
   atrs Attributes
   eslt *SQLFlowSelectStmt
   slct StandardSelect
@@ -190,6 +191,7 @@ func attrsUnion(as1, as2 Attributes) Attributes {
 %type  <expl> ExprList pythonlist columns
 %type  <ctexp> constraint
 %type  <ctexpl> constraint_list
+%type  <octexpl> optional_constraint_list
 %type  <atrs> attr
 %type  <atrs> attrs
 %type  <tbls> stringlist, identlist
@@ -323,36 +325,41 @@ run_clause
 | TO RUN IDENT CMD stringlist INTO identlist { $$.ImageName = $3; $$.Parameters = $5; $$.OutputTables = $7 }
 ;
 
+optional_constraint_list
+: /* empty */ { $$ = ConstraintList{} }
+| CONSTRAINT constraint_list { $$ = $2 }
+;
+
 optimize_clause
-: TO MAXIMIZE expr CONSTRAINT constraint_list WITH attrs USING IDENT INTO IDENT {
+: TO MAXIMIZE expr optional_constraint_list WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
-	$$.Constrants = $5;
-	$$.OptimizeAttrs = $7;
-	$$.Solver = $9;
-	$$.OptimizeInto = $11;
+	$$.Constraints = $4;
+	$$.OptimizeAttrs = $6;
+	$$.Solver = $8;
+	$$.OptimizeInto = $10;
 }
-| TO MAXIMIZE expr CONSTRAINT constraint_list WITH attrs INTO IDENT {
+| TO MAXIMIZE expr optional_constraint_list WITH attrs INTO IDENT {
 	$$.Direction = "MAXIMIZE";
 	$$.Objective = $3;
-	$$.Constrants = $5;
-	$$.OptimizeAttrs = $7;
-	$$.OptimizeInto = $9;
+	$$.Constraints = $4;
+	$$.OptimizeAttrs = $6;
+	$$.OptimizeInto = $8;
 }
-| TO MINIMIZE expr CONSTRAINT constraint_list WITH attrs USING IDENT INTO IDENT {
+| TO MINIMIZE expr optional_constraint_list WITH attrs USING IDENT INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
-	$$.Constrants = $5;
-	$$.OptimizeAttrs = $7;
-	$$.Solver = $9;
-	$$.OptimizeInto = $11;
+	$$.Constraints = $4;
+	$$.OptimizeAttrs = $6;
+	$$.Solver = $8;
+	$$.OptimizeInto = $10;
 }
-| TO MINIMIZE expr CONSTRAINT constraint_list WITH attrs INTO IDENT {
+| TO MINIMIZE expr optional_constraint_list WITH attrs INTO IDENT {
 	$$.Direction = "MINIMIZE";
 	$$.Objective = $3;
-	$$.Constrants = $5;
-	$$.OptimizeAttrs = $7;
-	$$.OptimizeInto = $9;
+	$$.Constraints = $4;
+	$$.OptimizeAttrs = $6;
+	$$.OptimizeInto = $8;
 };
 
 show_train_clause

--- a/go/parser/extended_syntax_parser_test.go
+++ b/go/parser/extended_syntax_parser_test.go
@@ -244,7 +244,7 @@ INTO db.table;`
 	a.True(r.Optimize)
 	a.Equal("MAXIMIZE", r.Direction)
 	a.Equal("SUM((price - materials_cost - other_cost) * product)", r.Objective.String())
-	a.Equal("SUM(finishing * product) <= 100", r.Constrants[0].String())
+	a.Equal("SUM(finishing * product) <= 100", r.Constraints[0].String())
 	a.Equal("db.table", r.OptimizeInto)
 	a.Equal("glpk", r.Solver)
 
@@ -259,7 +259,7 @@ INTO db.table;`
 	a.NoError(e)
 	a.Equal("MINIMIZE", r.Direction)
 	a.Equal("db.table", r.OptimizeInto)
-	a.Equal("product", r.Constrants[0].GroupBy)
+	a.Equal("product", r.Constraints[0].GroupBy)
 	a.Equal("", r.Solver)
 }
 


### PR DESCRIPTION
Some optimization problem may have no constraint (especially non-linear programming), for example, `TO MINIMIZE x * x + 2 * x WITH var_type="Reals"`. This PR make `CONSTRAINT` optional in the optimize clause.