### PR TITLE
Fix go maxcompute select error

### DIFF
--- a/go/executor/fields.go
+++ b/go/executor/fields.go
@@ -16,16 +16,11 @@ package executor
 import (
 	"database/sql"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
 )
-
-func newZeroValue(t reflect.Type) interface{} {
-	return reflect.New(t).Interface()
-}
 
 func fieldValue(val interface{}) (interface{}, error) {
 	switch v := val.(type) {

--- a/go/executor/fields.go
+++ b/go/executor/fields.go
@@ -29,6 +29,11 @@ func fieldValue(val interface{}) (interface{}, error) {
 			return (*v).Bool, nil
 		}
 		return nil, nil
+	case *sql.NullInt32:
+		if (*v).Valid {
+			return (*v).Int32, nil
+		}
+		return nil, nil
 	case *sql.NullInt64:
 		if (*v).Valid {
 			return (*v).Int64, nil
@@ -90,7 +95,7 @@ func fieldValue(val interface{}) (interface{}, error) {
 	case *float64:
 		return *v, nil
 	default:
-		return nil, fmt.Errorf("unrecognized type %v", v)
+		return nil, fmt.Errorf("unrecognized type %T", v)
 	}
 }
 

--- a/go/executor/sql_stmt.go
+++ b/go/executor/sql_stmt.go
@@ -98,7 +98,7 @@ func parseRow(columns []string, columnTypes []*sql.ColumnType, rows *sql.Rows, w
 	// runtime. Some databases support dynamic types between rows,
 	// such as sqlite's affinity. So we move columnTypes inside
 	// the row.Next() loop.
-	values := ir.NewRowValuesToScan(columnTypes)
+	values := ir.NewRowValuesToScan(columnTypes, true)
 	if err := rows.Scan(values...); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix the error:
```
--- FAIL: TestEnd2EndMaxComputePAI/group/CasePAIMaxComputeDNNTrainPredictExplain (250.02s)
            testing.go:165: 
                  Error Trace:  testing.go:165
                                      e2e_pai_maxcompute_test.go:323
                  Error:        unsupported type comparison type.googleapis.com/google.protobuf.StringValue int64
                  Test:         TestEnd2EndMaxComputePAI/group/CasePAIMaxComputeDNNTrainPredictExplain
```


The gomaxcompute would return `string` as the ScanType for `BIGINT/DOUBLE/...` column. This would cause errors when we want to get the integral value of a `BIGINT` column.