### PR TITLE
Fix maxcompute.py import error when running optimization clause on Dataworks

### DIFF
--- a/python/runtime/dbapi/maxcompute.py
+++ b/python/runtime/dbapi/maxcompute.py
@@ -15,7 +15,7 @@ try:
     from odps import ODPS, tunnel
     COMPRESS_ODPS_ZLIB = tunnel.CompressOption.CompressAlgorithm.ODPS_ZLIB
 except:  # noqa: E722
-    pass
+    COMPRESS_ODPS_ZLIB = None
 
 from runtime.dbapi.connection import Connection, ResultSet
 from six.moves.urllib.parse import parse_qs, urlparse


### PR DESCRIPTION
Fix the following error.
```
Traceback (most recent call last):
 File "<stdin>", line 23, in <module>
 File "/opt/sqlflow/python/runtime/optimize/__init__.py", line 14, in <module>
   from runtime.optimize.optflow import run_optimize_on_optflow  # noqa: F401
 File "/opt/sqlflow/python/runtime/optimize/optflow.py", line 22, in <module>
   from runtime.model.oss import get_bucket
 File "/opt/sqlflow/python/runtime/model/__init__.py", line 14, in <module>
   from runtime.model.metadata import collect_metadata  # noqa: F401
 File "/opt/sqlflow/python/runtime/model/metadata.py", line 17, in <module>
   from runtime.feature.column import (JSONDecoderWithFeatureColumn,
 File "/opt/sqlflow/python/runtime/feature/__init__.py", line 14, in <module>
   from runtime.feature.compile import compile_ir_feature_columns  # noqa: F401
 File "/opt/sqlflow/python/runtime/feature/compile.py", line 21, in <module>
   from runtime.model.model import EstimatorType
 File "/opt/sqlflow/python/runtime/model/model.py", line 22, in <module>
   from runtime.model.db import (read_with_generator_and_metadata,
 File "/opt/sqlflow/python/runtime/model/db.py", line 19, in <module>
   from runtime.db import buffered_db_writer, connect_with_data_source
 File "/opt/sqlflow/python/runtime/db.py", line 20, in <module>
   from runtime.dbapi import connect as dbapi_connect
 File "/opt/sqlflow/python/runtime/dbapi/__init__.py", line 15, in <module>
   from runtime.dbapi.maxcompute import MaxComputeConnection
 File "/opt/sqlflow/python/runtime/dbapi/maxcompute.py", line 80, in <module>
   class MaxComputeConnection(Connection):
 File "/opt/sqlflow/python/runtime/dbapi/maxcompute.py", line 135, in MaxComputeConnection
   compress_option=COMPRESS_ODPS_ZLIB):
NameError: name 'COMPRESS_ODPS_ZLIB' is not defined
```