### PR TITLE
fix workflow pending

### DIFF
--- a/go/workflow/argo/workflow.go
+++ b/go/workflow/argo/workflow.go
@@ -45,7 +45,7 @@ func isPodFailed(pod *corev1.Pod) bool {
 }
 
 func isWorkflowPending(wf *wfv1.Workflow) bool {
-	return wf.Status.Phase == wfv1.NodePending
+	return wf.Status.Phase == wfv1.NodePending || wf.Status.Phase == ""
 }
 
 func getPodNameByStepGroup(wf *wfv1.Workflow, stepGroupName string) (string, error) {


### PR DESCRIPTION
The `workflow.status.phase` may be empty if steps have not been pulled.
