### PR TITLE
Do not remove py3-pip after install python package

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -35,7 +35,6 @@ RUN python3 -m pip install --quiet /build/couler*.whl /build/fluid*.whl && \
         mv /build/sqlflowserver /build/sqlflow /build/step /usr/local/bin/ && \
         mkdir -p $SQLFLOW_PARSER_SERVER_LOADING_PATH && \
         mv /build/*.jar $SQLFLOW_PARSER_SERVER_LOADING_PATH && \
-        apk del --purge py3-pip && \
         rm -rf /build
 
 # Install kubectl for submitting argo workflow


### PR DESCRIPTION
fixed #3124 

Remove `py3-pip` would also remove some Python package like `six`.
