### PR TITLE
Prepare to support PAI prediction using experimental codegen

### DIFF
--- a/go/executor/pai_local.go
+++ b/go/executor/pai_local.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	"sqlflow.org/sqlflow/go/codegen/pai"
-	"sqlflow.org/sqlflow/go/database"
 	"sqlflow.org/sqlflow/go/ir"
 	"sqlflow.org/sqlflow/go/model"
 )
@@ -40,11 +39,7 @@ func (s *paiLocalExecutor) ExecuteTrain(trainStmt *ir.TrainStmt) error {
 	if err != nil {
 		return err
 	}
-	ossModelPathToSave, e := getModelPath(trainStmt.Into, s.Session)
-	if e != nil {
-		return e
-	}
-	currProject, e := database.GetDatabaseName(s.Session.DbConnStr)
+	ossModelPathToSave, e := model.GetOSSModelPath(trainStmt.Into, s.Session)
 	if e != nil {
 		return e
 	}
@@ -56,7 +51,7 @@ func (s *paiLocalExecutor) ExecuteTrain(trainStmt *ir.TrainStmt) error {
 	// download model from OSS to local cwd and save to sqlfs
 	// NOTE(typhoonzero): model in sqlfs will be used by sqlflow model zoo currently
 	// should use the model in sqlfs when predicting.
-	if e = downloadOSSModel(ossModelPathToSave+"/", currProject); e != nil {
+	if e = downloadOSSModel(ossModelPathToSave + "/"); e != nil {
 		return e
 	}
 	m := model.New(s.Cwd, trainStmt.OriginalSQL)
@@ -70,7 +65,7 @@ func (s *paiLocalExecutor) ExecutePredict(predStmt *ir.PredictStmt) error {
 	if err != nil {
 		return err
 	}
-	ossModelPathToSave, e := getModelPath(predStmt.Using, s.Session)
+	ossModelPathToSave, e := model.GetOSSModelPath(predStmt.Using, s.Session)
 	if e != nil {
 		return e
 	}
@@ -84,7 +79,7 @@ func (s *paiLocalExecutor) ExecuteExplain(explainStmt *ir.ExplainStmt) error {
 	if err != nil {
 		return err
 	}
-	ossModelPathToSave, e := getModelPath(explainStmt.ModelName, s.Session)
+	ossModelPathToSave, e := model.GetOSSModelPath(explainStmt.ModelName, s.Session)
 	if e != nil {
 		return e
 	}
@@ -98,7 +93,7 @@ func (s *paiLocalExecutor) ExecuteEvaluate(evalStmt *ir.EvaluateStmt) error {
 	if err != nil {
 		return err
 	}
-	ossModelPathToSave, e := getModelPath(evalStmt.ModelName, s.Session)
+	ossModelPathToSave, e := model.GetOSSModelPath(evalStmt.ModelName, s.Session)
 	if e != nil {
 		return e
 	}

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"io"
 	"io/ioutil"
 	"os"
@@ -422,4 +423,34 @@ func MockInDB(cwd, trainSelect, table string) error {
 		return e
 	}
 	return m.saveDB(database.GetTestingDBSingleton().URL(), table, database.GetSessionFromTestingDB())
+}
+
+// GetOSSModelBucket gets the OSS bucket of to save models.
+func GetOSSModelBucket() (*oss.Bucket, error) {
+	const bucketName = "sqlflow-models"
+	ak := os.Getenv("SQLFLOW_OSS_AK")
+	sk := os.Getenv("SQLFLOW_OSS_SK")
+	ep := os.Getenv("SQLFLOW_OSS_MODEL_ENDPOINT")
+	if ak == "" || sk == "" || ep == "" {
+		return nil, fmt.Errorf("should define SQLFLOW_OSS_MODEL_ENDPOINT, SQLFLOW_OSS_AK, SQLFLOW_OSS_SK when using submitter alisa")
+	}
+
+	cli, e := oss.New(ep, ak, sk)
+	if e != nil {
+		return nil, e
+	}
+	return cli.Bucket(bucketName)
+}
+
+// GetOSSModelPath gets the OSS path of the saved models.
+func GetOSSModelPath(modelName string, session *pb.Session) (string, error) {
+	userID := session.UserId
+	projectName, err := database.GetDatabaseName(session.DbConnStr)
+	if err != nil {
+		return "", err
+	}
+	if userID == "" {
+		userID = "unknown"
+	}
+	return strings.Join([]string{projectName, userID, modelName}, "/"), nil
 }

--- a/python/runtime/alisa/submitter.py
+++ b/python/runtime/alisa/submitter.py
@@ -248,7 +248,7 @@ def submit_alisa_predict(datasource, select, result_table, label_column,
     oss_model_path = get_oss_model_save_path(datasource, model_name)
     params["oss_model_path"] = oss_model_path
     model_type, estimator = get_oss_saved_model_type_and_estimator(
-        oss_model_path, project)
+        oss_model_path)
     setup_predict_entry(params, model_type)
 
     # (TODO:lhw) get train label column from model meta
@@ -298,7 +298,7 @@ def submit_alisa_explain(datasource, select, result_table, model_name,
 
     oss_model_path = get_oss_model_save_path(datasource, model_name)
     model_type, estimator = get_oss_saved_model_type_and_estimator(
-        oss_model_path, project)
+        oss_model_path)
     params["oss_model_path"] = oss_model_path
 
     label_column = model_params.get("label_col")
@@ -341,7 +341,7 @@ def submit_alisa_evaluate(datasource, model_name, select, result_table,
     params["oss_model_path"] = oss_model_path
 
     model_type, estimator = get_oss_saved_model_type_and_estimator(
-        oss_model_path, project)
+        oss_model_path)
     if model_type == EstimatorType.PAIML:
         raise SQLFlowDiagnostic("PAI model evaluation is not supported yet.")
 

--- a/python/runtime/alisa/submitter.py
+++ b/python/runtime/alisa/submitter.py
@@ -29,12 +29,12 @@ from runtime.pai.submitter import (ENTRY_FILE, JOB_ARCHIVE_FILE, PARAMS_FILE,
                                    drop_tables, gen_rand_string,
                                    get_evaluate_metrics,
                                    get_oss_model_save_path,
-                                   get_oss_saved_model_type_and_estimator,
                                    get_pai_explain_cmd, get_pai_predict_cmd,
                                    get_pai_tf_cmd, get_pai_train_cmd,
-                                   get_project, prepare_archive,
-                                   save_model_to_sqlfs, setup_explain_entry,
-                                   setup_predict_entry)
+                                   get_project,
+                                   get_saved_model_type_and_estimator,
+                                   prepare_archive, save_model_to_sqlfs,
+                                   setup_explain_entry, setup_predict_entry)
 
 # yapf: enable
 
@@ -247,8 +247,8 @@ def submit_alisa_predict(datasource, select, result_table, label_column,
 
     oss_model_path = get_oss_model_save_path(datasource, model_name)
     params["oss_model_path"] = oss_model_path
-    model_type, estimator = get_oss_saved_model_type_and_estimator(
-        oss_model_path)
+    model_type, estimator = get_saved_model_type_and_estimator(
+        datasource, model_name)
     setup_predict_entry(params, model_type)
 
     # (TODO:lhw) get train label column from model meta
@@ -297,8 +297,8 @@ def submit_alisa_explain(datasource, select, result_table, model_name,
         result_table = "%s.%s" % (project, result_table)
 
     oss_model_path = get_oss_model_save_path(datasource, model_name)
-    model_type, estimator = get_oss_saved_model_type_and_estimator(
-        oss_model_path)
+    model_type, estimator = get_saved_model_type_and_estimator(
+        datasource, model_name)
     params["oss_model_path"] = oss_model_path
 
     label_column = model_params.get("label_col")
@@ -340,8 +340,8 @@ def submit_alisa_evaluate(datasource, model_name, select, result_table,
     oss_model_path = get_oss_model_save_path(datasource, model_name)
     params["oss_model_path"] = oss_model_path
 
-    model_type, estimator = get_oss_saved_model_type_and_estimator(
-        oss_model_path)
+    model_type, estimator = get_saved_model_type_and_estimator(
+        datasource, model_name)
     if model_type == EstimatorType.PAIML:
         raise SQLFlowDiagnostic("PAI model evaluation is not supported yet.")
 

--- a/python/runtime/dbapi/connection.py
+++ b/python/runtime/dbapi/connection.py
@@ -216,5 +216,8 @@ class Connection(object):
     def commit(self):
         pass
 
+    def persist_table(self, table):
+        pass
+
     def __del__(self):
         self.close()

--- a/python/runtime/dbapi/maxcompute.py
+++ b/python/runtime/dbapi/maxcompute.py
@@ -129,6 +129,10 @@ class MaxComputeConnection(Connection):
         schema = self._conn.get_table(table_name).schema
         return [(c.name, str(c.type).upper()) for c in schema.columns]
 
+    def persist_table(self, table):
+        sql = "ALTER TABLE %s DISABLE LIFECYCLE;" % table
+        self.execute(sql)
+
     def write_table(self,
                     table_name,
                     rows,

--- a/python/runtime/model/db.py
+++ b/python/runtime/model/db.py
@@ -211,14 +211,23 @@ def read_with_generator_and_metadata(datasource, table, buff_size=256):
     metadata = _read_metadata(r)
 
     def reader():
-        while True:
-            buffer = r.read(buff_size)
-            if not buffer:
-                break
+        try:
+            while True:
+                buffer = r.read(buff_size)
+                if not buffer:
+                    break
 
-            yield buffer
+                yield buffer
+        finally:
+            reader.close()
 
-        r.close()
-        conn.close()
+    def close():
+        if not reader.is_closed:
+            r.close()
+            conn.close()
+            reader.is_closed = True
+
+    reader.is_closed = False
+    reader.close = close
 
     return reader, metadata

--- a/python/runtime/model/model.py
+++ b/python/runtime/model/model.py
@@ -243,6 +243,18 @@ class Model(object):
 
         return Model._from_dict(metadata)
 
+    @staticmethod
+    def load_metadata_from_db(datasource, table):
+        model_zoo_addr, table, tag = _decompose_model_name(table)
+        if model_zoo_addr:
+            gen, metadata = load_model_from_model_zoo(model_zoo_addr, table,
+                                                      tag)
+        else:
+            gen, metadata = read_with_generator_and_metadata(datasource, table)
+
+        gen.close()
+        return Model._from_dict(metadata)
+
     def save_to_oss(self, oss_model_dir, local_dir=None):
         """
         This save function would archive all the files on local_dir
@@ -294,15 +306,6 @@ class Model(object):
             oss.load_file(oss_model_dir, tarball, TARBALL_NAME)
             Model._unzip(local_dir, tarball)
 
-        return Model.load_metadata_from_oss(oss_model_dir)
-
-    @staticmethod
-    def load_metadata_from_oss(oss_model_dir):
-        # NOTE: maybe PAI ML models
-        if not oss.has_file(oss_model_dir, MODEL_OBJ_FILE_NAME):
-            return None
-
-        with temp_file.TemporaryDirectory() as tmp_dir:
             model_obj_file = os.path.join(tmp_dir, MODEL_OBJ_FILE_NAME)
             oss.load_file(oss_model_dir, model_obj_file, MODEL_OBJ_FILE_NAME)
             with open(model_obj_file, "r") as f:

--- a/python/runtime/model/model.py
+++ b/python/runtime/model/model.py
@@ -29,7 +29,7 @@ from runtime.model.tar import unzip_dir, zip_dir
 TARBALL_NAME = "model.tar.gz"
 
 # serialize the Model object into file
-MODEL_OBJ_FILE_NAME = "sqlflow_metadata.json"
+MODEL_OBJ_FILE_NAME = "metadata.json"
 
 
 class EstimatorType(object):

--- a/python/runtime/model/modelzoo.py
+++ b/python/runtime/model/modelzoo.py
@@ -36,10 +36,20 @@ def load_model_from_model_zoo(address, model, tag):
         six.reraise(*sys.exc_info())
 
     def reader():
-        with channel:
+        try:
             tar_req = ReleaseModelRequest(name=model, tag=tag)
             tar_resp = stub.DownloadModel(tar_req)
             for each_resp in tar_resp:
                 yield each_resp.content_tar
+        finally:
+            reader.close()
+
+    def close():
+        if not reader.is_closed:
+            channel.close()
+            reader.is_closed = True
+
+    reader.is_closed = False
+    reader.close = close
 
     return reader, meta

--- a/python/runtime/model/oss.py
+++ b/python/runtime/model/oss.py
@@ -205,13 +205,6 @@ def load_file(oss_model_dir, local_file_name, oss_file_name=None):
     bucket.get_object_to_file(oss_file_path, local_file_name)
 
 
-def has_file(oss_model_dir, file_name):
-    oss_file_path = "/".join([oss_model_dir.rstrip("/"), file_name])
-    oss_file_path = remove_bucket_prefix(oss_file_path)
-    bucket = get_models_bucket()
-    return bucket.object_exists(oss_file_path)
-
-
 def load_string(oss_file_path):
     data = load_bytes(oss_file_path)
     return data.decode("utf-8")

--- a/python/runtime/model/oss.py
+++ b/python/runtime/model/oss.py
@@ -205,6 +205,13 @@ def load_file(oss_model_dir, local_file_name, oss_file_name=None):
     bucket.get_object_to_file(oss_file_path, local_file_name)
 
 
+def has_file(oss_model_dir, file_name):
+    oss_file_path = "/".join([oss_model_dir.rstrip("/"), file_name])
+    oss_file_path = remove_bucket_prefix(oss_file_path)
+    bucket = get_models_bucket()
+    return bucket.object_exists(oss_file_path)
+
+
 def load_string(oss_file_path):
     data = load_bytes(oss_file_path)
     return data.decode("utf-8")

--- a/python/runtime/pai/__init__.py
+++ b/python/runtime/pai/__init__.py
@@ -13,5 +13,5 @@
 
 from runtime.pai.submitter_evaluate import submit_pai_evaluate as evaluate  # noqa
 from runtime.pai.submitter_explain import submit_pai_explain as explain  # noqa
-from runtime.pai.submitter_predict import submit_pai_predict as predict  # noqa
+from runtime.pai.submitter_predict import submit_pai_predict as pred  # noqa
 from runtime.pai.submitter_train import submit_pai_train as train  # noqa

--- a/python/runtime/pai/pai_model.py
+++ b/python/runtime/pai/pai_model.py
@@ -15,6 +15,7 @@ import subprocess
 
 from runtime.dbapi.maxcompute import MaxComputeConnection
 from runtime.model import EstimatorType, oss
+from runtime.model.model import Model
 
 
 def get_oss_model_url(model_full_path):
@@ -60,7 +61,7 @@ def clean_oss_model_path(oss_path):
     oss.delete_oss_dir_recursive(bucket, oss_path)
 
 
-def get_oss_saved_model_type_and_estimator(model_name, project):
+def get_oss_saved_model_type_and_estimator(model_name):
     """Get oss model type and estimator name, model can be:
     1. PAI ML models: model is saved by pai
     2. xgboost: on OSS with model file xgboost_model_desc
@@ -77,20 +78,10 @@ def get_oss_saved_model_type_and_estimator(model_name, project):
     # FIXME(typhoonzero): if the model not exist on OSS, assume it's a random
     # forest model should use a general method to fetch the model and see the
     # model type.
-    bucket = oss.get_models_bucket()
-    tf = bucket.object_exists(model_name + "/tensorflow_model_desc")
-    if tf:
-        modelType = EstimatorType.TENSORFLOW
-        bucket.get_object_to_file(
-            model_name + "/tensorflow_model_desc_estimator",
-            "tmp_estimator_name")
-        with open("tmp_estimator_name") as file:
-            estimator = file.readline()
-        return modelType, estimator
+    metadata = Model.load_metadata_from_oss(model_name)
+    if metadata is None:
+        return EstimatorType.PAIML, ""
 
-    xgb = bucket.object_exists(model_name + "/xgboost_model_desc")
-    if xgb:
-        modelType = EstimatorType.XGBOOST
-        return modelType, "xgboost"
-
-    return EstimatorType.PAIML, ""
+    estimator = metadata.get_meta("class_name")
+    estimator_type = Model.estimator_type(estimator)
+    return estimator_type, estimator

--- a/python/runtime/pai/submitter_evaluate.py
+++ b/python/runtime/pai/submitter_evaluate.py
@@ -95,7 +95,7 @@ def submit_pai_evaluate(datasource,
     params["oss_model_path"] = oss_model_path
 
     model_type, estimator = pai_model.get_oss_saved_model_type_and_estimator(
-        oss_model_path, project)
+        oss_model_path)
     if model_type == EstimatorType.PAIML:
         raise SQLFlowDiagnostic("PAI model evaluation is not supported yet.")
 

--- a/python/runtime/pai/submitter_evaluate.py
+++ b/python/runtime/pai/submitter_evaluate.py
@@ -94,8 +94,8 @@ def submit_pai_evaluate(datasource,
                                                        user=user)
     params["oss_model_path"] = oss_model_path
 
-    model_type, estimator = pai_model.get_oss_saved_model_type_and_estimator(
-        oss_model_path)
+    model_type, estimator = pai_model.get_saved_model_type_and_estimator(
+        datasource, model_name)
     if model_type == EstimatorType.PAIML:
         raise SQLFlowDiagnostic("PAI model evaluation is not supported yet.")
 

--- a/python/runtime/pai/submitter_explain.py
+++ b/python/runtime/pai/submitter_explain.py
@@ -158,7 +158,7 @@ def submit_pai_explain(datasource,
                                                        user=user)
     params["oss_model_path"] = oss_model_path
     model_type, estimator = pai_model.get_oss_saved_model_type_and_estimator(
-        oss_model_path, project)
+        oss_model_path)
     params["load"] = model_name
 
     label_column = model_params.get("label_col")

--- a/python/runtime/pai/submitter_explain.py
+++ b/python/runtime/pai/submitter_explain.py
@@ -157,8 +157,8 @@ def submit_pai_explain(datasource,
                                                        model_name,
                                                        user=user)
     params["oss_model_path"] = oss_model_path
-    model_type, estimator = pai_model.get_oss_saved_model_type_and_estimator(
-        oss_model_path)
+    model_type, estimator = pai_model.get_saved_model_type_and_estimator(
+        datasource, model_name)
     params["load"] = model_name
 
     label_column = model_params.get("label_col")

--- a/python/runtime/pai/submitter_predict.py
+++ b/python/runtime/pai/submitter_predict.py
@@ -130,8 +130,8 @@ def submit_pai_predict(datasource,
                                                            user=user)
         params["oss_model_path"] = oss_model_path
         model_type, estimator = \
-            pai_model.get_oss_saved_model_type_and_estimator(oss_model_path)
-
+            pai_model.get_saved_model_type_and_estimator(
+                datasource, model_name)
         setup_predict_entry(params, model_type)
 
         if try_pai_local_run(params, oss_model_path):

--- a/python/runtime/pai/submitter_predict.py
+++ b/python/runtime/pai/submitter_predict.py
@@ -130,15 +130,16 @@ def submit_pai_predict(datasource,
                                                            model_name,
                                                            user=user)
         params["oss_model_path"] = oss_model_path
-        model_type, estimator = pai_model.get_oss_saved_model_type_and_estimator(
-            oss_model_path)
+        model_type, estimator = \
+            pai_model.get_oss_saved_model_type_and_estimator(oss_model_path)
 
         setup_predict_entry(params, model_type)
 
         if try_pai_local_run(params, oss_model_path):
             return
 
-        # TODO(sneaxiy): should create predict result table in pai/xxx/predict.py
+        # TODO(sneaxiy): should create predict result table in
+        # pai/xxx/predict.py
         create_predict_result_table(datasource, data_table, result_table,
                                     label_column, None, model_type)
 

--- a/python/runtime/pai/submitter_test.py
+++ b/python/runtime/pai/submitter_test.py
@@ -21,7 +21,7 @@ import runtime.feature.field_desc as fd
 import runtime.testing as testing
 import runtime.xgboost as xgboost_extended  # noqa: F401
 import tensorflow as tf  # noqa: E0401,F401
-from runtime.pai import (evaluate, explain, get_pai_tf_cmd, pai_model, predict,
+from runtime.pai import (evaluate, explain, get_pai_tf_cmd, pai_model, pred,
                          train)
 from runtime.pai.cluster_conf import get_cluster_config
 from runtime.pai.pai_distributed import define_tf_flags
@@ -89,6 +89,15 @@ feature_column_map = {
 label_column = fc.NumericColumn(fd.FieldDesc(name="class"))
 
 
+def test_submit_pai_predict_task():
+    original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test
+TO PREDICT alifin_jtest_dev.pai_dnn_predict.class
+USING e2etest_pai_dnn;"""
+    pred(testing.get_datasource(), original_sql,
+         """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test""",
+         "e2etest_pai_dnn", "class", {}, "alifin_jtest_dev.pai_dnn_predict")
+
+
 @unittest.skipUnless(testing.get_driver() == "maxcompute"
                      and testing.get_submitter() == "pai",
                      "skip non PAI tests")
@@ -114,10 +123,10 @@ INTO e2etest_pai_dnn;"""
         original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test
 TO PREDICT alifin_jtest_dev.pai_dnn_predict.class
 USING e2etest_pai_dnn;"""
-        predict(testing.get_datasource(), original_sql,
-                """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test""",
-                "e2etest_pai_dnn", "class", {},
-                "alifin_jtest_dev.pai_dnn_predict")
+        pred(testing.get_datasource(), original_sql,
+             """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test""",
+             "e2etest_pai_dnn", "class", {},
+             "alifin_jtest_dev.pai_dnn_predict")
 
     def test_submit_pai_explain_task(self):
         original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test
@@ -162,10 +171,10 @@ INTO e2etest_xgb_classify_model;"""
         original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test
 TO PREDICT alifin_jtest_dev.pai_xgb_predict.class
 USING e2etest_xgb_classify_model;"""
-        predict(testing.get_datasource(), original_sql,
-                "SELECT * FROM alifin_jtest_dev.sqlflow_iris_test",
-                "e2etest_xgb_classify_model", "class", {},
-                "alifin_jtest_dev.pai_xgb_predict")
+        pred(testing.get_datasource(), original_sql,
+             "SELECT * FROM alifin_jtest_dev.sqlflow_iris_test",
+             "e2etest_xgb_classify_model", "class", {},
+             "alifin_jtest_dev.pai_xgb_predict")
 
     def test_submit_pai_xgb_explain_task(self):
         original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test
@@ -224,10 +233,10 @@ INTO e2e_test_random_forest;"""
         original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_test
 TO PREDICT alifin_jtest_dev.pai_rf_predict.class
 USING e2e_test_random_forest_wuyi;"""
-        predict(testing.get_datasource(), original_sql,
-                "SELECT * FROM alifin_jtest_dev.sqlflow_iris_test",
-                "e2e_test_random_forest_wuyi", "class", {},
-                "alifin_jtest_dev.pai_rf_predict")
+        pred(testing.get_datasource(), original_sql,
+             "SELECT * FROM alifin_jtest_dev.sqlflow_iris_test",
+             "e2e_test_random_forest_wuyi", "class", {},
+             "alifin_jtest_dev.pai_rf_predict")
 
     def test_submit_pai_random_forest_explain_task(self):
         original_sql = """SELECT * FROM alifin_jtest_dev.sqlflow_iris_train

--- a/python/runtime/pai/submitter_train.py
+++ b/python/runtime/pai/submitter_train.py
@@ -121,10 +121,9 @@ def submit_pai_train(datasource,
     else:
         params["entry_type"] = "train_tf"
 
-    train_table, val_table = table_ops.create_train_and_eval_tmp_table(
-        select, validation_select, datasource)
-
-    try:
+    with table_ops.create_tmp_tables_guard([select, validation_select],
+                                           datasource) as (train_table,
+                                                           val_table):
         params["pai_table"], params["pai_val_table"] = train_table, val_table
 
         # clean target dir
@@ -153,5 +152,3 @@ def submit_pai_train(datasource,
                 "file://" + os.path.join(cwd, PARAMS_FILE))
 
             submit_pai_task(cmd, datasource)
-    finally:
-        table_ops.drop_tables([train_table, val_table], datasource)

--- a/python/runtime/pai_local/__init__.py
+++ b/python/runtime/pai_local/__init__.py
@@ -25,6 +25,6 @@ def _gen_pai_local_method(name):
 
 
 train = _gen_pai_local_method('train')
-predict = _gen_pai_local_method('predict')
+pred = _gen_pai_local_method('pred')
 evaluate = _gen_pai_local_method('evaluate')
 explain = _gen_pai_local_method('explain')

--- a/python/runtime/step/tensorflow/train.py
+++ b/python/runtime/step/tensorflow/train.py
@@ -193,13 +193,10 @@ def train_step(original_sql,
     # save model to DB/OSS
     model = Model(EstimatorType.TENSORFLOW, model_meta)
     if num_workers == 1 or worker_id == 0:
-        if is_pai:
-            oss_model_dir = FLAGS.sqlflow_oss_modeldir
-            model.save_to_oss(oss_model_dir)
-            print("Model saved to OSS: %s" % oss_model_dir)
-        else:
-            model.save_to_db(datasource, save)
-            print("Model saved to DB: %s" % save)
+        saved = model.save_to_db(datasource,
+                                 save,
+                                 oss_model_dir=FLAGS.sqlflow_oss_modeldir)
+        print("Model saved to DB: %s" % saved)
 
     print("Done training")
     conn.close()


### PR DESCRIPTION
- Add `experimental.getModelMetadataFromOSS` in the Go side. Also, move `pai.getModelBucket` to `model.GetOSSModelBucket` and move `pai.getModelPath` to `model.GetOSSModelPath`.
- Add `table_ops.create_tmp_tables_guard` in the Python side to replace `try...finally` clauses.

TODO: make the `runtime/pai` Python package to support the experimental codegen.