### PR TITLE
Make CI run on both legacy codegen and experimental codegen

### DIFF
--- a/scripts/test/hive.sh
+++ b/scripts/test/hive.sh
@@ -49,6 +49,12 @@ export PYTHONPATH=$GOPATH/src/sqlflow.org/sqlflow/python:$PYTHONPATH
 
 go generate ./...
 go install ./...
-gotest -p 1 -covermode=count -coverprofile=coverage.txt -timeout 1800s  -v ./...
+
+for USE_EXPERIMENTAL_CODEGEN in "true" ""; do
+    export SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$USE_EXPERIMENTAL_CODEGEN
+    echo "Run go tests when SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$SQLFLOW_USE_EXPERIMENTAL_CODEGEN"
+    gotest -p 1 -covermode=count -coverprofile=coverage.txt -timeout 1800s  -v ./...
+done
+
 coverage run -m unittest discover -v python "db_test.py"
 coverage run -m unittest discover -v python "hive_test.py"

--- a/scripts/test/hive.sh
+++ b/scripts/test/hive.sh
@@ -40,7 +40,6 @@ export SQLFLOW_HIVE_LOCATION_ROOT_PATH=/sqlflow
 export SQLFLOW_TEST_NAMENODE_ADDR="127.0.0.1:8020"
 
 export SQLFLOW_TEST_DB=hive
-export SQLFLOW_USE_EXPERIMENTAL_CODEGEN=true
 
 # NOTE: we have already installed runtime under Python installation
 # path using latest develop branch, but when testing on CI, we need to use the
@@ -52,7 +51,7 @@ go install ./...
 
 for USE_EXPERIMENTAL_CODEGEN in "true" ""; do
     export SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$USE_EXPERIMENTAL_CODEGEN
-    echo "Run go tests when SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$SQLFLOW_USE_EXPERIMENTAL_CODEGEN"
+    echo "Run Go tests when SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$SQLFLOW_USE_EXPERIMENTAL_CODEGEN"
     gotest -p 1 -covermode=count -coverprofile=coverage.txt -timeout 1800s  -v ./...
 done
 

--- a/scripts/test/mysql.sh
+++ b/scripts/test/mysql.sh
@@ -41,7 +41,7 @@ go install ./...
 
 for USE_EXPERIMENTAL_CODEGEN in "true" ""; do
     export SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$USE_EXPERIMENTAL_CODEGEN
-    echo "Run go tests when SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$SQLFLOW_USE_EXPERIMENTAL_CODEGEN"
+    echo "Run Go tests when SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$SQLFLOW_USE_EXPERIMENTAL_CODEGEN"
     gotest -p 1 -covermode=count -coverprofile=coverage.txt -timeout 1500s  -v ./...
 done
 

--- a/scripts/test/mysql.sh
+++ b/scripts/test/mysql.sh
@@ -32,14 +32,18 @@ while true; do
 done
 
 export SQLFLOW_TEST_DB=mysql
-export SQLFLOW_USE_EXPERIMENTAL_CODEGEN=true
 
 python -c "import sqlflow_models"
 python -c "import runtime.db"
 
 go generate ./...
 go install ./...
-gotest -p 1 -covermode=count -coverprofile=coverage.txt -timeout 1500s  -v ./...
+
+for USE_EXPERIMENTAL_CODEGEN in "true" ""; do
+    export SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$USE_EXPERIMENTAL_CODEGEN
+    echo "Run go tests when SQLFLOW_USE_EXPERIMENTAL_CODEGEN=$SQLFLOW_USE_EXPERIMENTAL_CODEGEN"
+    gotest -p 1 -covermode=count -coverprofile=coverage.txt -timeout 1500s  -v ./...
+done
 
 # When running the following command, the TensorFlow FLAGS module would pass
 # ["discover", "-v", "python", "*_test.py"] as the sys.argv to init the


### PR DESCRIPTION
Also, fix some errors on Hive CI.

```
2020-10-12T13:34:28.0638028Z [0m[91m    --- FAIL: TestEnd2EndHive/caseTrainSQL (47.71s)
2020-10-12T13:34:28.0639440Z [0m[0m        testing.go:165: 
2020-10-12T13:34:28.0641323Z [0m[0m            	Error Trace:	testing.go:165
2020-10-12T13:34:28.0644278Z [0m[0m            	            				e2e_common_cases.go:395
2020-10-12T13:34:28.0646410Z [0m[0m            	Error:      	unsupported type comparison type.googleapis.com/google.protobuf.Int32Value int64
2020-10-12T13:34:28.0648765Z [0m[0m            	Test:       	TestEnd2EndHive/caseTrainSQL
2020-10-12T13:34:28.0650927Z [0m[0m        testing.go:165: 
2020-10-12T13:34:28.0652283Z [0m[0m            	Error Trace:	testing.go:165
2020-10-12T13:34:28.0653437Z [0m[0m            	            				e2e_common_cases.go:395
2020-10-12T13:34:28.0655322Z [0m[0m            	Error:      	unsupported type comparison type.googleapis.com/google.protobuf.Int32Value int64
2020-10-12T13:34:28.0657517Z [0m[0m            	Test:       	TestEnd2EndHive/caseTrainSQL
2020-10-12T13:34:28.0658744Z [0m[0m        testing.go:165: 
2020-10-12T13:34:28.0660689Z [0m[0m            	Error Trace:	testing.go:165
2020-10-12T13:34:28.0661827Z [0m[0m            	            				e2e_common_cases.go:395
2020-10-12T13:34:28.0664259Z [0m[0m            	Error:      	unsupported type comparison type.googleapis.com/google.protobuf.Int32Value int64
2020-10-12T13:34:28.0666540Z [0m[0m            	Test:       	TestEnd2EndHive/caseTrainSQL
2020-10-12T13:34:28.0667935Z [0m[0m        testing.go:165: 
2020-10-12T13:34:28.0669059Z [0m[0m            	Error Trace:	testing.go:165
2020-10-12T13:34:28.0670226Z [0m[0m            	            				e2e_common_cases.go:395
2020-10-12T13:34:28.0671996Z [0m[0m            	Error:      	unsupported type comparison type.googleapis.com/google.protobuf.Int32Value int64
2020-10-12T13:34:28.0673829Z [0m[0m            	Test:       	TestEnd2EndHive/caseTrainSQL
2020-10-12T13:34:28.0674978Z [0m[0m        testing.go:165: 
2020-10-12T13:34:28.0675929Z [0m[0m            	Error Trace:	testing.go:165
2020-10-12T13:34:28.0677068Z [0m[0m            	            				e2e_common_cases.go:395
2020-10-12T13:34:28.0678801Z [0m[0m            	Error:      	unsupported type comparison type.googleapis.com/google.protobuf.Int32Value int64
2020-10-12T13:34:28.0680776Z [0m[0m            	Test:       	TestEnd2EndHive/caseTrainSQL
```