### PR TITLE
Retain build-essential and python3-dev in the step image.

### DIFF
--- a/docker/step/Dockerfile
+++ b/docker/step/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/bash -c 'if [ "$FIND_FASTED_MIRROR" == "true" ]; then source find_faste
   && echo "Choose the fastest PIP source ..." \
   && choose_fastest_pip_source; fi' && \
   apt-get update && \
-  apt-get -qq install -y --no-install-recommends openjdk-8-jre-headless python3 libmysqlclient20 python3-idna libgomp1 python3-setuptools python3-pip && \
+  apt-get -qq install -y --no-install-recommends openjdk-8-jre-headless python3 libmysqlclient20 python3-idna libgomp1 python3-setuptools python3-pip build-essential python3-dev && \
   ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
   apt-get install -y tzdata > /dev/null && \
   dpkg-reconfigure --frontend noninteractive tzdata && \
@@ -30,7 +30,7 @@ WORKDIR /install
 ENV PATH="${PATH}:/install/bin"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-  apt-get -qq install -y wget unzip build-essential libmysqlclient-dev python3-dev && \
+  apt-get -qq install -y wget unzip libmysqlclient-dev && \
   wget -q http://docs-aliyun.cn-hangzhou.oss.aliyun-inc.com/assets/attach/119096/cn_zh/1557995455961/odpscmd_public.zip && \
   mkdir -p /install/local/odpscmd && \
   unzip -qq odpscmd_public.zip -d /install/local/odpscmd && \


### PR DESCRIPTION
It's common that we will build the runnable images based on the base image - sqlflow/sqlflow:step and then install additional python packages. Some python packages such as `psutil` need compilation which requires gcc and `Python.h`. In order the prepare the compilation environment in the base image, we will retain build-essential and python3-dev packages in sqlflow/sqlflow:step.