### PR TITLE
Correct estimator_predict args

### DIFF
--- a/python/runtime/pai/tensorflow_submitter/predict.py
+++ b/python/runtime/pai/tensorflow_submitter/predict.py
@@ -124,10 +124,8 @@ def _predict(datasource,
     else:
         model_params['model_dir'] = save
         print("Start predicting using estimator model...")
-        estimator_predict(estimator, model_params, save, result_table,
-                          feature_column_names, feature_column_names_map,
-                          feature_columns, feature_metas, train_label_name,
-                          result_col_name, conn, predict_generator,
-                          selected_cols)
+        estimator_predict(result_table, feature_column_names, feature_metas,
+                          train_label_name, result_col_name, conn,
+                          predict_generator, selected_cols)
 
     print("Done predicting. Predict table : %s" % result_table)


### PR DESCRIPTION
This causes the unit test to fail on PAI.
Let's follow the [function signature](https://github.com/sneaxiy/sqlflow/blob/c6352174a34c7512e5ca3557e0a6677855f59a8a/python/runtime/tensorflow/predict.py#L141-L143).