### PR TITLE
Always remove root perm dirs when pushing images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,8 +119,7 @@ jobs:
         export TRAVIS_BUILD_DIR=${{ github.workspace }}
         export FIND_FASTED_MIRROR=false
         export TRAVIS_BUILD_STAGE_NAME=Deploy
-        bash scripts/travis/deploy_docker.sh || \
-        docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python
+        bash scripts/travis/deploy_docker.sh || docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python
   linux-client:
     runs-on: ubuntu-latest
     needs: [test-mysql, test-hive-java, test-workflow]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,8 @@ jobs:
         export FIND_FASTED_MIRROR=false
         export TRAVIS_BUILD_STAGE_NAME=Deploy
         bash scripts/travis/deploy_docker.sh
+        # clean root permission dirs
+        docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python
   linux-client:
     runs-on: ubuntu-latest
     needs: [test-mysql, test-hive-java, test-workflow]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,6 @@ jobs:
         export TRAVIS_BUILD_DIR=${{ github.workspace }}
         export FIND_FASTED_MIRROR=false
         export TRAVIS_BUILD_STAGE_NAME=Deploy
-        # always clean root permission dirs
         bash scripts/travis/deploy_docker.sh || \
         docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python
   linux-client:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
         ALIYUN_DOCKER_USERNAME: "sqlflow@prod.trusteeship.aliyunid.com"
         ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
       run: |
-      set -e
+        set -e
         export TRAVIS_TAG=${{ steps.tagName.outputs.tag }}
         export TRAVIS_PULL_REQUEST=${{ github.event.number }}
         export TRAVIS_BUILD_DIR=${{ github.workspace }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,13 +113,14 @@ jobs:
         ALIYUN_DOCKER_USERNAME: "sqlflow@prod.trusteeship.aliyunid.com"
         ALIYUN_DOCKER_PASSWORD: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
       run: |
+      set -e
         export TRAVIS_TAG=${{ steps.tagName.outputs.tag }}
         export TRAVIS_PULL_REQUEST=${{ github.event.number }}
         export TRAVIS_BUILD_DIR=${{ github.workspace }}
         export FIND_FASTED_MIRROR=false
         export TRAVIS_BUILD_STAGE_NAME=Deploy
-        bash scripts/travis/deploy_docker.sh
-        # clean root permission dirs
+        # always clean root permission dirs
+        bash scripts/travis/deploy_docker.sh || \
         docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python
   linux-client:
     runs-on: ubuntu-latest

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -70,6 +70,3 @@ build_sqlflow_image mysql
 build_sqlflow_image jupyter
 build_sqlflow_image step
 build_sqlflow_image modelzooserver
-
-echo "Clean up root permission $TRAVIS_BUILD_DIR/build ..."
-docker run --rm  -v "$TRAVIS_BUILD_DIR":/work sqlflow:ci rm -rf /work/build /work/java /work/python


### PR DESCRIPTION
Always remove root perm dirs whether the `deploy_docker.sh` fails or not.