### PR TITLE
Fix pai explain

### DIFF
--- a/python/runtime/pai/submitter_explain.py
+++ b/python/runtime/pai/submitter_explain.py
@@ -159,8 +159,8 @@ def submit_pai_explain(datasource,
 
     # format resultTable name to "db.table" to let the codegen form a
     # submitting argument of format "odps://project/tables/table_name"
+    project = table_ops.get_project(datasource)
     if result_table:
-        project = table_ops.get_project(datasource)
         if result_table.count(".") == 0:
             result_table = "%s.%s" % (project, result_table)
         params["result_table"] = result_table

--- a/python/runtime/step/tensorflow/explain.py
+++ b/python/runtime/step/tensorflow/explain.py
@@ -195,7 +195,11 @@ def _explain(datasource,
              oss_bucket_name=None):
     estimator_cls = import_model(estimator_string)
     if is_tf_estimator(estimator_cls):
-        model_params['model_dir'] = save
+        with open("exported_path", "r") as fid:
+            exported_path = str(fid.read())
+
+        model_params["warm_start_from"] = exported_path
+
     model_params.update(feature_columns)
     pop_optimizer_and_loss(model_params)
 

--- a/python/runtime/step/tensorflow/explain.py
+++ b/python/runtime/step/tensorflow/explain.py
@@ -196,7 +196,6 @@ def _explain(datasource,
     estimator_cls = import_model(estimator_string)
     if is_tf_estimator(estimator_cls):
         model_params['model_dir'] = save
-
     model_params.update(feature_columns)
     pop_optimizer_and_loss(model_params)
 

--- a/python/runtime/step/tensorflow/explain.py
+++ b/python/runtime/step/tensorflow/explain.py
@@ -195,10 +195,7 @@ def _explain(datasource,
              oss_bucket_name=None):
     estimator_cls = import_model(estimator_string)
     if is_tf_estimator(estimator_cls):
-        with open("exported_path", "r") as fid:
-            exported_path = str(fid.read())
-
-        model_params["warm_start_from"] = exported_path
+        model_params['model_dir'] = save
 
     model_params.update(feature_columns)
     pop_optimizer_and_loss(model_params)


### PR DESCRIPTION
We should always get the `project` no matter whether `result_table` is empty because `project` is used [here](https://github.com/sql-machine-learning/sqlflow/blob/e1a219e047296818f41655ca842b3cb2c3a91fe2/python/runtime/pai/submitter_explain.py#L202).