### PR TITLE
Refine SQLFS reader

### DIFF
--- a/go/sqlfs/reader.go
+++ b/go/sqlfs/reader.go
@@ -76,6 +76,9 @@ func (r *reader) readNextFragments() error {
 func (r *reader) nextBlock() (string, error) {
 	if r.fragmentIdx == len(r.fragments) {
 		if r.rowIdx > 0 && len(r.fragments) < r.rowBufSize {
+			// reset r.fragments and r.fragmentIdx when EOF
+			r.fragments = nil
+			r.fragmentIdx = 0
 			return "", io.EOF
 		}
 
@@ -85,6 +88,9 @@ func (r *reader) nextBlock() (string, error) {
 	}
 
 	if len(r.fragments) == 0 {
+		// reset r.fragments and r.fragmentIdx when EOF
+		r.fragments = nil
+		r.fragmentIdx = 0
 		return "", io.EOF
 	}
 	block := r.fragments[r.fragmentIdx].block

--- a/go/sqlfs/reader_test.go
+++ b/go/sqlfs/reader_test.go
@@ -75,7 +75,7 @@ func caseSQLFSWriteAndRead(t *testing.T, rowBufSize int) {
 	// A big read of rest
 	buf = make([]byte, bufSize*2)
 	n, e = r.Read(buf)
-	a.Equal(io.EOF, e)
+	a.NoError(e)
 	a.Equal(bufSize+2, n)
 	a.Equal(1, strings.Count(string(buf), "\n"))
 	a.Equal(bufSize+1, strings.Count(string(buf), "x"))

--- a/go/sqlfs/sql_writer_test.go
+++ b/go/sqlfs/sql_writer_test.go
@@ -15,9 +15,7 @@ package sqlfs
 
 import (
 	"fmt"
-	"io"
 	"math/rand"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,71 +41,6 @@ func TestSQLFSNewSQLWriter(t *testing.T) {
 	has, e1 := hasTable(db.DB, tbl)
 	a.NoError(e1)
 	a.True(has)
-
-	a.NoError(dropTableIfExists(db.DB, tbl))
-}
-
-func TestSQLFSSQLWriterWriteAndRead(t *testing.T) {
-	caseSQLFSSQLWriterWriteAndRead(t, 1)
-	caseSQLFSSQLWriterWriteAndRead(t, 32)
-}
-
-func caseSQLFSSQLWriterWriteAndRead(t *testing.T, rowBufSize int) {
-	createSQLFSTestingDatabaseOnce.Do(createSQLFSTestingDatabase)
-	db := database.GetTestingDBSingleton()
-	a := assert.New(t)
-
-	if db.DriverName == "hive" {
-		t.Skip("Skip as SQLFLOW_TEST_DB is Hive")
-	}
-	t.Logf("Confirm executed with %s", db.DriverName)
-
-	tbl := fmt.Sprintf("%s.unittest%d", testDatabaseName, rand.Int())
-	w, e := newSQLWriter(db, tbl, bufSize)
-	a.NoError(e)
-	a.NotNil(w)
-
-	// A small output.
-	buf := []byte("\n\n\n")
-	n, e := w.Write(buf)
-	a.NoError(e)
-	a.Equal(len(buf), n)
-
-	// A big output.
-	buf = make([]byte, bufSize+1)
-	for i := range buf {
-		buf[i] = 'x'
-	}
-	n, e = w.Write(buf)
-	a.NoError(e)
-	a.Equal(len(buf), n)
-
-	a.NoError(w.Close())
-
-	r, e := Open(db.DB, tbl, rowBufSize)
-	a.NoError(e)
-	a.NotNil(r)
-
-	// A small read
-	buf = make([]byte, 2)
-	n, e = r.Read(buf)
-	a.NoError(e)
-	a.Equal(2, n)
-	a.Equal(2, strings.Count(string(buf), "\n"))
-
-	// A big read of rest
-	buf = make([]byte, bufSize*2)
-	n, e = r.Read(buf)
-	a.Equal(io.EOF, e)
-	a.Equal(bufSize+2, n)
-	a.Equal(1, strings.Count(string(buf), "\n"))
-	a.Equal(bufSize+1, strings.Count(string(buf), "x"))
-
-	// Another big read
-	n, e = r.Read(buf)
-	a.Equal(io.EOF, e)
-	a.Equal(0, n)
-	a.NoError(r.Close())
 
 	a.NoError(dropTableIfExists(db.DB, tbl))
 }


### PR DESCRIPTION
- Remove ut `TestSQLFSHiveWriterWriteAndRead` and `TestSQLFSSQLWriterWriteAndRead`, since they are the same as `TestSQLFSWriteAndRead`.
- Make `sqlfs.reader` return `0, io.EOF` at the end of the table, which behaves the same as `os.Open(...)` in Go.