### PR TITLE
Refine couler codegen template

### DIFF
--- a/go/codegen/experimental/codegen_couler.go
+++ b/go/codegen/experimental/codegen_couler.go
@@ -66,7 +66,6 @@ func GenerateCodeCouler(sqlProgram string, session *pb.Session) (string, error) 
 		if image == "" {
 			image = defaultDockerImage
 		}
-		// TODO(typhoonzero): find out the image that should be used by the predict statements.
 		step := &stepContext{
 			Code:      stepCode,
 			Image:     image,
@@ -175,9 +174,14 @@ if step_log_file:
 		"sleep %d" % step_exit_time_wait,
 		"exit $exit_code"
 	])
-	couler.run_script(image="{{.Image}}", command="bash", source=code, env=step_envs, resources=resources)
 else:
-	couler.run_script(image="{{.Image}}", source=step_entry_{{.StepIndex}}, env=step_envs, resources=resources)
+    code = "\n".join([
+        "python <<EOF",
+        pyfunc.body(step_entry_{{.StepIndex}}),
+        "EOF",
+    ])
+
+couler.run_script(image="{{.Image}}", command="bash", source=code, env=step_envs, resources=resources)
 {{end}}
 `
 

--- a/go/codegen/experimental/codegen_couler.go
+++ b/go/codegen/experimental/codegen_couler.go
@@ -139,14 +139,14 @@ step_envs = dict()
 
 sqlflow_secret = None
 if "{{.SecretName}}" != "":
-	# note(yancey1989): set dry_run to true, just reference the secret meta to generate workflow YAML,
-	# we should create the secret before launching sqlflowserver
-	secret_data=json.loads('''{{.SecretData}}''')
-	sqlflow_secret = couler.secret(secret_data, name="{{ .SecretName }}", dry_run=True)
+    # note(yancey1989): set dry_run to true, just reference the secret meta to generate workflow YAML,
+    # we should create the secret before launching sqlflowserver
+    secret_data=json.loads('''{{.SecretData}}''')
+    sqlflow_secret = couler.secret(secret_data, name="{{ .SecretName }}", dry_run=True)
 
 resources = None
 if '''{{.Resources}}''' != "":
-  resources=json.loads('''{{.Resources}}''')
+    resources=json.loads('''{{.Resources}}''')
 
 couler.clean_workflow_after_seconds_finished({{.WorkflowTTL}})
 
@@ -157,27 +157,27 @@ step_exit_time_wait = {{.StepExitTimeWait}}
 {{.Code}}
 
 codes = [
-	"python <<EOF",
-	pyfunc.body(step_entry_{{.StepIndex}}),
-	"EOF",
+    "python <<EOF",
+    pyfunc.body(step_entry_{{.StepIndex}}),
+    "EOF",
 ]
 
 if step_log_file:
-	log_dir = path.dirname(step_log_file)
-	codes = [
-		"if [[ -f /opt/sqlflow/init_step_container.sh ]]; then",
-		"  bash /opt/sqlflow/init_step_container.sh",
-		"fi",
-		"mkdir -p %s" % log_dir,
-		"set -o pipefail # fail when any sub-command fail",
-		"(",
-	] + codes + [
-		") 2>&1 | tee %s" % step_log_file,
-		"exit_code=$?",
-		"# sleep a while for finishing log collection",
-		"sleep %d" % step_exit_time_wait,
-		"exit $exit_code",
-	]
+    log_dir = path.dirname(step_log_file)
+    codes = [
+        "if [[ -f /opt/sqlflow/init_step_container.sh ]]; then",
+        "  bash /opt/sqlflow/init_step_container.sh",
+        "fi",
+        "mkdir -p %s" % log_dir,
+        "set -o pipefail # fail when any sub-command fail",
+        "(",
+    ] + codes + [
+        ") 2>&1 | tee %s" % step_log_file,
+        "exit_code=$?",
+        "# sleep a while for finishing log collection",
+        "sleep %d" % step_exit_time_wait,
+        "exit $exit_code",
+    ]
 
 couler.run_script(image="{{.Image}}", command="bash", source="\n".join(codes), env=step_envs, resources=resources)
 {{end}}

--- a/go/codegen/experimental/codegen_step_train.go
+++ b/go/codegen/experimental/codegen_step_train.go
@@ -43,6 +43,7 @@ type trainStepFiller struct {
 }
 
 func escapeSpecialRunesAndTrimSpace(s string) string {
+	s = strings.TrimSpace(s)
 	s = strings.ReplaceAll(s, "\r", "\\r")
 	s = strings.ReplaceAll(s, "\n", "\\n")
 	s = strings.ReplaceAll(s, "`", "\\`")

--- a/go/codegen/experimental/codegen_test.go
+++ b/go/codegen/experimental/codegen_test.go
@@ -35,7 +35,7 @@ func TestExperimentalXGBCodegen(t *testing.T) {
 	if err != nil {
 		t.Errorf("error %s", err)
 	}
-	a.True(strings.Contains(coulerCode, `couler.run_script(image="sqlflow/sqlflow:step", source=step_entry_0, env=step_envs, resources=resources)`))
+	a.True(strings.Contains(coulerCode, `couler.run_script(image="sqlflow/sqlflow:step", command="bash", source="\n".join(codes), env=step_envs, resources=resources)`))
 
 	// test with COLUMN clause
 	sql = "SELECT * FROM iris.train TO TRAIN xgboost.gbtree WITH objective=\"multi:softmax\",num_class=3 COLUMN petal_length LABEL class INTO sqlflow_models.xgb_classification;"


### PR DESCRIPTION
Considering when we want to run the SQL statement with backticks:

```SQL
SELECT `class` FROM table;
```

- If we use `bash "python ..."` command to run the step (i.e, we use `couler.run_script(command="bash"...)` to call couler), we have to escape the SQL statement to be
```SQL
SELECT \`class\` FROM table
```
Otherwise, the bash shell would consider \`class\` to be a shell command, causing the error `command class not found`.

- If we use `python ...` command to run the step (i.e, we use `couler.run_script(command=None...)` to call couler), there is no need to escape the backticks.

Instead of judging whether to escape the backticks in different cases, this PR unifies all couler calls to be `couler.run_script(command="bash"...)`. 