### PR TITLE
Speed up imports and fix the bug when selecting None value

### DIFF
--- a/go/cmd/sqlflowserver/e2e_common_cases.go
+++ b/go/cmd/sqlflowserver/e2e_common_cases.go
@@ -94,8 +94,9 @@ func caseSelect(t *testing.T) {
 		"petal_width",
 		"class",
 	}
+	dialect := os.Getenv("SQLFLOW_TEST_DB")
 	for idx, headCell := range head {
-		if os.Getenv("SQLFLOW_TEST_DB") == "hive" {
+		if dialect == "hive" {
 			a.Equal("train."+expectedHeads[idx], headCell)
 		} else {
 			a.Equal(expectedHeads[idx], headCell)
@@ -109,6 +110,12 @@ func caseSelect(t *testing.T) {
 		for colIdx, rowCell := range row {
 			a.True(EqualAny(expectedRows[rowIdx][colIdx], rowCell))
 		}
+	}
+
+	if dialect == "mysql" || dialect == "hive" {
+		describeSQL := fmt.Sprintf(`DESCRIBE %s;`, caseTrainTable)
+		_, _, _, err := connectAndRunSQL(describeSQL)
+		a.NoError(err)
 	}
 }
 

--- a/go/codegen/experimental/codegen_normal_stmt.go
+++ b/go/codegen/experimental/codegen_normal_stmt.go
@@ -22,13 +22,13 @@ import (
 
 const normalStmtStepTmpl = `
 def step_entry_{{.StepIndex}}():
-    import runtime
-    import runtime.dbapi
-    from runtime.dbapi import table_writer
-
-    conn = runtime.dbapi.connect("{{.DataSource}}")
+    from runtime.dbapi import connect
+    conn = connect("{{.DataSource}}")
     stmt = """{{.Stmt}}"""
     if conn.is_query(stmt):
+        # Importing table_writer is slow. So only
+        # import it when needed.
+        from runtime.dbapi import table_writer
         rs = conn.query(stmt)
         if rs.error():
             raise Exception("execute query error: %s " % rs.error())

--- a/python/runtime/dbapi/table_writer/protobuf_writer.py
+++ b/python/runtime/dbapi/table_writer/protobuf_writer.py
@@ -13,6 +13,8 @@
 
 from google.protobuf import text_format, wrappers_pb2
 from runtime.dbapi.connection import ResultSet
+# NOTE(sneaxiy): importing sqlflow_pb2 consumes about
+# 0.24s. Do not know how to shorten the import time.
 from runtime.dbapi.table_writer import sqlflow_pb2
 
 
@@ -40,7 +42,9 @@ class ProtobufWriter(object):
 
     @staticmethod
     def pod_to_pb_any(value):
-        if isinstance(value, bool):
+        if value is None:
+            v = sqlflow_pb2.Row.Null()
+        elif isinstance(value, bool):
             v = wrappers_pb2.BoolValue(value=value)
         elif isinstance(value, int):
             v = wrappers_pb2.Int64Value(value=value)


### PR DESCRIPTION
- When using the refactorized codes to run a simple select statement like `SELECT * FROM iris.train LIMIT 5;`, it consumes about 2s, which is not user-friendly. It is because importing `MySQL/Hive/...Connection` is quite slow. This PR refines it, and the time to run `SELECT * FROM iris.train LIMIT 5;` decreases from 2s to 0.24s.
- Some tables contain None data. It was not supported in the previous refactorized version.