### PR TITLE
Add sqlfs read one by one mode to speed up metadata reading

### DIFF
--- a/go/codegen/experimental/codegen_step.go
+++ b/go/codegen/experimental/codegen_step.go
@@ -244,7 +244,7 @@ func getModelMetadataFromDBImpl(dbConnStr, table string) (*Metadata, error) {
 		table = dbName + "." + table
 	}
 
-	fs, err := sqlfs.Open(db.DB, table)
+	fs, err := sqlfs.Open(db.DB, table, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -306,7 +306,7 @@ func loadModelFromDB(db *database.DB, table, cwd string) (*Model, error) {
 // DumpDBModel dumps a model tarball from database to local
 // file system and return the file name
 func DumpDBModel(db *database.DB, table, cwd string) (string, error) {
-	sqlf, err := sqlfs.Open(db.DB, table)
+	sqlf, err := sqlfs.Open(db.DB, table, true)
 	if err != nil {
 		return "", fmt.Errorf("Can't open sqlfs %s, %v", table, err)
 	}
@@ -341,7 +341,7 @@ func ExtractMetaFromTarball(tarballName, cwd string) (*Model, error) {
 
 // DumpDBModelExperimental returns the dumped model tar file name and model meta (JSON serialized).
 func DumpDBModelExperimental(db *database.DB, table, cwd string) (string, *Model, error) {
-	sqlf, err := sqlfs.Open(db.DB, table)
+	sqlf, err := sqlfs.Open(db.DB, table, true)
 	if err != nil {
 		return "", nil, fmt.Errorf("Can't open sqlfs %s, %v", table, err)
 	}

--- a/go/modelzooserver/modelzooserver.go
+++ b/go/modelzooserver/modelzooserver.go
@@ -372,7 +372,7 @@ func (s *modelZooServer) ReleaseModel(ctx context.Context, req *pb.ReleaseModelR
 		}
 		modelMeta.TrainSelect = modelMeta.GetMetaAsString("original_sql")
 
-		sendFile, err = sqlfs.Open(db.DB, req.Name)
+		sendFile, err = sqlfs.Open(db.DB, req.Name, true)
 		if err != nil {
 			return nil, err
 		}
@@ -604,7 +604,7 @@ func (s *modelZooServer) DownloadModel(req *pb.ReleaseModelRequest, respStream p
 		return err
 	}
 
-	sqlf, err := sqlfs.Open(s.DB.DB, fmt.Sprintf("%s.%s_%s", publicModelDB, modelTableName, strings.ReplaceAll(modelTag, ".", "_")))
+	sqlf, err := sqlfs.Open(s.DB.DB, fmt.Sprintf("%s.%s_%s", publicModelDB, modelTableName, strings.ReplaceAll(modelTag, ".", "_")), true)
 	if err != nil {
 		return err
 	}

--- a/go/modelzooserver/using_model_test.go
+++ b/go/modelzooserver/using_model_test.go
@@ -163,7 +163,7 @@ INTO sqlflow_models.modelzoo_model_iris;`)
 	db, err := database.OpenAndConnectDB(database.GetTestingMySQLURL())
 	a.NoError(err)
 	defer db.Close()
-	sqlf, err := sqlfs.Open(db.DB, "sqlflow_models.modelzoo_model_iris")
+	sqlf, err := sqlfs.Open(db.DB, "sqlflow_models.modelzoo_model_iris", true)
 	a.NoError(err)
 	defer sqlf.Close()
 	// Note that modelBuf is a gob encoded struct

--- a/go/sqlfs/hive_writer_test.go
+++ b/go/sqlfs/hive_writer_test.go
@@ -60,6 +60,11 @@ func TestSQLFSNewHiveWriter(t *testing.T) {
 }
 
 func TestSQLFSHiveWriterWriteAndRead(t *testing.T) {
+	caseSQLFSHiveWriterWriteAndRead(t, true)
+	caseSQLFSHiveWriterWriteAndRead(t, false)
+}
+
+func caseSQLFSHiveWriterWriteAndRead(t *testing.T, readAllOnce bool) {
 	createSQLFSTestingDatabaseOnce.Do(createSQLFSTestingDatabase)
 	db := database.GetTestingDBSingleton()
 	a := assert.New(t)
@@ -91,7 +96,7 @@ func TestSQLFSHiveWriterWriteAndRead(t *testing.T) {
 
 	a.NoError(w.Close())
 
-	r, e := Open(db.DB, tbl)
+	r, e := Open(db.DB, tbl, readAllOnce)
 	a.NoError(e)
 	a.NotNil(r)
 

--- a/go/sqlfs/reader.go
+++ b/go/sqlfs/reader.go
@@ -31,14 +31,14 @@ type blockReader interface {
 }
 
 type readAllOnceBlockReader struct {
-	frames []*fragment
-	cur    int
+	fragments []*fragment
+	cur       int
 }
 
 func newReadAllOnceBlockReader(db *sql.DB, table string) (blockReader, error) {
 	r := &readAllOnceBlockReader{
-		frames: nil,
-		cur:    0,
+		fragments: nil,
+		cur:       0,
 	}
 
 	stmt := fmt.Sprintf("SELECT id,block FROM %s;", table)
@@ -59,17 +59,17 @@ func newReadAllOnceBlockReader(db *sql.DB, table string) (blockReader, error) {
 		if e = rows.Scan(&f.id, &f.block); e != nil {
 			return nil, e
 		}
-		r.frames = append(r.frames, f)
+		r.fragments = append(r.fragments, f)
 	}
-	sort.Slice(r.frames, func(i, j int) bool {
-		return r.frames[i].id < r.frames[j].id
+	sort.Slice(r.fragments, func(i, j int) bool {
+		return r.fragments[i].id < r.fragments[j].id
 	})
 	return r, nil
 }
 
 func (r *readAllOnceBlockReader) nextBlock() (string, error) {
-	if r.cur < len(r.frames) {
-		f := r.frames[r.cur]
+	if r.cur < len(r.fragments) {
+		f := r.fragments[r.cur]
 		r.cur++
 		return f.block, nil
 	}

--- a/go/sqlfs/reader.go
+++ b/go/sqlfs/reader.go
@@ -107,14 +107,14 @@ func (r *readOneByOneBlockReader) nextBlock() (string, error) {
 	return f.block, nil
 }
 
-// Reader implements io.ReadCloser
-type Reader struct {
+// reader implements io.ReadCloser
+type reader struct {
 	buf []byte
 	br  blockReader
 }
 
 // Open returns a reader to read from the given table in db.
-func Open(db *sql.DB, table string, readAllOnce bool) (*Reader, error) {
+func Open(db *sql.DB, table string, readAllOnce bool) (io.ReadCloser, error) {
 	has, e := hasTable(db, table)
 	if !has {
 		return nil, fmt.Errorf("open: table %s doesn't exist", table)
@@ -137,10 +137,10 @@ func Open(db *sql.DB, table string, readAllOnce bool) (*Reader, error) {
 		}
 	}
 
-	return &Reader{buf: nil, br: br}, nil
+	return &reader{buf: nil, br: br}, nil
 }
 
-func (r *Reader) Read(p []byte) (n int, e error) {
+func (r *reader) Read(p []byte) (n int, e error) {
 	if r.br == nil {
 		return 0, fmt.Errorf("read from a closed reader")
 	}
@@ -166,7 +166,7 @@ func (r *Reader) Read(p []byte) (n int, e error) {
 }
 
 // Close the reader connection to sqlfs
-func (r *Reader) Close() error {
+func (r *reader) Close() error {
 	r.br = nil // Mark closed.
 	return nil
 }

--- a/go/sqlfs/reader_test.go
+++ b/go/sqlfs/reader_test.go
@@ -26,6 +26,11 @@ import (
 )
 
 func TestSQLFSWriteAndRead(t *testing.T) {
+	caseSQLFSWriteAndRead(t, true)
+	caseSQLFSWriteAndRead(t, false)
+}
+
+func caseSQLFSWriteAndRead(t *testing.T, readAllOnce bool) {
 	a := assert.New(t)
 	const bufSize = 32 * 1024
 
@@ -56,7 +61,7 @@ func TestSQLFSWriteAndRead(t *testing.T) {
 
 	a.NoError(w.Close())
 
-	r, e := Open(db.DB, tbl)
+	r, e := Open(db.DB, tbl, readAllOnce)
 	a.NoError(e)
 	a.NotNil(r)
 

--- a/go/sqlfs/sql_writer_test.go
+++ b/go/sqlfs/sql_writer_test.go
@@ -48,6 +48,11 @@ func TestSQLFSNewSQLWriter(t *testing.T) {
 }
 
 func TestSQLFSSQLWriterWriteAndRead(t *testing.T) {
+	caseSQLFSSQLWriterWriteAndRead(t, true)
+	caseSQLFSSQLWriterWriteAndRead(t, false)
+}
+
+func caseSQLFSSQLWriterWriteAndRead(t *testing.T, readAllOnce bool) {
 	createSQLFSTestingDatabaseOnce.Do(createSQLFSTestingDatabase)
 	db := database.GetTestingDBSingleton()
 	a := assert.New(t)
@@ -79,7 +84,7 @@ func TestSQLFSSQLWriterWriteAndRead(t *testing.T) {
 
 	a.NoError(w.Close())
 
-	r, e := Open(db.DB, tbl)
+	r, e := Open(db.DB, tbl, readAllOnce)
 	a.NoError(e)
 	a.NotNil(r)
 

--- a/python/runtime/model/db.py
+++ b/python/runtime/model/db.py
@@ -147,8 +147,7 @@ class ReadOneByOneBlockReader(object):
         elif len(ret) == 1:
             return ret[1]
         else:
-            raise ValueError("invalid invalid sqlfs db: duplicate id %d" %
-                             self.cur_id)
+            raise ValueError("invalid sqlfs db: duplicate id %d" % self.cur_id)
 
 
 class SQLFSReader(object):

--- a/python/runtime/model/model.py
+++ b/python/runtime/model/model.py
@@ -255,12 +255,15 @@ class Model(object):
     def _load_metadata_from_db_impl(datasource, table):
         model_zoo_addr, table, tag = _decompose_model_name(table)
         if model_zoo_addr:
-            gen, metadata = load_model_from_model_zoo(model_zoo_addr, table,
-                                                      tag)
+            _, metadata = load_model_from_model_zoo(model_zoo_addr,
+                                                    table,
+                                                    tag,
+                                                    meta_only=True)
         else:
-            gen, metadata = read_with_generator_and_metadata(datasource, table)
+            _, metadata = read_with_generator_and_metadata(datasource,
+                                                           table,
+                                                           meta_only=True)
 
-        gen.close()
         return Model._from_dict(metadata)
 
     def save_to_oss(self, oss_model_dir, local_dir=None):

--- a/python/runtime/model/modelzoo.py
+++ b/python/runtime/model/modelzoo.py
@@ -21,7 +21,7 @@ from runtime.model.modelzooserver_pb2 import ReleaseModelRequest
 from runtime.model.modelzooserver_pb2_grpc import ModelZooServerStub
 
 
-def load_model_from_model_zoo(address, model, tag):
+def load_model_from_model_zoo(address, model, tag, meta_only=False):
     stub = None
     meta = None
     channel = grpc.insecure_channel(address)
@@ -34,6 +34,10 @@ def load_model_from_model_zoo(address, model, tag):
         # make sure that the channel is closed when exception raises
         channel.close()
         six.reraise(*sys.exc_info())
+
+    if meta_only:
+        channel.close()
+        return None, meta
 
     def reader():
         try:


### PR DESCRIPTION
Model metadata usually contains little bytes. Add read one by one mode to speed up model metadata reading instead of reading all rows in the model table.