### PR TITLE
Fix PAI py3 tests

### DIFF
--- a/python/runtime/model/oss.py
+++ b/python/runtime/model/oss.py
@@ -16,7 +16,6 @@ import pickle
 import sys
 
 import oss2
-import six
 import tensorflow as tf
 from runtime.diagnostics import SQLFlowDiagnostic
 from runtime.tensorflow import is_tf_estimator
@@ -120,13 +119,9 @@ def save_dir(oss_model_dir, local_dir):
     '''
     bucket = get_models_bucket()
     for (root, dirs, files) in os.walk(local_dir, topdown=True):
-        if not six.PY2:
-            root = root.decode("utf-8")
         dst_dir = "/".join([oss_model_dir.rstrip("/"), root])
         mkdir(bucket, dst_dir)
         for file_name in files:
-            if not six.PY2:
-                file_name = file_name.decode("utf-8")
             curr_file_path = os.path.join(root, file_name)
             remote_file_path = "/".join([dst_dir.rstrip("/"), file_name])
             remote_file_path = remove_bucket_prefix(remote_file_path)


### PR DESCRIPTION
It's wired that I ran `os.walk` with Python3.6 got bytes type not str type earlier, but it seems to be string type now. And, it should be string type as the document says of all Python versions.