### PR TITLE
Add install SQLFlow playground on Kubernetes doc

### DIFF
--- a/doc/run/k8s/install-sqlflow-multi-users.yaml
+++ b/doc/run/k8s/install-sqlflow-multi-users.yaml
@@ -16,11 +16,11 @@ spec:
       containers:
       - image: sqlflow/sqlflow:server
         name: server
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["sqlflowserver", "--argo-mode"]
         env:
         - name: SQLFLOW_WORKFLOW_LOGVIEW_ENDPOINT
-          value: "http://playground.sqlflow.tech:2746"
+          value: "http://localhost:9001"
         - name: SQLFLOW_WORKFLOW_STEP_IMAGE
           value: sqlflow/sqlflow:step
         - name: SQLFLOW_WORKFLOW_TTL
@@ -60,7 +60,7 @@ spec:
       containers:
       - image: sqlflow/sqlflow:jupyterhub
         name: jupyterhub
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /jupyter/certs
           name: cert-path
@@ -73,6 +73,8 @@ spec:
             value: /jupyter/certs/playground.sqlflow.tech.key
           - name: SQLFLOW_JUPYTER_SSL_CERT
             value: /jupyter/certs/playground.sqlflow.tech.pem
+          - name: SQLFLOW_JUPYTER_USE_OAUTH
+            value: "true"
           - name: SQLFLOW_JUPYTER_OAUTH_CLIENT_ID
             valueFrom:
               secretKeyRef:
@@ -90,4 +92,4 @@ spec:
       - name: cert-path
         hostPath:
           path: /jupyter/certs
-          type: Directory
+          type: DirectoryOrCreate

--- a/doc/run/k8s/install-sqlflow-multi-users.yaml
+++ b/doc/run/k8s/install-sqlflow-multi-users.yaml
@@ -73,7 +73,7 @@ spec:
             value: /jupyter/certs/playground.sqlflow.tech.key
           - name: SQLFLOW_JUPYTER_SSL_CERT
             value: /jupyter/certs/playground.sqlflow.tech.pem
-          - name: SQLFLOW_JUPYTER_USE_OAUTH
+          - name: SQLFLOW_JUPYTER_USE_GITHUB_OAUTH
             value: "true"
           - name: SQLFLOW_JUPYTER_OAUTH_CLIENT_ID
             valueFrom:

--- a/doc/run/kubernetes.md
+++ b/doc/run/kubernetes.md
@@ -2,8 +2,8 @@
 
 This is a tutorial on how to install SQLFlow playground on your Kubernetes, this tutorial includes two sections:
 
-- [Install SQLFlow playground with single-user mode](#install-sqlflow-with-single-user).
-- [Install SQLFlow playground with multi-users mode](#install-sqlflow-with-multi-users).
+- [Setup SQLFlow playground with single-user mode](#setup-sqlflow-playground-with-single-user-mode).
+- [Setup SQLFlow playground with multi-users mode](#setup-sqlflow-playground-with-multi-user-mode).
 
 Before starting any sections, please [Setup Minikube and Argo](#setup-minikube-and-argo) first.
 
@@ -14,20 +14,29 @@ Before starting any sections, please [Setup Minikube and Argo](#setup-minikube-a
 
     ``` bash
     kubectl create namespace argo
+
+    kubectl create rolebinding default-admin --clusterrole=admin --serviceaccount=default:default
+
     kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.7.7/manifests/install.yaml
+    ```
+1. Wait until Argo is up, run below command until you see all pods in argo namespace is `READY` and `Running`
+    ```bash
+    kubectl get pods -nargo --watch
     ```
 
 1. Access the Argo UI
 
     ``` bash
-    kubectl -n argo port-forward deployment/argo-server 2746:2746
+    nohup kubectl -n argo port-forward deployment/argo-server 9001:2746 --address=0.0.0.0 &
     ```
 
-    Then visit: `http://127.0.0.1:2746`
+    Then visit: `http://127.0.0.1:9001`
 
 ## Setup SQLFlow Playground with Single-user Mode
 
-On the single-user mode, we would install a MySQL server, a SQLFlow server with Jupyter Notebook as GUI on your Kubernetes cluster:
+On the single-user mode, we would install a MySQL server,
+a model zoo server and a SQLFlow server with Jupyter Notebook
+as GUI on your Kubernetes cluster:
 
 1. Run the following command to install SQLFlow and its dependencies:
 
@@ -35,42 +44,95 @@ On the single-user mode, we would install a MySQL server, a SQLFlow server with 
     kubectl apply -f https://raw.githubusercontent.com/sql-machine-learning/sqlflow/develop/doc/run/k8s/install-sqlflow.yaml
     ```
 
-1. Monitor the installation using the following command until all components show a `Running` status and `3/3` ready.
+1. Monitor the installation using the following command until all components show a `Running` status and `4/4` ready.
 
     ``` bash
     kubectl get pods --watch
     ```
 
 Congratulations! You have successfully installed SQLFlow with single-user
-mode on your Kubernetes cluster. Next you can run your query using SQLFlow as the following command:
-
-1. Retrieve the login token from logs
-
-    ``` bash
-    kubectl logs sqlflow-server notebook  | awk -F "token=" 'END{print $2}'
-    ```
+mode on your Kubernetes cluster. Next, you can try some tutorials with
+following steps:
 
 1. Map the Jupyter Notebook to a local port using the following command:
 
     ``` bash
-    kubectl port-forward deployment/sqlflow-server 8888:8888
+    nohup kubectl port-forward pod/sqlflow-server 8888:8888 --address=0.0.0.0 &
     ```
 
-1. Open a web browser and go to `http://localhost:8888`, and type in the token to login,
-you can find many tutorials e.g. `iris-dnn.md` in the Jupyter Notebook file lists,
-and do as what the tutorial says.
+1. Open a web browser and go to `http://localhost:8888`, you can find many
+tutorials, e.g. `iris-dnn.npynb` in the Jupyter Notebook file lists, and do
+as what the tutorial says.
 
 ## Setup SQLFlow Playground with Multi-user Mode
 
-From the above single-user mode section, SQLFLow playground use Jupyter Notebook as GUI system, and
-Jupyter community provides [JupyterHub](https://jupyterhub.readthedocs.io/en/stable/) to serve Jupyter Notebook
-for multiple users, [kubespawner] enable JupyterHub to spawan Jupyter Notebook server on Kubernetes. We packages
-these components into a Docker image `sqlflow/sqlflow:jupyterhub`, you can check the [Dockerfile](/docker/jupyterhub/Dockerfile).
+In above section, SQLFLow playground use Jupyter Notebook as GUI system
+to serve a single user. Actually, Jupyter community provides the [JupyterHub](https://jupyterhub.readthedocs.io/en/stable/)
+which can serve Jupyter Notebook for multiple users. [kubespawner](https://github.com/jupyterhub/kubespawner)
+enable JupyterHub to spawan Jupyter Notebook server on Kubernetes. We packages
+these components into a Docker image `sqlflow/sqlflow:jupyterhub`, you can check
+the [Dockerfile](/docker/jupyterhub/Dockerfile).
 
-1. Run the following command to install SQLFlow JupyterHub and server.
+Jupyterhub is someway suitable a team, so we have to consider about using `https` and add `authentication`.
+Of course, you can choose not to enable them. In below section, we will describe how to install our
+playground with your own `https` and `authentication` enabled/disabled.
+
+1. Download k8s config file for our multi-user playground
 
     ``` bash
-    kubectl apply -f https://raw.githubusercontent.com/sql-machine-learning/sqlflow/develop/doc/run/k8s/install-sqlflow-multi-users.yaml 
+    wget https://raw.githubusercontent.com/sql-machine-learning/sqlflow/develop/doc/run/k8s/install-sqlflow-multi-users.yaml 
+    ```
+1. Prepare for `https`, we make a directory for keeping `ssl` certificate file,
+    if you want to put it in other directory, make sure to modify the downloaded
+    config file as well. Then put the ssl certificate files into this directory.
+
+    ```bash
+    mkdir /jupyter/certs
+    cp {your_cert.key} /jupyter/certs/playground.sqlflow.tech.key
+    cp {your_cert.pem} /jupyter/certs/playground.sqlflow.tech.pem
+    ```
+
+    **NOTE:** If you don't want to enable `https`, you can skip the certificate setup.
+    Correspondingly, you need to set `SQLFLOW_JUPYTER_SSL_KEY` and
+    `SQLFLOW_JUPYTER_SSL_CERT` to empty in config.
+
+    ```yaml
+    - name: SQLFLOW_JUPYTER_SSL_KEY
+      value: ""
+    - name: SQLFLOW_JUPYTER_SSL_CERT
+      value: ""
+    ```
+
+1. Prepare for `authentication`. JupyterHub support kinds of
+    [authentications](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html).
+    In our playground, we defaultly enabled the [GitHub OAuth](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#github-setup). If you want to use `GitHub OAuth`, you may register
+    your own [GitHub app](https://github.com/settings/applications/new) and
+    get your `client_id` and `client_secret`. Then store these two information
+    in kubernetes secret store (please keep them safe at anytime).
+
+    ```
+    kubectl create secret generic sqlflow \
+        --from-literal=jupyter_oauth_client_id={client_id} \
+        --from-literal=jupyter_oauth_client_secret={client_secret}
+    ```
+
+    **NOTE:** If you do not want any `authentication`, you may safely skip above step.
+    **But** you still need to make a fake secret in k8s' store. Then disable
+    OAuth in config by setting `SQLFLOW_JUPYTER_USE_OAUTH`'s value to 'false'.
+    ```bash
+    kubectl create secret generic sqlflow \
+        --from-literal=jupyter_oauth_client_id=dummy \
+        --from-literal=jupyter_oauth_client_secret=dummy
+    ```
+    Change config file to disable authentication.
+    ```yaml
+    - name: SQLFLOW_JUPYTER_USE_OAUTH
+      value: "false"
+    ```
+
+1. Next is to deploy the cluster using below command.
+    ```bash
+    kubectl apply -f install-sqlflow-multi-users.yaml
     ```
 
 1. Monitor the installation using the following command until all components show a `Running` status.
@@ -85,11 +147,35 @@ mode on your Kubernetes cluster. Next you can login on the web page and run quer
 1. Map the Jupyter Notebook to a local port using the following command:
 
     ``` bash
-    kubectl port-forward deployment/sqlflow-jupyterhub 8000:8000
+    nohup kubectl port-forward deployment/sqlflow-jupyterhub 8000:8000 --address=0.0.0.0 &
     ```
 
-1. Open your browser and go to `localhost:8000`, type in any username/password to login, wait a while, you would be in a 
-Jupyter Notebook web page, and you can find many tutorials here.
+1. Open your browser and go to `localhost:8000`
+1. If you use `GitHub OAuth`, then click the auth button to login.
+    If you disabled the authentication, just type in any username/password
+    to login. Wait a while, you would enter a Jupyter Notebook web page,
+    and you can find many tutorials here.
 
-Note: SQLFlow playground use [dummyauthenticator] as the authenticator, which allows all users login regardless of password,
-you can find more authenticator method from [here](https://jupyterhub.readthedocs.io/en/stable/getting-started/authenticators-users-basics.html).
+## Trouble shooting
+
+1. Sometimes, you can't get the GitHub files with wget, like `https://raw.githubusercontent.com/argoproj/argo/v2.7.7/manifests/install.yaml`.
+
+    Try open it in your browser and save to local, or use a VPN to get the file.
+
+1. Port-forwarding may lost function after a while of idle time.
+
+    Just kill them and re-forwarding.
+
+1. First time run Jupyter Notebook, reporting databse is not found.
+    This may because you login and enter the notebook too fast, the MySQL
+    service is not ready yet.
+
+1. Pulling docker image is really slow.
+
+    You may change your docker repository. Or pull the images to local beforehand.
+
+1. Update my playground.
+
+    By default, SQLFlow playground will use local cached images to work. You can
+    delete and re-pull the images to update the playground. You may mostly want
+    to update those images with prefix `sqlflow/sqlflow:`

--- a/doc/run/kubernetes.md
+++ b/doc/run/kubernetes.md
@@ -118,7 +118,7 @@ playground with your own `https` and `authentication` enabled/disabled.
 
     **NOTE:** If you do not want any `authentication`, you may safely skip above step.
     **But** you still need to make a fake secret in k8s' store. Then disable
-    OAuth in config by setting `SQLFLOW_JUPYTER_USE_OAUTH`'s value to 'false'.
+    OAuth in config by setting `SQLFLOW_JUPYTER_USE_GITHUB_OAUTH`'s value to 'false'.
     ```bash
     kubectl create secret generic sqlflow \
         --from-literal=jupyter_oauth_client_id=dummy \
@@ -126,7 +126,7 @@ playground with your own `https` and `authentication` enabled/disabled.
     ```
     Change config file to disable authentication.
     ```yaml
-    - name: SQLFLOW_JUPYTER_USE_OAUTH
+    - name: SQLFLOW_JUPYTER_USE_GITHUB_OAUTH
       value: "false"
     ```
 
@@ -156,7 +156,7 @@ mode on your Kubernetes cluster. Next you can login on the web page and run quer
     to login. Wait a while, you would enter a Jupyter Notebook web page,
     and you can find many tutorials here.
 
-## Trouble shooting
+## Trouble Shooting
 
 1. Sometimes, you can't get the GitHub files with wget, like `https://raw.githubusercontent.com/argoproj/argo/v2.7.7/manifests/install.yaml`.
 
@@ -167,6 +167,7 @@ mode on your Kubernetes cluster. Next you can login on the web page and run quer
     Just kill them and re-forwarding.
 
 1. First time run Jupyter Notebook, reporting databse is not found.
+
     This may because you login and enter the notebook too fast, the MySQL
     service is not ready yet.
 

--- a/docker/jupyterhub/Dockerfile
+++ b/docker/jupyterhub/Dockerfile
@@ -6,7 +6,7 @@ ENV SQLFLOW_MYSQL_IMAGE=${SQLFLOW_MYSQL_IMAGE}
 ARG SQLFLOW_JUPYTER_IMAGE="sqlflow/sqlflow:jupyter"
 ENV SQLFLOW_JUPYTER_IMAGE=${SQLFLOW_JUPYTER_IMAGE}
 
-RUN pip install -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com --upgrade pip && pip install -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com jupyterhub-kubespawner \
+RUN pip install --upgrade pip && pip install jupyterhub-kubespawner \
     oauthenticator==0.11.0 \
     jupyterhub-dummyauthenticator==0.3.1 \
     jupyterhub_idle_culler==1.0

--- a/docker/jupyterhub/Dockerfile
+++ b/docker/jupyterhub/Dockerfile
@@ -6,8 +6,9 @@ ENV SQLFLOW_MYSQL_IMAGE=${SQLFLOW_MYSQL_IMAGE}
 ARG SQLFLOW_JUPYTER_IMAGE="sqlflow/sqlflow:jupyter"
 ENV SQLFLOW_JUPYTER_IMAGE=${SQLFLOW_JUPYTER_IMAGE}
 
-RUN pip install --upgrade pip && pip install jupyterhub-kubespawner \
+RUN pip install -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com --upgrade pip && pip install -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com jupyterhub-kubespawner \
     oauthenticator==0.11.0 \
+    jupyterhub-dummyauthenticator==0.3.1 \
     jupyterhub_idle_culler==1.0
 
 COPY docker/jupyterhub/jupyterhub_config.py /etc/jhub/jupyterhub_config.py

--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -57,7 +57,7 @@ c.JupyterHub.hub_connect_ip = c.KubeSpawner.hub_connect_ip
 c.KubeSpawner.service_account = 'default'
 
 # use GitHub oauth
-if os.getenv("SQLFLOW_JUPYTER_USE_OAUTH") == "true":
+if os.getenv("SQLFLOW_JUPYTER_USE_GITHUB_OAUTH") == "true":
     c.JupyterHub.authenticator_class = GitHubOAuthenticator
     c.GitHubOAuthenticator.oauth_callback_url = 'https://playground.sqlflow.tech/hub/oauth_callback'
     c.GitHubOAuthenticator.client_id = os.getenv(

--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -19,6 +19,7 @@ import os
 import socket
 import sys
 
+from dummyauthenticator import DummyAuthenticator
 from kubernetes import client
 from oauthenticator.github import GitHubOAuthenticator
 
@@ -56,11 +57,16 @@ c.JupyterHub.hub_connect_ip = c.KubeSpawner.hub_connect_ip
 c.KubeSpawner.service_account = 'default'
 
 # use GitHub oauth
-c.JupyterHub.authenticator_class = GitHubOAuthenticator
-c.GitHubOAuthenticator.oauth_callback_url = 'https://playground.sqlflow.tech/hub/oauth_callback'
-c.GitHubOAuthenticator.client_id = os.getenv("SQLFLOW_JUPYTER_OAUTH_CLIENT_ID")
-c.GitHubOAuthenticator.client_secret = os.getenv(
-    "SQLFLOW_JUPYTER_OAUTH_CLIENT_SECRET")
+if os.getenv("SQLFLOW_JUPYTER_USE_OAUTH") == "true":
+    c.JupyterHub.authenticator_class = GitHubOAuthenticator
+    c.GitHubOAuthenticator.oauth_callback_url = 'https://playground.sqlflow.tech/hub/oauth_callback'
+    c.GitHubOAuthenticator.client_id = os.getenv(
+        "SQLFLOW_JUPYTER_OAUTH_CLIENT_ID")
+    c.GitHubOAuthenticator.client_secret = os.getenv(
+        "SQLFLOW_JUPYTER_OAUTH_CLIENT_SECRET")
+else:
+    c.JupyterHub.authenticator_class = DummyAuthenticator
+    # c.Authenticator.admin_users = {'put your admin user here'}
 
 c.JupyterHub.allow_named_servers = True
 
@@ -95,7 +101,7 @@ c.KubeSpawner.extra_containers = [{
     "image":
     sqlflow_mysql_image,
     "imagePullPolicy":
-    "Always",
+    "IfNotPresent",
     "livenessProbe": {
         "exec": {
             "command": ["cat", "/work/mysql-inited"]

--- a/docker/jupyterhub/provision.sh
+++ b/docker/jupyterhub/provision.sh
@@ -55,4 +55,4 @@ EOM
 
 # Patch GitHub OAuth, add retry
 sed -i -e'160r /tmp/retry_code' -e'160d' \
-    /usr/local/lib/python3.6/dist-packages/oauthenticator/github.py
+    /usr/local/lib/python3.8/dist-packages/oauthenticator/github.py


### PR DESCRIPTION
This time we make `install playground on k8s` real work for readers.
1. described how to install single-user/multi-users playground.
1. enable `https` and `OAuth` in playground, users can create playground like ours.