### PR TITLE
Add buffer size for SQLFS writer in Python side

### DIFF
--- a/python/runtime/model/db.py
+++ b/python/runtime/model/db.py
@@ -73,10 +73,10 @@ class SQLFSWriter(object):
         self.writer.write([self.row_idx, block])
         self.row_idx += 1
 
-    def close(self, *args, **kwargs):
+    def close(self):
         self.flush()
         self.writer.close()
-        self.context_manager.__exit__(*args, **kwargs)
+        self.context_manager.__exit__(None, None, None)
 
     def flush(self):
         if self.buffer:
@@ -87,7 +87,7 @@ class SQLFSWriter(object):
         return self
 
     def __exit__(self, *args, **kwargs):
-        self.close(*args, **kwargs)
+        self.close()
 
 
 def _build_ordered_reader(reader):

--- a/python/runtime/model/db.py
+++ b/python/runtime/model/db.py
@@ -75,7 +75,7 @@ class SQLFSWriter(object):
 
     def close(self):
         self.flush()
-        self.writer.close()
+        # NOTE: __exit__ would close the self.writer
         self.context_manager.__exit__(None, None, None)
 
     def flush(self):


### PR DESCRIPTION
MySQL `TEXT` can contain 65536 characters at most (r.f. https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html#data-types-storage-reqs-strings). Add `buf_size` for `SQLFSWriter` to control the maximum character number on one line.