### PR TITLE
Fix UseExperimentalExecutor

### DIFF
--- a/go/executor/executor.go
+++ b/go/executor/executor.go
@@ -214,17 +214,14 @@ func (s *pythonExecutor) tryExperimentalExecute(sqlStmt ir.SQLFlowStmt, logStder
 		return true, err
 	}
 
-	stepFuncCode, err := experimental.GetPyFuncBody(stepCode, "step_entry_0")
-	if err != nil {
-		return true, err
-	}
-
 	const bashCodeTmpl = `python -u <<EOF
 %s
+
+step_entry_0()
 EOF
 `
 
-	cmd := exec.Command("bash", "-c", fmt.Sprintf(bashCodeTmpl, stepFuncCode))
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(bashCodeTmpl, stepCode))
 	cmd.Dir = s.Cwd
 	errorLog, err := s.runCommand(cmd, nil, logStderr)
 	if err != nil {

--- a/go/executor/executor.go
+++ b/go/executor/executor.go
@@ -174,24 +174,21 @@ type pythonExecutor struct {
 }
 
 // UseExperimentalExecutor returns whether to use the experimental codegen
-func UseExperimentalExecutor(exec Executor) (bool, error) {
+func UseExperimentalExecutor(dbConnStr string) (bool, error) {
 	if os.Getenv("SQLFLOW_USE_EXPERIMENTAL_CODEGEN") != "true" {
 		return false, nil
 	}
 
-	if pyExec, ok := exec.(*pythonExecutor); ok {
-		dialect, _, err := database.ParseURL(pyExec.Session.DbConnStr)
-		if err != nil {
-			return false, err
-		}
-
-		// TODO(sneaxiy): remove this line when PyAlisa is ready.
-		if dialect == "alisa" {
-			return false, nil
-		}
-		return true, nil
+	dialect, _, err := database.ParseURL(dbConnStr)
+	if err != nil {
+		return false, err
 	}
-	return false, nil
+
+	// TODO(sneaxiy): remove this line when PyAlisa is ready.
+	if dialect == "alisa" {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (s *pythonExecutor) tryExperimentalExecute(sqlStmt ir.SQLFlowStmt, logStderr bool) (bool, error) {
@@ -200,7 +197,7 @@ func (s *pythonExecutor) tryExperimentalExecute(sqlStmt ir.SQLFlowStmt, logStder
 		return false, nil
 	}
 
-	ok, err := UseExperimentalExecutor(s)
+	ok, err := UseExperimentalExecutor(s.Session.DbConnStr)
 	if err != nil {
 		return true, err
 	}

--- a/go/sql/executor_ir.go
+++ b/go/sql/executor_ir.go
@@ -186,7 +186,7 @@ func runSingleSQLFlowStatement(wr *pipe.Writer, sql *parser.SQLFlowStmt, db *dat
 	exec := executor.New(session.Submitter)
 	exec.Setup(wr, db, modelDir, cwd, session)
 
-	useExperimentalExecutor, err := executor.UseExperimentalExecutor(exec)
+	useExperimentalExecutor, err := executor.UseExperimentalExecutor(session.DbConnStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Fix UseExperimentalExecutor to make the PAI and Alisa executor run correctly using the experimental codegen.
- Call `step_entry_0` directly instead of using couler to get the method codes.