### PR TITLE
Add self.commit after conn.execute and make dbapi raise Exception

### DIFF
--- a/go/cmd/sqlflow/main_test.go
+++ b/go/cmd/sqlflow/main_test.go
@@ -131,7 +131,8 @@ func TestRunStmt(t *testing.T) {
 	// TODO(yancey1989): assert should not panics in repl
 	output, err := step.GetStdout(func() error { return runStmt(clientOpts, "show tables", true) })
 	a.Error(err)
-	a.Contains(output, "Exception: execute query error: (1046, 'No database selected')")
+	a.Contains(output, "1046") // 1046 is the error code of "No database selected"
+	a.Contains(output, "No database selected")
 	output, err = step.GetStdout(func() error { return runStmt(clientOpts, "use iris", true) })
 	a.NoError(err)
 	a.Contains(output, "Database changed to iris")

--- a/go/cmd/sqlflowserver/e2e_common_cases.go
+++ b/go/cmd/sqlflowserver/e2e_common_cases.go
@@ -203,6 +203,10 @@ LABEL class INTO sqlflow_models.my_adanet_model;`, // train adanet
 }
 
 func caseTrainRegression(t *testing.T) {
+	seedEnvKey := "SQLFLOW_TF_RANDOM_SEED"
+	os.Setenv(seedEnvKey, "1")
+	defer os.Unsetenv(seedEnvKey)
+
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT *
 FROM housing.train
@@ -236,9 +240,10 @@ FROM housing.predict LIMIT 5;`)
 	}
 
 	for _, row := range rows {
-		// NOTE: predict result maybe random, only check predicted
-		// class >=0, need to change to more flexible checks than
-		// checking expectedPredClasses := []int64{2, 1, 0, 2, 0}
+		// NOTE: predict result maybe random. Since it is
+		// a regression model. The predict result may be
+		// negative. Here we fix the TensorFlow random
+		// seed to get the deterministic result.
 		AssertGreaterEqualAny(a, row[13], float64(0))
 
 		// avoiding nil features in predict result

--- a/go/cmd/sqlflowserver/e2e_common_cases.go
+++ b/go/cmd/sqlflowserver/e2e_common_cases.go
@@ -203,10 +203,6 @@ LABEL class INTO sqlflow_models.my_adanet_model;`, // train adanet
 }
 
 func caseTrainRegression(t *testing.T) {
-	seedEnvKey := "SQLFLOW_TF_RANDOM_SEED"
-	os.Setenv(seedEnvKey, "1")
-	defer os.Unsetenv(seedEnvKey)
-
 	a := assert.New(t)
 	trainSQL := fmt.Sprintf(`SELECT *
 FROM housing.train
@@ -240,10 +236,9 @@ FROM housing.predict LIMIT 5;`)
 	}
 
 	for _, row := range rows {
-		// NOTE: predict result maybe random. Since it is
-		// a regression model, the predict result may be
-		// negative. Here we fix the TensorFlow random
-		// seed to get the deterministic result.
+		// NOTE: predict result maybe random, only check predicted
+		// class >=0, need to change to more flexible checks than
+		// checking expectedPredClasses := []int64{2, 1, 0, 2, 0}
 		AssertGreaterEqualAny(a, row[13], float64(0))
 
 		// avoiding nil features in predict result

--- a/go/cmd/sqlflowserver/e2e_common_cases.go
+++ b/go/cmd/sqlflowserver/e2e_common_cases.go
@@ -241,7 +241,7 @@ FROM housing.predict LIMIT 5;`)
 
 	for _, row := range rows {
 		// NOTE: predict result maybe random. Since it is
-		// a regression model. The predict result may be
+		// a regression model, the predict result may be
 		// negative. Here we fix the TensorFlow random
 		// seed to get the deterministic result.
 		AssertGreaterEqualAny(a, row[13], float64(0))

--- a/go/cmd/sqlflowserver/e2e_mysql_test.go
+++ b/go/cmd/sqlflowserver/e2e_mysql_test.go
@@ -170,6 +170,7 @@ func TestEnd2EndMySQL(t *testing.T) {
 
 	t.Run("CaseShowDatabases", caseShowDatabases)
 	t.Run("CaseSelect", caseSelect)
+	t.Run("CaseInsert", caseInsert)
 	t.Run("CaseShouldError", CaseShouldError)
 	t.Run("CaseTrainSQL", caseTrainSQL)
 	t.Run("caseCoverageCommon", caseCoverageCommon)
@@ -216,6 +217,25 @@ func TestEnd2EndMySQL(t *testing.T) {
 	t.Run("CaseTestOptimizeClauseWithGroupBy", caseTestOptimizeClauseWithGroupBy)
 	t.Run("CaseTestOptimizeClauseWithBinaryVarType", caseTestOptimizeClauseWithBinaryVarType)
 	t.Run("CaseTestOptimizeClauseWithoutConstraint", caseTestOptimizeClauseWithoutConstraint)
+}
+
+func caseInsert(t *testing.T) {
+	const sqlTmpl = `DROP TABLE IF EXISTS %[1]s;
+	CREATE TABLE %[1]s (c BIGINT);
+	INSERT INTO %[1]s VALUES('1');`
+
+	table := caseDB + ".non_exist_table_name"
+	dropTableSQL := fmt.Sprintf(`DROP TABLE %s;`, table)
+	defer connectAndRunSQL(dropTableSQL)
+
+	a := assert.New(t)
+	_, _, _, err := connectAndRunSQL(fmt.Sprintf(sqlTmpl, table))
+	a.NoError(err)
+
+	countSQL := fmt.Sprintf(`SELECT * FROM %s;`, table)
+	_, rows, _, err := connectAndRunSQL(countSQL)
+	a.NoError(err)
+	a.Equal(1, len(rows))
 }
 
 func caseScoreCard(t *testing.T) {

--- a/go/codegen/experimental/codegen_normal_stmt.go
+++ b/go/codegen/experimental/codegen_normal_stmt.go
@@ -29,9 +29,7 @@ def step_entry_{{.StepIndex}}():
         # Importing table_writer is slow. So only
         # import it when needed.
         from runtime.dbapi import table_writer
-        rs = conn.query(stmt)
-        if rs.error():
-            raise Exception("execute query error: %s\n%s " % (stmt, rs.error()))
+        rs = conn.query(stmt)  # Exception would raise if error
         tw = table_writer.ProtobufWriter(rs)
         lines = tw.dump_strings()
         for l in lines:

--- a/go/codegen/experimental/codegen_normal_stmt.go
+++ b/go/codegen/experimental/codegen_normal_stmt.go
@@ -37,9 +37,7 @@ def step_entry_{{.StepIndex}}():
         for l in lines:
             print(l)
     else:
-        success = conn.execute(stmt)
-        if not success:
-            raise Exception("execute statement error: %s" % stmt)
+        conn.execute(stmt)  # Exception would raise if error
 
     conn.close()
 `

--- a/go/codegen/experimental/codegen_normal_stmt.go
+++ b/go/codegen/experimental/codegen_normal_stmt.go
@@ -31,7 +31,7 @@ def step_entry_{{.StepIndex}}():
     if conn.is_query(stmt):
         rs = conn.query(stmt)
         if rs.error():
-            raise Exception("execute query error: %s " % rs.error())
+            raise Exception("execute query error: %s\n%s " % (stmt, rs.error()))
         tw = table_writer.ProtobufWriter(rs)
         lines = tw.dump_strings()
         for l in lines:
@@ -39,7 +39,9 @@ def step_entry_{{.StepIndex}}():
     else:
         success = conn.execute(stmt)
         if not success:
-            raise Exception("execute statment error: %s" % stmt)
+            raise Exception("execute statement error: %s" % stmt)
+
+    conn.close()
 `
 
 var normalStmtStepTemplate = template.Must(template.New("NormalStmtStep").Parse(normalStmtStepTmpl))

--- a/python/runtime/dbapi/connection.py
+++ b/python/runtime/dbapi/connection.py
@@ -145,7 +145,11 @@ class Connection(object):
             A ResultSet object which is iteratable, each generated
             record in the iterator is a result-row wrapped by list
         """
-        return self._get_result_set(statement)
+        rs = self._get_result_set(statement)
+        if rs.success():
+            return rs
+        else:
+            raise Exception('Execute "%s" error\n%s' % (statement, rs.error()))
 
     def is_query(self, statement):
         """Return true if the statement is a query SQL statement."""
@@ -181,7 +185,7 @@ class Connection(object):
                 self.commit()
                 return True
             else:
-                raise Exception('Execute %s error\n%s',
+                raise Exception('Execute "%s" error\n%s' %
                                 (statement, rs.error()))
         finally:
             if rs is not None:

--- a/python/runtime/dbapi/connection.py
+++ b/python/runtime/dbapi/connection.py
@@ -173,9 +173,11 @@ class Connection(object):
         rs = None
         try:
             rs = self._get_result_set(statement)
-            return rs.success()
-        except Exception as e:  # noqa: E722
-            raise e
+            if rs.success():
+                self.commit()
+                return True
+            else:
+                raise ValueError(rs.error())
         finally:
             if rs is not None:
                 rs.close()
@@ -200,6 +202,9 @@ class Connection(object):
         Close the connection, implementation should support
         close multi-times
         """
+        pass
+
+    def commit(self):
         pass
 
     def __del__(self):

--- a/python/runtime/dbapi/connection.py
+++ b/python/runtime/dbapi/connection.py
@@ -181,7 +181,8 @@ class Connection(object):
                 self.commit()
                 return True
             else:
-                raise ValueError(rs.error())
+                raise Exception('Execute %s error\n%s',
+                                (statement, rs.error()))
         finally:
             if rs is not None:
                 rs.close()

--- a/python/runtime/dbapi/connection.py
+++ b/python/runtime/dbapi/connection.py
@@ -174,6 +174,10 @@ class Connection(object):
         try:
             rs = self._get_result_set(statement)
             if rs.success():
+                # NOTE(sneaxiy): must execute commit!
+                # Otherwise, the `INSERT` statement
+                # would have no effect even though
+                # the connection is closed.
                 self.commit()
                 return True
             else:

--- a/python/runtime/dbapi/hive_test.py
+++ b/python/runtime/dbapi/hive_test.py
@@ -29,9 +29,11 @@ class TestHiveConnection(TestCase):
 
     def test_query(self):
         conn = HiveConnection(testing.get_datasource())
-        with self.assertRaises(Exception):
+        try:
             conn.query("select * from notexist limit 1")
-        self.assertTrue("Table not found" in rs.error())
+            self.assertTrue(False)
+        except Exception as e:
+            self.assertTrue("Table not found" in str(e))
 
         rs = conn.query("select * from train limit 1")
         self.assertTrue(rs.success())

--- a/python/runtime/dbapi/hive_test.py
+++ b/python/runtime/dbapi/hive_test.py
@@ -29,8 +29,8 @@ class TestHiveConnection(TestCase):
 
     def test_query(self):
         conn = HiveConnection(testing.get_datasource())
-        rs = conn.query("select * from notexist limit 1")
-        self.assertFalse(rs.success())
+        with self.assertRaises(Exception):
+            conn.query("select * from notexist limit 1")
         self.assertTrue("Table not found" in rs.error())
 
         rs = conn.query("select * from train limit 1")

--- a/python/runtime/dbapi/maxcompute_test.py
+++ b/python/runtime/dbapi/maxcompute_test.py
@@ -30,8 +30,8 @@ class TestMaxComputeConnection(TestCase):
 
     def test_query(self):
         conn = MaxComputeConnection(testing.get_datasource())
-        rs = conn.query("select * from notexist limit 1")
-        self.assertFalse(rs.success())
+        with self.assertRaises(Exception):
+            conn.query("select * from notexist limit 1")
         self.assertTrue("Table not found" in rs.error())
 
         rs = conn.query(

--- a/python/runtime/dbapi/maxcompute_test.py
+++ b/python/runtime/dbapi/maxcompute_test.py
@@ -30,9 +30,11 @@ class TestMaxComputeConnection(TestCase):
 
     def test_query(self):
         conn = MaxComputeConnection(testing.get_datasource())
-        with self.assertRaises(Exception):
+        try:
             conn.query("select * from notexist limit 1")
-        self.assertTrue("Table not found" in rs.error())
+            self.assertTrue(False)
+        except Exception as e:
+            self.assertTrue("Table not found" in str(e))
 
         rs = conn.query(
             "select * from alifin_jtest_dev.sqlflow_iris_train limit 1")

--- a/python/runtime/dbapi/mysql_test.py
+++ b/python/runtime/dbapi/mysql_test.py
@@ -69,8 +69,8 @@ class TestMySQLConnection(TestCase):
         self.assertTrue(2, len(rows))
         rs = conn.execute("drop table test_exec")
         self.assertTrue(rs)
-        rs = conn.execute("drop table not_exist")
-        self.assertFalse(rs)
+        with self.assertRaises(Exception):
+            conn.execute("drop table not_exist")
 
     def test_get_table_schema(self):
         conn = MySQLConnection(testing.get_datasource())

--- a/python/runtime/dbapi/mysql_test.py
+++ b/python/runtime/dbapi/mysql_test.py
@@ -38,8 +38,8 @@ class TestMySQLConnection(TestCase):
 
     def test_query(self):
         conn = MySQLConnection(testing.get_datasource())
-        rs = conn.query("select * from notexist limit 1")
-        self.assertFalse(rs.success())
+        with self.assertRaises(Exception):
+            conn.query("select * from notexist limit 1")
 
         rs = conn.query("select * from train limit 1")
         self.assertTrue(rs.success())


### PR DESCRIPTION
- Fix the bug that the statement `INSERT INTO ...` does not take effect. We must commit the cursor after each SQL statement.
- Make the `conn.query` and `conn.execute` raise Exception if there is any error. This is designed to expose the errors asap instead of hiding the error in `ResultSet.success()` or `ResultSet.error()`.