### PR TITLE
Refine SQLFS reader by adding rowBufSize

### DIFF
--- a/go/codegen/experimental/codegen_step.go
+++ b/go/codegen/experimental/codegen_step.go
@@ -244,7 +244,7 @@ func getModelMetadataFromDBImpl(dbConnStr, table string) (*Metadata, error) {
 		table = dbName + "." + table
 	}
 
-	fs, err := sqlfs.Open(db.DB, table, false)
+	fs, err := sqlfs.Open(db.DB, table, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -306,7 +306,7 @@ func loadModelFromDB(db *database.DB, table, cwd string) (*Model, error) {
 // DumpDBModel dumps a model tarball from database to local
 // file system and return the file name
 func DumpDBModel(db *database.DB, table, cwd string) (string, error) {
-	sqlf, err := sqlfs.Open(db.DB, table, true)
+	sqlf, err := sqlfs.Open(db.DB, table, 32)
 	if err != nil {
 		return "", fmt.Errorf("Can't open sqlfs %s, %v", table, err)
 	}
@@ -341,7 +341,7 @@ func ExtractMetaFromTarball(tarballName, cwd string) (*Model, error) {
 
 // DumpDBModelExperimental returns the dumped model tar file name and model meta (JSON serialized).
 func DumpDBModelExperimental(db *database.DB, table, cwd string) (string, *Model, error) {
-	sqlf, err := sqlfs.Open(db.DB, table, true)
+	sqlf, err := sqlfs.Open(db.DB, table, 32)
 	if err != nil {
 		return "", nil, fmt.Errorf("Can't open sqlfs %s, %v", table, err)
 	}

--- a/go/modelzooserver/modelzooserver.go
+++ b/go/modelzooserver/modelzooserver.go
@@ -372,7 +372,7 @@ func (s *modelZooServer) ReleaseModel(ctx context.Context, req *pb.ReleaseModelR
 		}
 		modelMeta.TrainSelect = modelMeta.GetMetaAsString("original_sql")
 
-		sendFile, err = sqlfs.Open(db.DB, req.Name, true)
+		sendFile, err = sqlfs.Open(db.DB, req.Name, 32)
 		if err != nil {
 			return nil, err
 		}
@@ -604,7 +604,7 @@ func (s *modelZooServer) DownloadModel(req *pb.ReleaseModelRequest, respStream p
 		return err
 	}
 
-	sqlf, err := sqlfs.Open(s.DB.DB, fmt.Sprintf("%s.%s_%s", publicModelDB, modelTableName, strings.ReplaceAll(modelTag, ".", "_")), true)
+	sqlf, err := sqlfs.Open(s.DB.DB, fmt.Sprintf("%s.%s_%s", publicModelDB, modelTableName, strings.ReplaceAll(modelTag, ".", "_")), 32)
 	if err != nil {
 		return err
 	}

--- a/go/modelzooserver/using_model_test.go
+++ b/go/modelzooserver/using_model_test.go
@@ -163,7 +163,7 @@ INTO sqlflow_models.modelzoo_model_iris;`)
 	db, err := database.OpenAndConnectDB(database.GetTestingMySQLURL())
 	a.NoError(err)
 	defer db.Close()
-	sqlf, err := sqlfs.Open(db.DB, "sqlflow_models.modelzoo_model_iris", true)
+	sqlf, err := sqlfs.Open(db.DB, "sqlflow_models.modelzoo_model_iris", 32)
 	a.NoError(err)
 	defer sqlf.Close()
 	// Note that modelBuf is a gob encoded struct

--- a/go/sqlfs/hive_writer_test.go
+++ b/go/sqlfs/hive_writer_test.go
@@ -60,11 +60,11 @@ func TestSQLFSNewHiveWriter(t *testing.T) {
 }
 
 func TestSQLFSHiveWriterWriteAndRead(t *testing.T) {
-	caseSQLFSHiveWriterWriteAndRead(t, true)
-	caseSQLFSHiveWriterWriteAndRead(t, false)
+	caseSQLFSHiveWriterWriteAndRead(t, 1)
+	caseSQLFSHiveWriterWriteAndRead(t, 32)
 }
 
-func caseSQLFSHiveWriterWriteAndRead(t *testing.T, readAllOnce bool) {
+func caseSQLFSHiveWriterWriteAndRead(t *testing.T, rowBufSize int) {
 	createSQLFSTestingDatabaseOnce.Do(createSQLFSTestingDatabase)
 	db := database.GetTestingDBSingleton()
 	a := assert.New(t)
@@ -96,7 +96,7 @@ func caseSQLFSHiveWriterWriteAndRead(t *testing.T, readAllOnce bool) {
 
 	a.NoError(w.Close())
 
-	r, e := Open(db.DB, tbl, readAllOnce)
+	r, e := Open(db.DB, tbl, rowBufSize)
 	a.NoError(e)
 	a.NotNil(r)
 

--- a/go/sqlfs/reader_test.go
+++ b/go/sqlfs/reader_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 func TestSQLFSWriteAndRead(t *testing.T) {
-	caseSQLFSWriteAndRead(t, true)
-	caseSQLFSWriteAndRead(t, false)
+	caseSQLFSWriteAndRead(t, 1)
+	caseSQLFSWriteAndRead(t, 32)
 }
 
-func caseSQLFSWriteAndRead(t *testing.T, readAllOnce bool) {
+func caseSQLFSWriteAndRead(t *testing.T, rowBufSize int) {
 	a := assert.New(t)
 	const bufSize = 32 * 1024
 
@@ -61,7 +61,7 @@ func caseSQLFSWriteAndRead(t *testing.T, readAllOnce bool) {
 
 	a.NoError(w.Close())
 
-	r, e := Open(db.DB, tbl, readAllOnce)
+	r, e := Open(db.DB, tbl, rowBufSize)
 	a.NoError(e)
 	a.NotNil(r)
 

--- a/go/sqlfs/sql_writer_test.go
+++ b/go/sqlfs/sql_writer_test.go
@@ -48,11 +48,11 @@ func TestSQLFSNewSQLWriter(t *testing.T) {
 }
 
 func TestSQLFSSQLWriterWriteAndRead(t *testing.T) {
-	caseSQLFSSQLWriterWriteAndRead(t, true)
-	caseSQLFSSQLWriterWriteAndRead(t, false)
+	caseSQLFSSQLWriterWriteAndRead(t, 1)
+	caseSQLFSSQLWriterWriteAndRead(t, 32)
 }
 
-func caseSQLFSSQLWriterWriteAndRead(t *testing.T, readAllOnce bool) {
+func caseSQLFSSQLWriterWriteAndRead(t *testing.T, rowBufSize int) {
 	createSQLFSTestingDatabaseOnce.Do(createSQLFSTestingDatabase)
 	db := database.GetTestingDBSingleton()
 	a := assert.New(t)
@@ -84,7 +84,7 @@ func caseSQLFSSQLWriterWriteAndRead(t *testing.T, readAllOnce bool) {
 
 	a.NoError(w.Close())
 
-	r, e := Open(db.DB, tbl, readAllOnce)
+	r, e := Open(db.DB, tbl, rowBufSize)
 	a.NoError(e)
 	a.NotNil(r)
 


### PR DESCRIPTION
Get sqlfs table data using `SELECT id, block FROM table WHERE id >= startIdx AND id < startIdx + rowBufSize;`. 

This is designed to:
- do not read all table data once to avoid using too many memories.
- speed up model metadata reading. Metadata is saved in the 0-th row of the table. We can get the metadata fast by only reading the 0-th row instead of reading the whole table data.