### PR TITLE
Support special char in username/passwd for mysql

### DIFF
--- a/python/runtime/dbapi/mysql.py
+++ b/python/runtime/dbapi/mysql.py
@@ -103,8 +103,8 @@ class MySQLConnection(Connection):
 
     def _parse_uri(self):
         # MySQL connection string is a DataSourceName(DSN),
-        # we need to do some pre-process
-        pattern = r"^(\w+)://(\w*):(\w*)@tcp\(([.a-zA-Z0-9\-]*):?([0-9]*)\)/(\w*)(\?.*)?$"  # noqa: W605, E501
+        # the username, passwd can be any character.
+        pattern = r"^(\w+)://(.*):(.*)@tcp\(([.a-zA-Z0-9\-]*):?([0-9]*)\)/(\w*)(\?.*)?$"  # noqa: W605, E501
         found_result = re.findall(pattern, self.uristr)
         scheme, user, passwd, host, port, db, config = found_result[0]
         netloc = "{}:{}@{}:{}".format(user, passwd, host, port or 3306)


### PR DESCRIPTION
When the MySQL username or password have char like `@` `#` etc, make it work.