### PR TITLE
Make MySQL string field type to be TEXT

### DIFF
--- a/python/runtime/feature/field_desc.py
+++ b/python/runtime/feature/field_desc.py
@@ -61,7 +61,7 @@ class DataType(object):
 
         if dtype == DataType.STRING:
             if driver == "mysql":
-                return "VARCHAR(255)"
+                return "TEXT"
             return "STRING"
 
         raise ValueError("unsupported data type {}".format(dtype))


### PR DESCRIPTION
`VARCHAR(255)` is not enough to save the long strings.