### PR TITLE
Add dtype to xgboost numeric_column

### DIFF
--- a/python/runtime/feature/compile.py
+++ b/python/runtime/feature/compile.py
@@ -68,7 +68,10 @@ def compile_feature_column(ir_fc, model_type, package):
 
     if isinstance(ir_fc, NumericColumn):
         fd = ir_fc.get_field_desc()[0]
-        return fc_package.numeric_column(fd.name, shape=fd.shape)
+        return fc_package.numeric_column(fd.name,
+                                         shape=fd.shape,
+                                         dtype=to_package_dtype(
+                                             fd.dtype, package))
 
     if isinstance(ir_fc, BucketColumn):
         source_fc = compile_feature_column(ir_fc.source_column, model_type,

--- a/python/runtime/xgboost/feature_column.py
+++ b/python/runtime/xgboost/feature_column.py
@@ -68,9 +68,10 @@ class CategoricalColumnTransformer(BaseColumnTransformer):
 
 
 class NumericColumnTransformer(BaseColumnTransformer):
-    def __init__(self, key, shape=(1, )):
+    def __init__(self, key, shape=(1, ), dtype='float32'):
         self.key = key
         self.shape = shape
+        self.dtype = dtype
 
     def _set_feature_column_names(self, names):
         BaseColumnTransformer._set_feature_column_names(self, names)
@@ -83,8 +84,8 @@ class NumericColumnTransformer(BaseColumnTransformer):
         return [self.key]
 
 
-def numeric_column(key, shape=(1, )):
-    return NumericColumnTransformer(key, shape)
+def numeric_column(key, shape=(1, ), dtype='float32'):
+    return NumericColumnTransformer(key, shape, dtype)
 
 
 class BucketizedColumnTransformer(CategoricalColumnTransformer):


### PR DESCRIPTION
To unify the parameters of `tensorflow.feature_column.numeric_column` and `xgboost.feature_column.numeric_column`.